### PR TITLE
polish: capture-state-snapshot reads public :deck-count, not fog-hidden (count deck)

### DIFF
--- a/dev/src/clj/ai_core.clj
+++ b/dev/src/clj/ai_core.clj
@@ -970,8 +970,15 @@
         servers (:servers corp-state)]
     {:credits (get-in gs [side :credit])
      :clicks (get-in gs [side :click])
-     :hand-size (count (get-in gs [side :hand]))
-     :deck-size (count (get-in gs [side :deck]))
+     ;; Prefer the public count fields for zone sizes. On the wire a player's
+     ;; OWN deck is fog-of-war-hidden (arrives as [] with the real size in
+     ;; :deck-count), so (count deck) is a constant 0 and the deck never moves
+     ;; in show-state-diff — even on a draw. Own hand IS visible, but read its
+     ;; public :hand-count too for consistency. Fall back to (count zone) when
+     ;; the count field is absent OR nil (older/synthetic states); `or` guards
+     ;; present-but-nil, which a bare get-in default would not.
+     :hand-size (or (get-in gs [side :hand-count]) (count (get-in gs [side :hand])))
+     :deck-size (or (get-in gs [side :deck-count]) (count (get-in gs [side :deck])))
      :discard-size (count (get-in gs [side :discard]))
      :installed-count (if (= side :runner)
                        (+ (count (:program rig))

--- a/dev/test/ai_pure_functions_test.clj
+++ b/dev/test/ai_pure_functions_test.clj
@@ -775,6 +775,54 @@
                   {:initial-prompt p :current-prompt p
                    :initial-size 2 :current-log [{:text "a"} {:text "b"}]}))))))
 
+;; ============================================================================
+;; capture-state-snapshot / show-state-diff tests (ai-core)
+;;
+;; The before/after verification snapshot must read PUBLIC count fields for
+;; zone sizes, not (count zone-vector). On the wire, a player's OWN deck is
+;; fog-of-war-hidden: it arrives as [] with the real size carried in the
+;; public :deck-count field (see game.core.diffs/deck-summary). Counting the
+;; empty vector reports a constant 0, so show-state-diff could never surface a
+;; draw. (Same bug class as the snapshot-header :hand-count fix, forum #28.)
+;; ============================================================================
+
+(defn- corp-snapshot-gs
+  "Wire-shaped game-state for the corp seat: own deck hidden as [] with the
+   real size in :deck-count; own hand is visible."
+  [deck-count hand-count]
+  {:corp   {:credit 7 :click 2
+            :hand (vec (repeat hand-count {:cid 0 :title "X"}))
+            :hand-count hand-count
+            :deck []                ; fog-of-war: own deck contents hidden
+            :deck-count deck-count  ; public size field
+            :discard [] :servers {}}
+   :runner {:credit 5 :click 0 :hand [] :rig {}}
+   :active-player "corp"})
+
+(deftest test-capture-snapshot-deck-size-uses-public-count
+  (testing "own deck is fog-hidden ([]) on the wire; :deck-size reads :deck-count"
+    (with-mock-state (mock-client-state :side "corp"
+                                        :game-state (corp-snapshot-gs 30 2))
+      (let [snap (core/capture-state-snapshot)]
+        (is (= 30 (:deck-size snap))
+            "deck-size must reflect the public deck-count, not the empty fog-hidden vector")
+        (is (= 2 (:hand-size snap))
+            "hand-size for own (visible) hand")))))
+
+(deftest test-show-state-diff-surfaces-draw
+  (testing "a draw (deck 30->29, hand 2->3) shows the deck line in detailed diff"
+    (let [before (with-mock-state (mock-client-state :side "corp"
+                                                     :game-state (corp-snapshot-gs 30 2))
+                   (core/capture-state-snapshot))
+          after  (with-mock-state (mock-client-state :side "corp"
+                                                     :game-state (corp-snapshot-gs 29 3))
+                   (core/capture-state-snapshot))
+          out    (with-out-str (core/show-state-diff before after true))]
+      (is (re-find #"Deck: 30 . 29" out)
+          "detailed diff must surface deck movement on a draw")
+      (is (re-find #"Hand: 2 . 3" out)
+          "detailed diff must surface hand movement on a draw"))))
+
 (defn -main []
   (let [results (run-tests 'ai-pure-functions-test)]
     (println "\n========================================")


### PR DESCRIPTION
## What

`capture-state-snapshot` (the before/after verification snapshot consumed by `show-state-diff`) built zone sizes with `(count zone)`. On the jinteki wire protocol a player's **own deck** is fog-of-war-hidden — it arrives as `[]` with the real size in the public `:deck-count` field (see `game.core.diffs/deck-summary`). So `:deck-size` was a **constant 0**.

Downstream, `show-state-diff` only prints the deck line `when (not= deck-diff 0)` — which never happened — so the `📚 Deck: X → Y` line **never fired, even on a draw**. Silent omission rather than a printed lie, but the same bug class as the snapshot-header `:hand-count` fix ([#28](https://github.com/Clamatius/netrunner/pull/28)): a display path counting a fog-hidden zone vector instead of reading the public count field.

## Fix

- Prefer the public count field, `or`-falling back to `(count zone)` when absent/nil.
- Own hand IS visible on the wire, but read its public `:hand-count` too so both sizes use the canonical field uniformly — avoids the adjacent-line drift that produced #28.
- `:discard-size` stays `(count …)` — own discard is a visible zone.

## Verification

- +2 red→green tests in `ai-pure-functions-test`: `capture-state-snapshot` reports `:deck-count` over the empty fog-hidden vector; `show-state-diff` surfaces deck+hand movement on a draw (RED reproduced `0` deck-size and a missing Deck line).
- Gate 352 → 354 tests, **0 failures / 0 errors**.
- Codex-reviewed: confirmed the engine always assocs a numeric `:deck-count`, suggested the `or` guard against present-but-nil (applied).

Found during an autonomous polish round by static audit of `ai_display`/`ai_core` for the fog-of-war count pattern, while a marquee Opus-vs-GPT-5.5 game ran in another worktree (read-only on my side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)