### PR TITLE
polish: autonomous fire-strategy paths honestly surface sub-opened prompts (#24)

### DIFF
--- a/dev/src/clj/ai_run_corp_handlers.clj
+++ b/dev/src/clj/ai_run_corp_handlers.clj
@@ -10,6 +10,7 @@
    - Returns result map {:status ... :action ...} to stop handler chain"
   (:require [ai-websocket-client-v2 :as ws]
             [ai-core :as core]
+            [ai-state :as state]
             [ai-run-corp-decisions :as decisions]))
 
 ;; ============================================================================
@@ -159,6 +160,41 @@
 ;; Corp Fire Handlers
 ;; ============================================================================
 
+(defn fire-unbroken-strategy-result
+  "Pure: given whether the fired subroutine opened a NEW prompt the Corp must
+   resolve (computed by the caller via core/new-prompt? to dodge stale
+   prompt-state), decide what the autonomous --fire-unbroken strategy auto-fire
+   should print and return.
+
+   This is the strategy-path twin of card-actions' fire-subs-report (issue #24).
+   The manual fire-subs path already surfaces a sub-opened prompt honestly; the
+   pre-committed --fire-unbroken *strategy* used to send the command and return
+   :action-taken unconditionally, so when a fired sub opens a prompt (e.g. Brân
+   1.0's \"install an ice from HQ/Archives\" sub) the run loop marched on while
+   the Corp sat on an unhandled prompt — the same flow-stall class #23 fixed, on
+   the un-babysat path.
+
+   Both branches keep :fired-at-position so the caller still records it (the ICE
+   was fired; re-entry must not re-fire). Only :status differs: :decision-required
+   pauses the loop to resolve the opened prompt; :action-taken lets it continue.
+
+   Returns {:lines [str...] :result <status-map>}."
+  [ice-title sub-count position new-prompt]
+  (let [base {:action :auto-fired-subs
+              :ice ice-title
+              :sub-count sub-count
+              :fired-at-position position}]
+    (if (some? new-prompt)
+      {:lines [(format "⏸️  A subroutine on %s opened a prompt the Corp must resolve: %s"
+                       ice-title (:msg new-prompt))
+               "   Resolve it (choose-value \"<label>\" / choose-card <N>), then continue the run."]
+       :result (assoc base
+                      :status :decision-required
+                      :wake-reason :sub-opened-prompt
+                      :prompt new-prompt)}
+      {:lines []
+       :result (assoc base :status :action-taken)})))
+
 (defn handle-corp-fire-unbroken
   "Priority 1.6: Corp fire-unbroken strategy - auto-fire unbroken subs.
    Waits for Runner's signal before firing (model-vs-model coordination)."
@@ -185,17 +221,25 @@
           (println (format "   Strategy: --fire-unbroken, firing %d sub(s) on %s (Runner signaled)"
                           (count unbroken-subs) ice-title))
           ;; Note: caller must call set-strategy! to mark fired-at-position
-          ;; We return the position so ai_runs can update it
-          (let [card-ref (core/create-card-ref current-ice)]
+          ;; (result carries it in both branches). We capture the pre-fire prompt
+          ;; so that — if a fired sub OPENS a prompt (issue #24) — we surface it as
+          ;; :decision-required instead of letting the loop march on (the same
+          ;; honest-reporting the manual fire-subs path got in #23).
+          (let [card-ref (core/create-card-ref current-ice)
+                old-prompt (state/get-prompt)]
             (ws/send-message! :game/action
                              {:gameid gameid
                               :command "unbroken-subroutines"
                               :args {:card card-ref}})
-            {:status :action-taken
-             :action :auto-fired-subs
-             :ice ice-title
-             :sub-count (count unbroken-subs)
-             :fired-at-position position}))))))
+            (Thread/sleep core/medium-delay)
+            (let [cur-prompt (state/get-prompt)
+                  ;; eid-aware so a stale leftover prompt isn't mistaken for a
+                  ;; sub-opened one (see core/new-prompt? rationale).
+                  new-prompt (when (core/new-prompt? old-prompt cur-prompt) cur-prompt)
+                  {:keys [lines result]} (fire-unbroken-strategy-result
+                                          ice-title (count unbroken-subs) position new-prompt)]
+              (doseq [l lines] (println l))
+              result)))))))
 
 (defn handle-corp-fire-decision
   "Priority 1.7: Corp at encounter-ice WITHOUT fire strategy - pause for human decision.
@@ -283,16 +327,22 @@
             (do
               (println (format "   --fire-if-asked: Runner signaled, firing %d sub(s) on %s"
                               (count unbroken-subs) ice-title))
-              (let [card-ref (core/create-card-ref current-ice)]
+              ;; Same honest-prompt detection as --fire-unbroken (issue #24): a
+              ;; fired sub can open a Corp prompt, which must surface as
+              ;; :decision-required rather than letting the loop march on.
+              (let [card-ref (core/create-card-ref current-ice)
+                    old-prompt (state/get-prompt)]
                 (ws/send-message! :game/action
                                  {:gameid gameid
                                   :command "unbroken-subroutines"
                                   :args {:card card-ref}})
-                {:status :action-taken
-                 :action :auto-fired-subs
-                 :ice ice-title
-                 :sub-count (count unbroken-subs)
-                 :fired-at-position position}))
+                (Thread/sleep core/medium-delay)
+                (let [cur-prompt (state/get-prompt)
+                      new-prompt (when (core/new-prompt? old-prompt cur-prompt) cur-prompt)
+                      {:keys [lines result]} (fire-unbroken-strategy-result
+                                              ice-title (count unbroken-subs) position new-prompt)]
+                  (doseq [l lines] (println l))
+                  result)))
 
             ;; Runner hasn't signaled yet - silently wait (poll again)
             :else

--- a/dev/test/ai_runs_test.clj
+++ b/dev/test/ai_runs_test.clj
@@ -10,6 +10,7 @@
             [ai-basic-actions :as ai-basic-actions]
             [ai-prompts :as ai-prompts]
             [ai-run-runner-handlers :as runner-handlers]
+            [ai-run-corp-handlers :as corp-handlers]
             [ai-card-actions :as card-actions]
             [ai-websocket-client-v2 :as ws]))
 
