### PR TITLE
polish: Runner status agenda line labels points-vs-cards units

### DIFF
--- a/dev/src/clj/ai_display.clj
+++ b/dev/src/clj/ai_display.clj
@@ -37,6 +37,21 @@
       (str " [" (clojure.string/join "][" parts) "]")
       "")))
 
+(defn format-runner-agenda-line
+  "Runner's-eye agenda threat line, with units made explicit.
+
+   The old single header — `Missing: 18 (Drawn: ~0, HQ: 5, R&D: 38, Remotes: 0/0)`
+   — conflated two different units under one parenthetical, so it read as
+   '18 agendas, 5 of them in HQ, 38 in R&D'. In fact:
+     missing         - agenda *POINTS* not yet scored or stolen (Corp needs 7)
+     expected-drawn  - estimated agenda *CARDS* the Corp has likely drawn into HQ
+     hq-size/rd-size - total *CARD* counts in HQ / R&D — the haystack, not agendas
+     unrezzed/advanced - remote-server counts the Runner can see
+   Labelling the points-vs-cards split removes the misread."
+  [agenda-points missing expected-drawn hq-size rd-size unrezzed-count advanced-count]
+  (format "Agenda Points: %d / 7  │  Unaccounted: %d agenda pts — hiding among HQ %d / R&D %d cards, Remotes %d unrezzed / %d advanced (~%d agenda cards likely drawn)"
+          agenda-points missing hq-size rd-size unrezzed-count advanced-count expected-drawn))
+
 (defn show-status
   "Display current game status or lobby state"
   []
@@ -268,8 +283,8 @@
                                                         content)))
                                                remotes))]
               (if (= "runner" my-side)
-                (println (format "Agenda Points: %d / 7  │  Missing: %d (Drawn: ~%d, HQ: %d, R&D: %d, Remotes: %d/%d)"
-                                agenda-points missing expected-drawn hq-size rd-size unrezzed-count advanced-count))
+                (println (format-runner-agenda-line
+                          agenda-points missing expected-drawn hq-size rd-size unrezzed-count advanced-count))
                 (println "Agenda Points:" agenda-points "/ 7")))
             (println "\n--- CORP ---")
             (println "Credits:" (state/corp-credits))

--- a/dev/test/ai_display_test.clj
+++ b/dev/test/ai_display_test.clj
@@ -10,6 +10,36 @@
             [test-helpers :refer [mock-client-state with-mock-state]]
             [ai-display :as display]))
 
+;; ============================================================================
+;; format-runner-agenda-line — points vs cards must be unambiguous
+;; ============================================================================
+;; The old header `Missing: 18 (Drawn: ~0, HQ: 5, R&D: 38, Remotes: 0/0)` mixed
+;; agenda *points* (Missing) with *card* counts (HQ/R&D) under one parenthetical,
+;; reading as "18 agendas, 5 in HQ". The relabel must keep the unit of each
+;; number legible.
+
+(deftest format-runner-agenda-line-labels-units
+  (testing "agenda points and card counts are each explicitly unit-labelled"
+    (let [line (display/format-runner-agenda-line 0 18 0 5 38 0 0)]
+      (is (str/includes? line "18 agenda pts")
+          "the unaccounted count is marked as agenda POINTS")
+      (is (str/includes? line "HQ 5 / R&D 38 cards")
+          "HQ/R&D are marked as CARD counts (the haystack), not agenda counts")
+      (is (str/includes? line "0 unrezzed")
+          "remote breakdown spells out unrezzed vs advanced")
+      (is (str/includes? line "0 advanced"))
+      (is (str/includes? line "~0 agenda cards likely drawn")
+          "the drawn estimate is labelled as an estimate of agenda cards")
+      (is (not (str/includes? line "Missing:"))
+          "the ambiguous bare 'Missing:' header is gone")))
+  (testing "values land in the right slots (no arg-order regression)"
+    (let [line (display/format-runner-agenda-line 4 11 3 6 30 2 1)]
+      (is (str/includes? line "Agenda Points: 4 / 7"))
+      (is (str/includes? line "11 agenda pts"))
+      (is (str/includes? line "HQ 6 / R&D 30 cards"))
+      (is (str/includes? line "Remotes 2 unrezzed / 1 advanced"))
+      (is (str/includes? line "~3 agenda cards likely drawn")))))
+
 (deftest test-game-over-status-decided
   (testing "decided game prints GAME-OVER with lowercased winner and turn"
     (with-mock-state (mock-client-state


### PR DESCRIPTION
Picks up the second deferred UX candidate from forum [102] (the first — raw-EDN trailing run-decision blocks — still needs your suppress-or-keep call).

## Problem
The Runner's-eye agenda line reads:
```
Agenda Points: 0 / 7  │  Missing: 18 (Drawn: ~0, HQ: 5, R&D: 38, Remotes: 0/0)
```
One parenthetical mixes two units: `Missing: 18` is agenda **points**, but `HQ: 5, R&D: 38` are **card** counts (the haystack the agendas hide in). It parses as "18 agendas, 5 of them in HQ" — wrong.

## Change
Extract a pure `format-runner-agenda-line` helper (first test coverage for this line) and relabel with explicit units:
```
Agenda Points: 0 / 7  │  Unaccounted: 18 agenda pts — hiding among HQ 5 / R&D 38 cards, Remotes 0 unrezzed / 0 advanced (~0 agenda cards likely drawn)
```
Same data, no new metrics — just legible units. `expected-drawn` moves to the end (grouped as an estimate aside, not interleaved with the haystack counts).

## ⚠️ Holding for your call on wording
This is a UX-copy change, which is your call, not mine — so I'm **not** self-merging. The *units-labeling* is correct under any layout; the exact phrasing ("hiding among", "Unaccounted") is adjustable. Merge as-is, or tell me the wording you want and I'll amend.

## Verification
- 2 tests in `ai-display-test` pin the unit labels + arg-order contract. Gate 348→349, 0 fail.
- gpt-5.5 review (`devin --model gpt-5.5 -p`): no real issues; confirmed the helper/call-site arg order is correct (the `expected-drawn` slot move lands right) and the tests pin the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)