### PR TITLE
polish: 3 send_command rough edges (silent unknown-cmd, fatal logging, false fire-subs no-op)

### DIFF
--- a/dev/send_command
+++ b/dev/send_command
@@ -86,7 +86,11 @@ did_you_mean() {
     # Fallback: substring match against the player-facing commands.
     local known="status board hand prompt credits clicks archives heap log card-text abilities list-playables diagnose-blocker start-turn end-turn smart-end-turn draw take-credit play install advance score rez run continue jack-out tank choose choose-card choose-value multi-choose wait get-cursor ping keep-hand mulligan discard remove-tag game-over-status"
     local hits
-    hits=$(printf '%s\n' $known | grep -iF -- "$attempted" | head -3 | paste -sd' ' -)
+    # `|| true`: grep exits non-zero on no match, which under `set -euo pipefail`
+    # would abort the whole script *here* — silently swallowing both this hint and
+    # the "Unknown command" error that follows. A novel wrong guess (no substring
+    # match) is exactly when we most need to print, so the substitution must never fail.
+    hits=$(printf '%s\n' $known | grep -iF -- "$attempted" | head -3 | paste -sd' ' - || true)
     if [[ -n "$hits" ]]; then
         echo -e "${YELLOW}💡 Did you mean: ${hits}${NC}" >&2
     else
@@ -537,12 +541,16 @@ shift || true
 # Determine project root for logging
 NETRUNNER_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Command logging - log every command with timestamp
+# Command logging - log every command with timestamp.
+# Logging is best-effort: a missing logs/ dir (fresh worktree) or unwritable path
+# must never abort the actual command under `set -euo pipefail`. mkdir the dir and
+# guard the write so a logging failure can't swallow the command the user asked for.
 LOG_FILE="${NETRUNNER_ROOT}/logs/commands.log"
+mkdir -p "${NETRUNNER_ROOT}/logs" 2>/dev/null || true
 if [[ -n "$CLIENT_NAME" ]]; then
-    echo "[$(date +'%Y-%m-%d %H:%M:%S')] $CLIENT_NAME: $COMMAND $*" >> "$LOG_FILE"
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] $CLIENT_NAME: $COMMAND $*" >> "$LOG_FILE" 2>/dev/null || true
 else
-    echo "[$(date +'%Y-%m-%d %H:%M:%S')] default: $COMMAND $*" >> "$LOG_FILE"
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] default: $COMMAND $*" >> "$LOG_FILE" 2>/dev/null || true
 fi
 
 # Help is pure text — it must work even when no REPL is running (e.g. after a

--- a/dev/src/clj/ai_card_actions.clj
+++ b/dev/src/clj/ai_card_actions.clj
@@ -517,6 +517,48 @@
                            :args nil})
         (Thread/sleep core/quick-delay)))))
 
