### PR TITLE
polish: explicit run-phase ladder with YOU-ARE-HERE marker (forum [099])

### DIFF
--- a/dev/src/clj/ai_display.clj
+++ b/dev/src/clj/ai_display.clj
@@ -13,9 +13,11 @@
 
 (def update-hud-section hud/update-hud-section)
 
-;; Forward declaration: run-server-display (defined below, near the run-priority
-;; helpers) is used by the status displays above its definition.
+;; Forward declaration: run-server-display and print-run-phase-ladder! (defined
+;; below, near the run-priority helpers) are used by the status displays above
+;; their definitions.
 (declare run-server-display)
+(declare print-run-phase-ladder!)
 
 ;; ============================================================================
 ;; Status & Information
@@ -185,9 +187,15 @@
             (when run-state
               (println "\n🏃 ACTIVE RUN:")
               (println "  Server:" (run-server-display (last (:server run-state))))
-              (println "  Phase:" (:phase run-state))
-              (when-let [pos (:position run-state)]
-                (println "  Position:" pos))
+              ;; Explicit phase ladder (forum [099]) — a YOU-ARE-HERE marker over
+              ;; the whole run arc beats a bare "Phase: movement" line that makes
+              ;; the seat reconstruct where it is from the rules. Falls back to the
+              ;; bare phase/position lines if the phase is unmodelled.
+              (when-not (print-run-phase-ladder! @state/client-state run-state
+                                                 (clojure.string/lower-case (or my-side "runner")))
+                (println "  Phase:" (:phase run-state))
+                (when-let [pos (:position run-state)]
+                  (println "  Position:" pos)))
               ;; Show ICE info during encounter-ice
               (when (= "encounter-ice" (:phase run-state))
                 (when-let [current-ice (core/current-run-ice @state/client-state)]
@@ -966,6 +974,82 @@
             (when gain (str " (this is what gets you your access: " gain ")")) ".")
        (str "      (BOTH players must pass for the run to advance — after you continue, expect to wait for " opp ".)")])))
 
