### PR TITLE
polish: partial multi-select no longer fires spurious auto-end-turn warning

### DIFF
--- a/dev/src/clj/ai_prompts.clj
+++ b/dev/src/clj/ai_prompts.clj
@@ -79,9 +79,13 @@
     (if prompt
       (do
         (ws/choose! choice)
-        ;; Wait for prompt to change instead of fixed sleep
-        (wait-for-prompt-change! old-eid)
-        (maybe-auto-end-turn-after-prompt!)
+        ;; Wait for prompt to change instead of fixed sleep. Only run the
+        ;; auto-end-turn hook if the prompt actually moved/resolved — an
+        ;; unchanged prompt is still blocking, so auto-end could never fire and
+        ;; the hook would only print a spurious "resolve the prompt" warning.
+        ;; (See choose-card! for the partial-multi-select case this bites.)
+        (when (wait-for-prompt-change! old-eid)
+          (maybe-auto-end-turn-after-prompt!))
         (core/with-cursor {:status :success}))
       (do
         (println "⚠️  No active prompt")
@@ -110,8 +114,9 @@
                       {:gameid gameid
                        :command "choice"
                        :args {:choice {:uuid (:uuid choice)}}})
-    (wait-for-prompt-change! old-eid)
-    (maybe-auto-end-turn-after-prompt!)
+    ;; Only run the auto-end hook if the prompt actually moved (see choose-card!).
+    (when (wait-for-prompt-change! old-eid)
+      (maybe-auto-end-turn-after-prompt!))
     (core/with-cursor {:status :success :choice choice})))
 
 (defn choose-option!
@@ -239,9 +244,16 @@
           (do
             (println (format "📇 Selecting card: %s (index %d)" (:title card) index))
             (ws/select-card! card eid)
-            ;; Wait for prompt to change instead of fixed sleep
-            (wait-for-prompt-change! eid)
-            (maybe-auto-end-turn-after-prompt!)
+            ;; Wait for prompt to change instead of fixed sleep. Gate the
+            ;; auto-end-turn hook on the prompt ACTUALLY moving: a partial
+            ;; multi-select (e.g. discard-to-N) leaves the prompt put while the
+            ;; server toggles toward :max — nothing resolved — so firing the hook
+            ;; would print a spurious "⚠️ Cannot auto-end turn: resolve the prompt"
+            ;; whose "use 'choose'" tip contradicts the `multi-choose` steer
+            ;; printed just above. When unchanged the prompt is still blocking, so
+            ;; auto-end could never fire anyway — gating loses nothing. (#18 tail)
+            (when (wait-for-prompt-change! eid)
+              (maybe-auto-end-turn-after-prompt!))
             (core/with-cursor {:status :success :card card}))
           (let [{:keys [pickable]} (core/resolve-selectable selectable)
                 pickable-idxs (map :idx pickable)]

--- a/dev/test/ai_prompts_test.clj
+++ b/dev/test/ai_prompts_test.clj
@@ -166,6 +166,56 @@
             (is (not (str/includes? out "No select prompt active")))))))))
 
 ;; ============================================================================