+(defn fire-subs-report
+  "Pure: decide what to print and return after firing unbroken subroutines.
+
+   The subtle case this exists for: a fired subroutine can OPEN A PROMPT (e.g.
+   Brân 1.0's \"install an ice from HQ/Archives\" sub), which pauses sub
+   resolution until the Corp resolves it. In that window there are often no new
+   *log* entries yet, so the naive \"no new log entries\" branch wrongly reports
+   \"subs already broken or run already ended\" — leaving the Corp sitting on an
+   unhandled prompt while believing the fire was a no-op (a flow stall on the
+   blessed Corp defense path). Detecting the newly-opened prompt and surfacing it
+   is the honest signal.
+
+   Inputs:
+     ice-title    - ICE name (string)
+     old-cursor   - cursor before firing (int)
+     new-cursor   - cursor after firing (int)
+     new-entries  - already-sliced new log entries (seq of {:text ...})
+     new-prompt   - a genuinely NEW prompt our side must resolve, or nil
+                    (caller computes via core/new-prompt? to dodge stale state)
+   Returns {:lines [str...] :result <status-map>}."
+  [ice-title old-cursor new-cursor new-entries new-prompt]
+  (let [header (format "✅ Fire request acknowledged (cursor %d → %d)" old-cursor new-cursor)
+        entry-lines (map #(str "  • " (:text %)) new-entries)]
+    (cond
+      ;; A subroutine opened a prompt; the rest can't fire until it's resolved.
+      (some? new-prompt)
+      {:lines (concat [header]
+                      entry-lines
+                      [(str "⏸️  A subroutine needs input before the rest can fire: "
+                            (:msg new-prompt))
+                       "   Resolve it (choose-value \"<label>\" / choose-card <N>), then firing continues."])
+       :result {:status :waiting-input :ice ice-title :prompt new-prompt}}
+
+      (seq new-entries)
+      {:lines (cons header entry-lines)
+       :result {:status :success :ice ice-title}}
+
+      :else
+      {:lines [header
+               "  (no new log entries — subs were already broken, or the run had already ended)"]
+       :result {:status :success :ice ice-title}})))
+
 (defn fire-unbroken-subs!
   "Fire unbroken subroutines on ICE (Corp only)
    Used during runs when Runner doesn't/can't break all subs
@@ -539,6 +581,7 @@
                          :side (:side card)
                          :type (:type card)}
                 old-cursor (state/get-cursor)
+                old-prompt (state/get-prompt)
                 old-log-count (count (get-in client-state [:game-state :log]))]
             (println (str "⚡ Firing unbroken subroutines on " (:title card) "..."))
             (ws/send-message! :game/action
@@ -549,14 +592,16 @@
             (let [new-state @state/client-state
                   new-cursor (state/get-cursor)
                   new-log (get-in new-state [:game-state :log])
-                  new-entries (drop old-log-count new-log)]
-              (println (format "✅ Fire request acknowledged (cursor %d → %d)"
-                              old-cursor new-cursor))
-              (if (seq new-entries)
-                (doseq [entry new-entries]
-                  (println (str "  • " (:text entry))))
-                (println "  (no new log entries — subs may have been already broken or run already ended)"))
-              (core/with-cursor {:status :success :ice (:title card)}))))))))
+                  new-entries (drop old-log-count new-log)
+                  cur-prompt (state/get-prompt)
+                  ;; eid-aware so a stale leftover prompt isn't mistaken for a
+                  ;; sub-opened one (see core/new-prompt? rationale).
+                  new-prompt (when (core/new-prompt? old-prompt cur-prompt) cur-prompt)
+                  {:keys [lines result]} (fire-subs-report
+                                          (:title card) old-cursor new-cursor
+                                          new-entries new-prompt)]
+              (doseq [l lines] (println l))
+              (core/with-cursor result))))))))
 
 (defn advance-card!
   "Advance an installed Corp card (agenda, ICE, or asset).

--- a/dev/test/ai_actions_test.clj
+++ b/dev/test/ai_actions_test.clj
@@ -262,6 +262,53 @@
             (is (not (str/includes? out "🎯 Scored"))
                 "must NOT print a phantom success on a refused score")))))))
 
