### PR TITLE
polish: snapshot header reads public :hand-count, not fog-hidden (count hand)

### DIFF
--- a/dev/src/clj/ai_display.clj
+++ b/dev/src/clj/ai_display.clj
@@ -607,6 +607,11 @@
             runner-credits (get-in gs [:runner :credit] 0)
             runner-clicks (get-in gs [:runner :click] 0)
             runner-hand (get-in gs [:runner :hand] [])
+            ;; Hand/HQ size is PUBLIC info, but the opponent's :hand is fog-of-war
+            ;; hidden in wire state (arrives empty). Read the public :hand-count
+            ;; field so the Opp segment doesn't under-report the opponent's hand
+            ;; as 0h; fall back to (count hand) only if the count field is absent.
+            runner-hand-ct (get-in gs [:runner :hand-count] (count runner-hand))
             runner-ap (get-in gs [:runner :agenda-point] 0)
             ;; Credits hosted on rig/play-area cards (e.g. Overclock during a run)
             ;; are spendable but omitted from the pool field -- surface as (+N)
@@ -620,15 +625,16 @@
             corp-credits (get-in gs [:corp :credit] 0)
             corp-clicks (get-in gs [:corp :click] 0)
             corp-hand (get-in gs [:corp :hand] [])
+            corp-hand-ct (get-in gs [:corp :hand-count] (count corp-hand))
             corp-ap (get-in gs [:corp :agenda-point] 0)
 
             ;; Format: T3-Corp | Me(R): 4c/2cl/5h/0AP | Opp(C): 5c/0cl/4h/0AP
             my-stats (if (= my-side "runner")
-                      (format "%sc/%dcl/%dh/%dAP" runner-cred-str runner-clicks (count runner-hand) runner-ap)
-                      (format "%dc/%dcl/%dh/%dAP" corp-credits corp-clicks (count corp-hand) corp-ap))
+                      (format "%sc/%dcl/%dh/%dAP" runner-cred-str runner-clicks runner-hand-ct runner-ap)
+                      (format "%dc/%dcl/%dh/%dAP" corp-credits corp-clicks corp-hand-ct corp-ap))
             opp-stats (if (= my-side "runner")
-                       (format "%dc/%dcl/%dh/%dAP" corp-credits corp-clicks (count corp-hand) corp-ap)
-                       (format "%sc/%dcl/%dh/%dAP" runner-cred-str runner-clicks (count runner-hand) runner-ap))
+                       (format "%dc/%dcl/%dh/%dAP" corp-credits corp-clicks corp-hand-ct corp-ap)
+                       (format "%sc/%dcl/%dh/%dAP" runner-cred-str runner-clicks runner-hand-ct runner-ap))
             my-label (if (= my-side "runner") "R" "C")
             opp-label (if (= my-side "runner") "C" "R")
 

--- a/dev/test/ai_display_test.clj
+++ b/dev/test/ai_display_test.clj
@@ -160,6 +160,35 @@
         (is (not (str/includes? line "(+"))
             (str "must not show hosted annotation when none, got: " line))))))
 
+(deftest test-status-compact-opponent-hand-count-public
+  ;; HQ/grip size is PUBLIC information in Netrunner. The compact header used
+  ;; (count hand), but the opponent's :hand is fog-of-war hidden in the wire
+  ;; state (arrives empty), so the Opp segment under-reported the opponent hand
+  ;; as 0h while the full `status` correctly showed the real count. The header
+  ;; must read the public :hand-count field for both seats, matching status.
+  (testing "runner seat: corp hand hidden but :hand-count public -> Opp shows 5h"
+    (with-mock-state (mock-client-state
+                      :side "runner"
+                      :game-state {:active-player "runner" :turn 1
+                                   :runner {:click 4 :credit 5 :hand [{:title "A"} {:title "B"}]
+                                            :hand-count 2 :agenda-point 0 :rig {}}
+                                   :corp {:click 0 :credit 5 :hand [] :hand-count 5 :agenda-point 0}})
+      (let [line (str/trim (with-out-str (display/status-compact)))]
+        (is (str/includes? line "Opp(C):5c/0cl/5h/0AP")
+            (str "opponent hand count must come from public :hand-count, got: " line))
+        (is (not (str/includes? line "Opp(C):5c/0cl/0h"))
+            (str "must not under-report opp hand as 0h, got: " line)))))
+  (testing "corp seat: runner grip hidden but :hand-count public -> Opp shows 5h"
+    (with-mock-state (mock-client-state
+                      :side "corp"
+                      :game-state {:active-player "corp" :turn 2
+                                   :corp {:click 3 :credit 8 :hand [{:title "X"}]
+                                          :hand-count 1 :agenda-point 0}
+                                   :runner {:click 0 :credit 4 :hand [] :hand-count 5 :agenda-point 0}})
+      (let [line (str/trim (with-out-str (display/status-compact)))]
+        (is (str/includes? line "Opp(R):4c/0cl/5h/0AP")
+            (str "opponent grip count must come from public :hand-count, got: " line))))))
+
 (deftest test-show-snapshot-bundles-read-loop
   ;; snapshot collapses the per-decision read-loop
   ;; (status-compact + prompt? + board-compact + hand + log + cursor) into one


### PR DESCRIPTION
## What

The compact status / `snapshot` header — the command the help text explicitly pushes as *the per-decision read-loop* (\"Use this.\") — under-reported the **opponent's** hand size as `0h`.

Found by hand-driving a live runner seat this polish round:

- `status` → `CORP Hand: 5 cards` ✅
- `snapshot` → `Opp(C):5c/0cl/0h/0AP` ❌

## Root cause

The header counted hands with `(count hand)`. The opponent's `:hand` is fog-of-war hidden in the wire state (arrives empty), so the count was 0. The full `status` already does the right thing via the public `:hand-count` field. HQ / grip size is **public information** in Netrunner — `0h` was a flat-out lie on the most-recommended read command. Same misleading-output class as the recent send_command polish work (see ai-netrunner forum thread).

## Fix

Header reads the public `:hand-count` field for both seats (own and opponent), falling back to `(count hand)` only if the count field is absent. Matches `status`.

## Test

+1 red→green test covering both seats (runner viewing corp HQ, corp viewing runner grip). Existing tests use empty `:hand` with no `:hand-count` and stay green via the fallback.

Gate: 350 → 351 tests, 801 assertions, **0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)