+;; choose-card! — partial multi-select must not trigger the auto-end-turn hook
+;;
+;; choose-card! fires maybe-auto-end-turn-after-prompt! after every select. On a
+;; partial multi-select (discard-to-N, prompt STAYS PUT while the server toggles
+;; toward :max) nothing has resolved, yet the hook reaches check-auto-end-turn!,
+;; which — clicks=0, prompt still blocking — prints a spurious
+;;   "⚠️  Cannot auto-end turn: Active prompt must be resolved first
+;;    💡 Use 'prompt' command to see choices, or 'choose' to respond"
+;; directly UNDER the ℹ️ "card toggled … use `multi-choose`" steer, contradicting
+;; it (choose vs multi-choose). Found live driving a Corp discard-to-5.
+;;
+;; Fix: only run the auto-end hook when wait-for-prompt-change! reports the prompt
+;; actually moved/resolved. When unchanged the prompt is still blocking, so
+;; auto-end could never fire anyway — gating loses nothing, removes the noise.
+;; ============================================================================
+
+(deftest choose-card-partial-multiselect-skips-auto-end-turn
+  (testing "an unchanged (partial multi-select) prompt does NOT invoke the auto-end-turn check"
+    (let [auto-end-called? (atom false)]
+      (with-mock-state (mock-client-state
+                        :side "corp"
+                        :prompt {:prompt-type "select" :eid "disc-1"
+                                 :msg "Discard down to 5 cards"
+                                 :selectable [{:cid "c1" :title "Hedge Fund"}
+                                              {:cid "c2" :title "IPO"}]})
+        (with-redefs [ws/select-card! (fn [_card _eid] true)
+                      ;; partial select: server toggles, prompt unchanged
+                      prompts/wait-for-prompt-change! (fn [_eid & _] false)
+                      basic/check-auto-end-turn! (fn [] (reset! auto-end-called? true))]
+          (with-out-str (prompts/choose-card! 0))
+          (is (false? @auto-end-called?)
+              "partial multi-select must not reach the auto-end-turn check"))))))
+
+(deftest choose-card-resolving-select-still-runs-auto-end-turn
+  (testing "a select that RESOLVES the prompt (moved) still runs the auto-end-turn check"
+    (let [auto-end-called? (atom false)]
+      (with-mock-state (mock-client-state
+                        :side "corp"
+                        :prompt {:prompt-type "select" :eid "disc-1"
+                                 :msg "Discard down to 5 cards"
+                                 :selectable [{:cid "c1" :title "Hedge Fund"}]})
+        (with-redefs [ws/select-card! (fn [_card _eid] true)
+                      ;; final select reaches :max → prompt resolves/moves
+                      prompts/wait-for-prompt-change! (fn [_eid & _] true)
+                      basic/check-auto-end-turn! (fn [] (reset! auto-end-called? true))]
+          (with-out-str (prompts/choose-card! 0))
+          (is (true? @auto-end-called?)
+              "a resolving select must still run the auto-end-turn check"))))))
+
+;; ============================================================================
 ;; keep-hand / mulligan — opening-mulligan ergonomics (polish round 2026-06-22)
 ;;
 ;; Two related rough edges, both surfaced by playing a real game:


### PR DESCRIPTION
## What
Found live driving a Corp **discard-to-5**: a single `choose-card` on the 4-card multi-select printed the honest #18 steer, then immediately contradicted it:

```
📇 Selecting card: Hedge Fund (index 5)
ℹ️  Select prompt still open — card toggled but selection not yet resolved.
    For multi-card selects (e.g. discard down to N) use `multi-choose <i> <j> …` to select all at once.

⚠️  Cannot auto-end turn: Active prompt must be resolved first
   Prompt: Discard down to 5 cards
💡 Use 'prompt' command to see choices, or 'choose' to respond
```

The ⚠️/💡 block is noise: the seat wasn't ending its turn, and "use 'choose'" contradicts the "use `multi-choose`" steer one line above. Same misleading-output class as the rest of this thread.

## Root cause
`choose-card!` / `choose-by-index!` / `press-choice!` call `maybe-auto-end-turn-after-prompt!` after **every** select. On a partial multi-select the prompt stays put (server toggles a card and only resolves at `:max`), so the hook reaches `check-auto-end-turn!` while the prompt is still blocking → the spurious "resolve the prompt first" warning.

## Fix
Gate the auto-end hook on `wait-for-prompt-change!` reporting the prompt **actually moved/resolved**. When the prompt is unchanged it's still blocking, so auto-end could never have fired anyway — gating removes the noise and loses nothing. `multi-choose!` already doesn't call the hook (verified clean live).

## Tests
+2 in `ai_prompts_test.clj`: a partial select (prompt unchanged) does **not** reach `check-auto-end-turn!`; a resolving select (prompt moved) still does. Red→green. Gate 348→350, 0 fail.

## Caveat
Unit-tested against the exact prompt-movement contract; the live render was the **bug** (observed driving the discard), the fix is a near-mechanical gate on the already-correct `wait-for-prompt-change!` boolean. Did not re-stage the full live arc post-fix — REPLs are rooted in the canonical checkout, not this worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)