+;; ============================================================================
+;; fire-subs-report — honest output when a fired subroutine opens a prompt
+;; ============================================================================
+;; Regression for the live-found bug: firing Brân 1.0's "install an ice" sub
+;; opens a Corp prompt and pauses resolution, so there are no new log entries
+;; yet — and the old code wrongly reported "subs already broken or run already
+;; ended", stalling the Corp on an unhandled prompt it believed was a no-op.
+
+(deftest fire-subs-report-prompt-opened
+  (testing "a subroutine that opens a new prompt is surfaced, not mislabeled as a no-op"
+    (let [prompt {:msg "Choose an ice to install from Archives or HQ"
+                  :prompt-type "select"}
+          {:keys [lines result]} (ai-card-actions/fire-subs-report
+                                  "Brân 1.0" 17 18 [] prompt)
+          out (str/join "\n" lines)]
+      (is (= :waiting-input (:status result))
+          "an open prompt means we're waiting on input, not done")
+      (is (= prompt (:prompt result)) "the prompt is threaded back to the caller")
+      (is (str/includes? out "needs input before the rest can fire")
+          "must tell the Corp a sub is mid-resolution")
+      (is (str/includes? out "Choose an ice to install from Archives or HQ")
+          "must echo the actual pending prompt message")
+      (is (not (str/includes? out "already broken"))
+          "must NOT claim the subs were already broken")
+      (is (not (str/includes? out "run had already ended"))
+          "must NOT claim the run already ended"))))
+
+(deftest fire-subs-report-subs-fired
+  (testing "new log entries (subs actually fired) are listed as success"
+    (let [{:keys [lines result]} (ai-card-actions/fire-subs-report
+                                  "Palisade" 5 6
+                                  [{:text "Corp uses Palisade to end the run."}]
+                                  nil)
+          out (str/join "\n" lines)]
+      (is (= :success (:status result)))
+      (is (str/includes? out "Corp uses Palisade to end the run.")
+          "fired-sub log lines are echoed"))))
+
+(deftest fire-subs-report-genuine-noop
+  (testing "no entries and no new prompt is a real no-op (e.g. subs already broken)"
+    (let [{:keys [lines result]} (ai-card-actions/fire-subs-report
+                                  "Ice Wall" 9 9 [] nil)
+          out (str/join "\n" lines)]
+      (is (= :success (:status result)))
+      (is (str/includes? out "no new log entries")
+          "the honest no-op message is preserved for the genuinely-empty case"))))
+
 (comment
   ;; Run all happy path tests
   (run-tests 'ai-actions-test)


### PR DESCRIPTION
Polish round, all three found by hand-driving a live Corp/Runner this session and reading every line skeptically. Same theme each time: **the output lies about what happened.**

## 1. `send_command` dies silently on a novel unknown command (shell)
For an unknown command whose name is *not* a substring of any known command (`rig`, `xyzzy`, `foobar`), `did_you_mean`'s fallback `hits=$(… | grep -iF -- "$attempted" | …)` runs `grep` with no match → exit 1 → `pipefail` → `set -e` kills the whole script *at that assignment*, before either the "did you mean" hint or the "Unknown command" error can print. Result: **total silence + exit 1** — the worst case for discoverability, since a genuinely novel wrong guess is exactly what `did_you_mean` exists to catch. Fix: `|| true` on the substitution.

## 2. Logging is fatal on a fresh worktree (shell)
The unconditional `echo >> logs/commands.log` fails under `set -e` if `logs/` doesn't exist yet (never-run worktree), killing the command before it runs. Logging is best-effort and must never swallow the user's command: `mkdir -p` the dir + guard the write.

## 3. `fire-subs` reports a false no-op when a subroutine opens a prompt (clojure)
On the blessed Corp defense path: firing Brân 1.0's unbroken subs fires its first sub (*install an ice from HQ/Archives*), which **opens a Corp select prompt** and pauses the remaining "End the run" subs. No new *log* entries yet → the old code reported `(no new log entries — subs may have been already broken or run already ended)`. Neither was true: the run was live, the subs unbroken, and the Corp was left sitting on an unhandled `Choose an ice to install…` prompt it believed was a no-op — a flow stall masked by a confidently wrong message.

Fix: detect the genuinely-new prompt (eid-aware via `core/new-prompt?`, so a stale leftover isn't mistaken for a sub-opened one) and surface it, returning `:waiting-input` with the prompt instead of phantom `:success`. Decision extracted into a pure `fire-subs-report` helper → 3 unit tests (prompt-opened / subs-fired / genuine-noop). Ground-truthed live: resolving the prompt with `choose-value "Done"` then fired the remaining subs and ended the run.

## Gate
`make test`: 336 → 339, 0 failures. Shell fixes verified by direct reproduction (before: silent; after: hint+error). Fix 3's live-integration render (get-prompt → new-prompt? → fire-subs-report wiring) deferred — unit-tested against the exact captured prompt; the integration pieces are independently proven.

## Also this round
Live-validated PR #22's run-phase ladder (the gap [100] flagged) — renders exactly as designed at a real encounter: `▶ #3 Encounter ICE 1 of 1 [Brân 1.0] ← YOU ARE HERE`, rezzed-ICE named, full arc with server name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)