+(def ^:private run-ladder-rungs
+  "Conceptual run-timing ladder (jinteki run structure), in order. Steps #2–#4
+   repeat per piece of ICE; the live :phase + :position pick the current rung."
+  [:begin :approach :encounter :movement :approach-server :access])
+
+(defn run-phase-ladder-lines
+  "Render the run's timing ladder with a YOU-ARE-HERE marker on the live rung, so
+   the seat sees the whole run arc at a glance without consulting the rules
+   (forum [099]).
+
+   Pure: the caller extracts the live facts and passes them in.
+     :phase       engine phase string — \"initiation\" | \"approach-ice\" |
+                  \"encounter-ice\" | \"movement\" | \"approach-server\" | \"success\"
+     :server-name display name of the attacked server (e.g. \"R&D\")
+     :position    ICE countdown — N = at ICE index N-1; 0/nil = past all ICE
+     :ice-count   number of ICE protecting the server (nil if unknown)
+     :ice-name    title of the current ICE (nil if unknown/unrezzed — never invent
+                  a name the Runner can't legally see)
+
+   Returns a vector of lines (header + 6 rungs), or nil when :phase is absent or
+   unrecognised (the caller then falls back to the bare phase line)."
+  [{:keys [phase server-name position ice-count ice-name]}]
+  (let [cur (case phase
+              "initiation"      :begin
+              "approach-ice"    :approach
+              "encounter-ice"   :encounter
+              ;; movement before the innermost ICE is passed is still :movement;
+              ;; once past all ICE (position 0/nil) the Runner is approaching the
+              ;; server. The wire phase stays "movement" across both, so split on
+              ;; position to keep the marker honest.
+              "movement"        (if (and position (pos? position)) :movement :approach-server)
+              "approach-server" :approach-server
+              "success"         :access
+              nil)]
+    (when cur
+      (let [srv      (or server-name "the server")
+            ;; Pass order: the Runner meets the OUTERMOST ICE (position = ice-count)
+            ;; first, so pass-index counts up as position counts down.
+            pass-idx (when (and ice-count position (pos? position))
+                       (inc (- ice-count position)))
+            ice-of   (if (and pass-idx ice-count) (format " %d of %d" pass-idx ice-count) "")
+            ice-tag  (if ice-name (format " [%s]" ice-name) "")
+            label    {:begin           "#1 Run begins"
+                      :approach        (str "#2 Approach ICE" ice-of ice-tag)
+                      :encounter       (str "#3 Encounter ICE" ice-of ice-tag)
+                      :movement        "#4 Movement — pass ICE, then approach the next"
+                      :approach-server (str "#5 Approach server (" srv ")")
+                      :access          (str "#6 Access " srv)}
+            mark     (fn [rung]
+                       (if (= rung cur)
+                         (str "   ▶ " (label rung) "   ← YOU ARE HERE")
+                         (str "     " (label rung))))]
+        (into ["  📍 Run timing (steps #2–#4 repeat per ICE):"]
+              (map mark run-ladder-rungs))))))
+
+(defn print-run-phase-ladder!
+  "Derive run-phase-ladder facts from live client `state` and print the ladder.
+   Returns true if a ladder was printed, nil/false otherwise (caller may fall
+   back to a bare phase line)."
+  [state run my-side]
+  (let [current-ice (core/current-run-ice state)
+        server-key  (last (:server run))
+        ice-count   (count (get-in state [:game-state :corp :servers
+                                          (keyword server-key) :ices]))
+        lines (run-phase-ladder-lines
+               {:phase       (:phase run)
+                :server-name (run-server-display server-key)
+                :position    (:position run)
+                :ice-count   (when (pos? ice-count) ice-count)
+                ;; Only name a rezzed ICE — fog of war hides unrezzed identities.
+                :ice-name    (when (and current-ice (:rezzed current-ice))
+                               (:title current-ice))})]
+    (when (seq lines)
+      (doseq [line lines] (println line))
+      true)))
+
 (defn show-prompt-detailed
   "Show current prompt with detailed choices"
   []
@@ -1026,7 +1110,10 @@
             (if run-phase
               ;; Show run phase context
               (do
-                (println (str "  Run Phase: " run-phase))
+                ;; Explicit YOU-ARE-HERE ladder (forum [099]); falls back to the
+                ;; bare phase line for any phase the ladder doesn't model.
+                (when-not (print-run-phase-ladder! state run my-side)
+                  (println (str "  Run Phase: " run-phase)))
                 ;; During encounter-ice, show ICE and breaker info
                 (when (= run-phase "encounter-ice")
                   (show-encounter-ice-info state run my-side))

--- a/dev/src/clj/ai_display.clj
+++ b/dev/src/clj/ai_display.clj
@@ -1011,8 +1011,11 @@
     (when cur
       (let [srv      (or server-name "the server")
             ;; Pass order: the Runner meets the OUTERMOST ICE (position = ice-count)
-            ;; first, so pass-index counts up as position counts down.
-            pass-idx (when (and ice-count position (pos? position))
+            ;; first, so pass-index counts up as position counts down. Guard the
+            ;; upper bound too: a position > ice-count (shouldn't happen, but the
+            ;; wire is the volatile coupling) would otherwise print a bogus
+            ;; "ICE 0 of N" / negative index — drop the index rather than lie.
+            pass-idx (when (and ice-count position (pos? position) (<= position ice-count))
                        (inc (- ice-count position)))
             ice-of   (if (and pass-idx ice-count) (format " %d of %d" pass-idx ice-count) "")
             ice-tag  (if ice-name (format " [%s]" ice-name) "")

--- a/dev/test/ai_display_test.clj
+++ b/dev/test/ai_display_test.clj
@@ -522,6 +522,20 @@
                              :position 1 :ice-count 3 :ice-name "Ice Wall"})]
       (is (str/includes? inner "3 of 3") (str "innermost should be 3 of 3:\n" inner)))))
 
+(deftest test-ladder-pass-order-out-of-range-position
+  (testing "position > ice-count drops the index rather than printing a bogus 'ICE 0 of N'"
+    ;; Defensive: the wire is the volatile coupling; a position past the ICE count
+    ;; must never render a non-positive / nonsense pass index (misleading output).
+    (let [out (ladder-str {:phase "encounter-ice" :server-name "R&D"
+                           :position 4 :ice-count 3 :ice-name "Ice Wall"})]
+      (is (not (str/includes? out "0 of 3"))
+          (str "must not print a zero index:\n" out))
+      (is (not (re-find #"-\d+ of" out))
+          (str "must not print a negative index:\n" out))
+      ;; falls back to the bare "Encounter ICE" rung with no "N of M"
+      (is (re-find #"Encounter ICE(?! \d)" out)
+          (str "out-of-range position should drop the pass index entirely:\n" out)))))
+
 (deftest test-ladder-approach-ice-hides-unrezzed-name
   (testing "approach-ice with unknown (unrezzed) ICE shows no card name"
     (let [out (ladder-str {:phase "approach-ice" :server-name "HQ"

--- a/dev/test/ai_display_test.clj
+++ b/dev/test/ai_display_test.clj
@@ -474,3 +474,79 @@
       (let [out (with-out-str (display/show-prompt-detailed))]
         (is (str/includes? out "your turn"))
         (is (str/includes? out "list-playables"))))))
+
+;; ============================================================================
+;; Run-phase ladder (forum [099]): make the run timing structure explicit with a
+;; YOU-ARE-HERE marker so the seat sees the whole arc without reading the rules.
+;; Pure function — exercised directly, no live state needed.
+;; ============================================================================
+
+(defn- ladder-str [opts]
+  (str/join "\n" (display/run-phase-ladder-lines opts)))
+
+(deftest test-ladder-marks-current-phase-once
+  (testing "exactly one YOU ARE HERE marker, on the rung matching the live phase"
+    (let [out (ladder-str {:phase "encounter-ice" :server-name "R&D"
+                           :position 1 :ice-count 2 :ice-name "Tithe"})]
+      ;; one and only one marker
+      (is (= 1 (count (re-seq #"YOU ARE HERE" out)))
+          (str "expected a single marker, got:\n" out))
+      ;; it lands on the Encounter rung, not Approach
+      (let [marked (->> (str/split-lines out)
+                        (filter #(str/includes? % "YOU ARE HERE"))
+                        first)]
+        (is (str/includes? marked "Encounter")
+            (str "marker should be on the Encounter rung, got: " marked))))))
+
+(deftest test-ladder-shows-all-six-steps-and-server-name
+  (testing "ladder renders the full 6-step arc with the human server name"
+    (let [out (ladder-str {:phase "success" :server-name "HQ"
+                           :position 0 :ice-count 1 :ice-name nil})]
+      (doseq [step ["#1" "#2" "#3" "#4" "#5" "#6"]]
+        (is (str/includes? out step) (str "missing " step " in:\n" out)))
+      (is (str/includes? out "Access HQ"))
+      ;; success => marker on Access
+      (is (str/includes? (->> (str/split-lines out)
+                              (filter #(str/includes? % "YOU ARE HERE")) first)
+                         "Access")))))
+
+(deftest test-ladder-ice-pass-order-and-name
+  (testing "encounter shows pass-order index (outermost first) and rezzed ICE name"
+    ;; 3 ICE on server, position 3 = outermost = '1 of 3'
+    (let [outer (ladder-str {:phase "encounter-ice" :server-name "R&D"
+                             :position 3 :ice-count 3 :ice-name "Ice Wall"})]
+      (is (str/includes? outer "1 of 3") (str "outermost should be 1 of 3:\n" outer))
+      (is (str/includes? outer "[Ice Wall]")))
+    ;; position 1 = innermost = '3 of 3'
+    (let [inner (ladder-str {:phase "encounter-ice" :server-name "R&D"
+                             :position 1 :ice-count 3 :ice-name "Ice Wall"})]
+      (is (str/includes? inner "3 of 3") (str "innermost should be 3 of 3:\n" inner)))))
+
+(deftest test-ladder-approach-ice-hides-unrezzed-name
+  (testing "approach-ice with unknown (unrezzed) ICE shows no card name"
+    (let [out (ladder-str {:phase "approach-ice" :server-name "HQ"
+                           :position 1 :ice-count 1 :ice-name nil})]
+      (is (str/includes? out "Approach ICE 1 of 1"))
+      (is (not (str/includes? out "["))
+          (str "must not invent an ICE name when unrezzed:\n" out))
+      (is (str/includes? (->> (str/split-lines out)
+                              (filter #(str/includes? % "YOU ARE HERE")) first)
+                         "Approach")))))
+
+(deftest test-ladder-movement-vs-approach-server
+  (testing "movement before innermost ICE marks Movement; past all ICE marks Approach server"
+    (let [mid (ladder-str {:phase "movement" :server-name "R&D"
+                           :position 1 :ice-count 2 :ice-name nil})]
+      (is (str/includes? (->> (str/split-lines mid)
+                              (filter #(str/includes? % "YOU ARE HERE")) first)
+                         "Movement")))
+    (let [past (ladder-str {:phase "movement" :server-name "R&D"
+                            :position 0 :ice-count 2 :ice-name nil})]
+      (is (str/includes? (->> (str/split-lines past)
+                              (filter #(str/includes? % "YOU ARE HERE")) first)
+                         "Approach server")))))
+
+(deftest test-ladder-unknown-phase-returns-nil
+  (testing "absent/unrecognised phase yields nil (caller falls back to bare line)"
+    (is (nil? (display/run-phase-ladder-lines {:phase nil :server-name "R&D"})))
+    (is (nil? (display/run-phase-ladder-lines {:phase "bogus" :server-name "R&D"})))))


### PR DESCRIPTION
## What

Responds to Michael's forum **[099]** steer: make the run timing structure *explicit* so the seat doesn't have to reconstruct "where am I in this run" from the rules at every window. A bare `Phase: movement` line forces that reconstruction; a 6-rung ladder over the whole run arc with a **YOU-ARE-HERE** marker doesn't.

```
🏃 ACTIVE RUN:
  Server: R&D
  📍 Run timing (steps #2–#4 repeat per ICE):
       #1 Run begins
       #2 Approach ICE 2 of 2 [Tithe]
     ▶ #3 Encounter ICE 2 of 2 [Tithe]   ← YOU ARE HERE
       #4 Movement — pass ICE, then approach the next
       #5 Approach server (R&D)
       #6 Access R&D
```

## How

New **pure** `run-phase-ladder-lines` maps live `(:phase, :position)` onto the fixed conceptual ladder:

- Steps #2–#4 repeat per ICE; **pass-order index** (outermost ICE first) and the **rezzed** ICE name are substituted in.
- **Fog of war honored** — an unrezzed ICE shows no name (never invents an identity the Runner can't legally see).
- `"movement"` splits on position: at position 0 (past all ICE) the marker moves to **#5 Approach server**, matching engine truth (the wire `:phase` stays `"movement"` across both the pass-ICE and approach-server steps).
- Unknown/absent phase returns `nil` → callers fall back to the existing bare phase/position line.

Wired into **both** the `status` ACTIVE RUN block and `show-prompt-detailed` via `print-run-phase-ladder!` (derives the facts from live state). Forward-declared so the status displays above the definition can use it.

## Tests

Pure function exercised directly — **+6 tests**: marker uniqueness, full 6-step arc + human server name, pass-order index (outermost = `1 of N`), unrezzed-name hiding, movement-vs-approach-server split, nil fallback. Suite **336 → 342**, 0 failures via `make test` (lein, compiles this worktree's disk).

## Validation note

Live REPL render was **not** used to verify: the persistent dev REPL is rooted in a *different* worktree (`admiring-ellis-4a5f87`), so its `:reload` reads a foreign copy of `ai_display.clj` — disturbing it would also step on a shared seat. Authoritative validation is the lein suite, which builds this branch's source from disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)