@@ -951,6 +952,50 @@
 
 ;; ============================================================================
 ;; Test Suite Summary
+;; ============================================================================
+;; fire-unbroken-strategy-result — honest autonomous-fire reporting (issue #24)
+;; ============================================================================
+;; The manual fire-subs path got honest prompt-detection in #23. The
+;; pre-committed --fire-unbroken / --fire-if-asked *strategy* paths used to
+;; send the fire command and return :action-taken unconditionally, so when a
+;; fired sub opened a Corp prompt (e.g. Brân 1.0's install-an-ice sub) the run
+;; loop marched on while the Corp sat on an unhandled prompt. These guard the
+;; pure decision: a sub-opened prompt → :decision-required (loop pauses to
+;; resolve), no prompt → :action-taken (loop continues). Both keep
+;; :fired-at-position so re-entry never re-fires.
+
+(deftest fire-unbroken-strategy-result-prompt-opened
+  (testing "a fired sub that opens a new prompt surfaces as :decision-required, not :action-taken"
+    (let [prompt {:msg "Choose an ice to install from Archives or HQ"
+                  :prompt-type "select"
+                  :eid 4242}
+          {:keys [lines result]} (corp-handlers/fire-unbroken-strategy-result
+                                  "Brân 1.0" 1 1 prompt)
+          out (clojure.string/join "\n" lines)]
+      (is (= :decision-required (:status result))
+          "an open prompt must pause the loop (terminal status), not let it march on")
+      (is (= prompt (:prompt result)) "the opened prompt is threaded back to the caller")
+      (is (= 1 (:fired-at-position result))
+          "still records fired-at-position so re-entry never re-fires the ICE")
+      (is (= :auto-fired-subs (:action result)))
+      (is (clojure.string/includes? out "Brân 1.0")
+          "names the ICE whose sub opened the prompt")
+      (is (clojure.string/includes? out "Choose an ice to install from Archives or HQ")
+          "echoes the actual pending prompt message")
+      (is (clojure.string/includes? out "Resolve it")
+          "tells the Corp how to clear the prompt"))))
+
+(deftest fire-unbroken-strategy-result-no-prompt
+  (testing "a fired sub with no opened prompt is :action-taken so the loop continues"
+    (let [{:keys [lines result]} (corp-handlers/fire-unbroken-strategy-result
+                                  "Palisade" 2 0 nil)]
+      (is (= :action-taken (:status result))
+          "no prompt → keep auto-continuing, as before")
+      (is (= 0 (:fired-at-position result)) "fired-at-position is preserved")
+      (is (= 2 (:sub-count result)))
+      (is (nil? (:prompt result)) "no prompt threaded when none opened")
+      (is (empty? lines) "the no-prompt path stays quiet (the fire line is printed by the caller)"))))
+
 ;; ============================================================================
 
 (defn -main


### PR DESCRIPTION
Closes #24.

## Problem
PR #23 made the **manual** fire-subs path (`fire-subs-report`) honestly report when a fired subroutine *opens a prompt* (e.g. Brân 1.0's "install an ice from HQ/Archives" sub) instead of a false no-op. But the autonomous **`--fire-unbroken` / `--fire-if-asked` strategy** paths in `ai_run_corp_handlers.clj` sent the `unbroken-subroutines` command and returned `{:status :action-taken}` **unconditionally** — so a pre-committed fire strategy on a prompt-opening ICE left the run loop marching on while the Corp sat on an unhandled prompt. Same flow-stall class #23 fixed, on the un-babysat path.

## Fix
Extract a pure `fire-unbroken-strategy-result` helper (the strategy twin of `fire-subs-report`). After firing, eid-aware `core/new-prompt?` detection returns:
- `:decision-required` (terminal — the loop pauses to resolve) when a sub opened a prompt, with the prompt threaded back and a resolve hint printed;
- `:action-taken` (continue) when no prompt opened — unchanged behavior.

Both branches keep `:fired-at-position` so the wrapper still records it and re-entry never re-fires. Wired into **both** strategy fire sites (`--fire-unbroken` and `--fire-if-asked`), since they shared the identical bug shape.

## Tests
`ai-runs-test` gains 2 tests on the pure helper (prompt-opened → `:decision-required`; no-prompt → `:action-taken`; `:fired-at-position` preserved in both). Gate **346 → 348**, 0 failures.

## Review
Cross-model review by gpt-5.5 (`devin --model gpt-5.5 -p`): **APPROVE, no requested changes** — confirmed the `:fired-at-position` preservation, the terminal-status pause semantics, the `new-prompt?` stale-guard, and that the `state/` namespace alias resolves correctly despite the local `state` destructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)