### PR TITLE
fix: --rez "<ICE>" pauses on other unrezzed ICE instead of silently auto-declining (marquee g3)

### DIFF
--- a/dev/docs/run-state-machine.md
+++ b/dev/docs/run-state-machine.md
@@ -501,7 +501,7 @@ Flags can be passed to `run!`, `continue-run!`, or `monitor-run!` to automate de
 | Flag | Description |
 |------|-------------|
 | `--no-rez` | Auto-decline all rez opportunities |
-| `--rez <ice>` | Only rez specified ICE, decline others (can repeat) |
+| `--rez <ice>` | Auto-rez the named ICE (can repeat). Any *other* unrezzed ICE PAUSES and hands back a rez decision — it is NOT silently declined. To decline the rest, send `--no-rez` (or re-enter `--rez "<that ICE>"`). |
 | `--fire-unbroken` | Auto-fire unbroken subs when Runner signals done breaking |
 | `--fire-if-asked` | Wait silently while Runner breaks, auto-fire when signaled, wake only for rez decisions |
 

--- a/dev/instructions/corp_play_structure.md
+++ b/dev/instructions/corp_play_structure.md
@@ -292,7 +292,7 @@ Corp gets priority at specific timing windows:
 ```bash
 ./dev/send_command corp monitor-run                     # Auto-pass until decision needed
 ./dev/send_command corp monitor-run --no-rez            # Also auto-decline all rez
-./dev/send_command corp monitor-run --rez "Tithe"       # Only rez Tithe, decline others
+./dev/send_command corp monitor-run --rez "Tithe"       # Auto-rez Tithe; PAUSE on any other unrezzed ICE
 ./dev/send_command corp monitor-run --fire-unbroken     # Auto-fire when Runner signals done
 ```
 
@@ -315,7 +315,7 @@ If the run already ended, returns immediately instead of blocking.
 
 **Caveats:**
 - Uses stuck-state detection instead of iteration limits (500 max as safety net)
-- Always wakes for rez decisions unless --rez or --no-rez specified
+- Always wakes for rez decisions. `--rez "X"` auto-rezzes X but still wakes on *other* unrezzed ICE; only `--no-rez` declines everything silently
 - Fallback: Use manual `continue` + `fire-subs` sequence if automation fails
 
 ### Gotchas

--- a/dev/send_command
+++ b/dev/send_command
@@ -361,7 +361,7 @@ ${GREEN}Running:${NC}
 
   ${BLUE}Run Flags:${NC} (usable with run, continue)
     --no-rez         Corp: don't rez any ICE
-    --rez <name>     Corp: only rez ICE matching <name>
+    --rez <name>     Corp: auto-rez ICE matching <name>; pause on other unrezzed ICE
     --fire-unbroken  Corp: auto-fire unbroken subroutines
     --full-break     Runner: auto-break all ICE with available breakers
     --no-continue    Don't auto-continue after run start

--- a/dev/src/clj/ai_run_corp_handlers.clj
+++ b/dev/src/clj/ai_run_corp_handlers.clj
@@ -123,13 +123,31 @@
           (println (format "   ICE %s already rezzed, continuing" ice-title))
           (send-continue! gameid))
 
-        ;; --rez set exists but this ICE not in it: decline
+        ;; --rez set exists but THIS unrezzed ICE is not in it: pause for a
+        ;; decision rather than silently auto-declining. The old behaviour sent
+        ;; `continue` and never handed control back, so on a multi-ICE server a
+        ;; Corp that committed `--rez "<outer>"` never got to rez/fire its inner
+        ;; ICE (marquee g3: inner Tithe never fired in the two runs that lost the
+        ;; game). That violates the --persistent contract — "returns to you for a
+        ;; real rez/fire decision": a 2nd unrezzed ICE the Corp hasn't spoken to
+        ;; IS a real decision. Surface it like the no-strategy approach-ice path
+        ;; (handle-corp-rez-decision); the Corp then rezzes it (plain `rez` /
+        ;; re-enter `--rez "<this>"`) or declines for the rest of the run
+        ;; (`--no-rez`). Print once per (position, ice) to avoid spam on re-entry.
         :else
-        (do
-          (println (format "   Strategy: --rez (not %s), declining" ice-title))
-          (merge (send-continue! gameid)
-                 {:action :auto-declined-rez
-                  :ice ice-title}))))))
+        (let [status-key [:corp-rez-strategy-decision position ice-title]
+              already-printed? (= @last-waiting-status status-key)]
+          (when-not already-printed?
+            (reset! last-waiting-status status-key)
+            (println (format "   Rez decision: %s — approaching an unrezzed ICE not in your --rez list." ice-title))
+            (println (format "      continue --rez \"%s\"   - rez it (keeps owning the run)" ice-title))
+            (println           "      continue --no-rez       - decline this and the rest of the run"))
+          {:status :decision-required
+           :wake-reason :rez-ice
+           :ice ice-title
+           :position position
+           :prompt my-prompt
+           :message (format "Corp must decide: rez %s or continue" ice-title)})))))
 
 (defn handle-corp-rez-decision
   "Priority 1.7: Corp at approach-ice WITHOUT strategy - pause for human decision."

--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -22,7 +22,7 @@
 ;; Structure:
 ;; {:full-break true/false      ; Runner: auto-break all ICE
 ;;  :no-rez true/false          ; Corp: don't rez anything
-;;  :rez #{\"Ice Wall\" ...}    ; Corp: only rez these ICE names
+;;  :rez #{\"Ice Wall\" ...}    ; Corp: auto-rez these ICE; pause on other unrezzed ICE
 ;;  :fire-unbroken true/false   ; Corp: auto-fire unbroken subs
 ;;  :force true/false}          ; Bypass all smart checks
 (defonce run-strategy (atom {}))
@@ -94,7 +94,7 @@
    --tank <ice-name> : Runner pre-authorizes letting subs fire on specified ICE
    --tank-all        : Runner pre-authorizes letting subs fire on ALL ICE (yolo)
    --no-rez          : Corp doesn't rez anything
-   --rez <ice-name>  : Corp only rezzes specified ICE
+   --rez <ice-name>  : Corp auto-rezzes named ICE; PAUSES on other unrezzed ICE
    --fire-unbroken   : Corp auto-fires unbroken subs
    --no-continue     : Don't auto-continue after run start
    --force           : Bypass all smart checks (for continue-run)
@@ -279,7 +279,7 @@
    Strategy flags:
    --full-break      : Runner auto-breaks all ICE (no pauses for break decisions)
    --no-rez          : Corp doesn't rez anything (auto-declines all rez opportunities)
-   --rez <ice-name>  : Corp only rezzes specified ICE, declines others
+   --rez <ice-name>  : Corp auto-rezzes named ICE; other unrezzed ICE PAUSES for a rez decision (not auto-declined)
    --fire-unbroken   : Corp auto-fires all unbroken subroutines
    --no-continue     : Don't auto-continue after run initiation (stop at first decision)
 
@@ -287,7 +287,7 @@
    (run! \"hq\")                        ; Auto-continues till decision needed
    (run! \"remote1\" \"--full-break\")   ; Auto-breaks all ICE
    (run! \"hq\" \"--no-continue\")       ; Stop after initiation (rare)
-   (run! \"remote1\" \"--rez\" \"Ice Wall\") ; Corp only rezzes Ice Wall"
+   (run! \"remote1\" \"--rez\" \"Ice Wall\") ; Corp auto-rezzes Ice Wall, pauses on other unrezzed ICE"
   [& args]
   (if (not (core/side= "Runner" (:side @state/client-state)))
     (do
@@ -886,13 +886,13 @@
    Strategy flags (from run! or passed directly):
    --full-break      : Runner auto-breaks all ICE
    --no-rez          : Corp auto-declines all rez opportunities
-   --rez <ice-name>  : Corp only rezzes specified ICE
+   --rez <ice-name>  : Corp auto-rezzes named ICE; PAUSES on other unrezzed ICE
    --fire-unbroken   : Corp auto-fires unbroken subs
    --force           : Bypass ALL smart checks, just send continue
 
    🛑 MUST PAUSE (requires decision):
    - Opponent pressed WAIT/indicate-action
-   - Corp has rez opportunity (approach-ice with unrezzed ICE) [unless --no-rez/--rez]
+   - Corp has rez opportunity (approach-ice with unrezzed ICE) [unless --no-rez, or --rez naming THIS ICE]
    - Runner has 2+ real choices (not just Continue/Done) [unless --full-break]
    - Waiting for opponent's decision during run
 
@@ -1292,7 +1292,7 @@
 
    Flags:
      --no-rez            Auto-decline all rez opportunities
-     --rez <ice-name>    Only rez specified ICE, decline others
+     --rez <ice-name>    Auto-rez named ICE; PAUSE (return a rez decision) on other unrezzed ICE
      --fire-unbroken     Auto-fire unbroken subs when Runner signals
      --fire-if-asked     Sleep mode: auto-fire, auto-continue, wake only for rez
      --persistent        Stay in the loop across empty opponent-priority windows
@@ -1305,7 +1305,7 @@
    Usage:
      (monitor-run!)                           ; Auto-pass until decision needed
      (monitor-run! \"--no-rez\")              ; Also auto-decline all rez opportunities
-     (monitor-run! \"--rez\" \"Tithe\")        ; Only rez Tithe, decline others
+     (monitor-run! \"--rez\" \"Tithe\")        ; Auto-rez Tithe; pause on any other unrezzed ICE
      (monitor-run! \"--fire-if-asked\")       ; Sleep until run ends
      (monitor-run! \"--persistent\")          ; Own the whole run; wake only for decisions
      (monitor-run! \"--since\" \"892\")        ; Fast-return if state advanced"

--- a/dev/test/ai_runs_test.clj
+++ b/dev/test/ai_runs_test.clj
@@ -157,8 +157,8 @@
           ;; Clean up
           (runs/reset-strategy!))))))
 
-(deftest test-corp-rez-declines-other-ice
-  (testing "Corp with --rez strategy declines ICE not in the set"
+(deftest test-corp-rez-pauses-on-other-unrezzed-ice
+  (testing "Corp with --rez strategy PAUSES on an unrezzed ICE not in the set (returns a rez decision) instead of silently declining — marquee g3 / forum [112]"
     (let [sent (atom [])]
       (with-mock-state
         (mock-state-with-run
@@ -170,12 +170,14 @@
         (with-redefs [ws/send-message! (mock-websocket-send! sent)]
           ;; Set strategy to rez Ice Wall only (not Enigma)
           (runs/set-strategy! {:rez #{"Ice Wall"}})
+          ;; An unrezzed ICE the Corp hasn't named is a real rez decision under
+          ;; the --persistent contract: pause and hand control back, don't
+          ;; silently `continue` past it (which hid inner-ICE rezzes in g3).
           (let [result (runs/continue-run!)]
-            (is (= :action-taken (:status result)))
-            (is (= :auto-declined-rez (:action result)))
+            (is (= :decision-required (:status result)))
             (is (= "Enigma" (:ice result)))
-            (is (= 1 (count @sent)))
-            (is (= "continue" (get-in @sent [0 :data :command]))))
+            (is (not-any? #(= "continue" (get-in % [:data :command])) @sent)
+                "must NOT silently pass priority — the unrezzed ICE is a real rez decision"))
           ;; Clean up
           (runs/reset-strategy!))))))
 

--- a/dev/test/continue_run_rez_test.clj
+++ b/dev/test/continue_run_rez_test.clj
@@ -252,3 +252,57 @@
               "should continue past the unrezzed ICE so the run proceeds")
           (is (re-find #"(?i)can't afford|did not take" out)
               (str "should explain why it declined, got: " out)))))))
+
+;; =============================================================================
+;; Test: --rez "X" must PAUSE on an unrezzed ICE that is NOT in the whitelist,
+;; not silently auto-decline it (marquee g3 finding, forum [112]).
+;;
+;; On a multi-ICE server the Corp commits `--rez "Palisade"` (outer). When the
+;; Runner reaches the inner unrezzed Tithe, the old :else branch sent `continue`
+;; and returned :auto-declined-rez WITHOUT handing control back — so the Corp
+;; never got to rez/fire its inner ICE. That violates the --persistent contract
+;; ("returns to you for a real rez/fire decision"): a 2nd unrezzed ICE the Corp
+;; hasn't spoken to IS a real decision. It now pauses (:decision-required) like
+;; the no-strategy approach-ice path, so the inner ICE gets its own decision.
+;; =============================================================================
+
+(defn- rez-strategy-ctx-ice
+  "Like rez-strategy-ctx but with a named, unrezzed ICE being approached."
+  [strategy ice-title]
+  {:side "corp"
+   :run-phase "approach-ice"
+   :my-prompt {:msg (str "Rez " ice-title "?") :prompt-type "run" :choices []}
+   :strategy strategy
+   :gameid (java.util.UUID/fromString "00000000-0000-0000-0000-000000000002")
+   :state {:game-state
+           {:run {:phase "approach-ice" :position 1 :server [:hq]}
+            :corp {:credit 7
+                   :servers {:hq {:ices [{:cid 77 :title ice-title :cost 1 :rezzed false}]}}}}}})
+
+(deftest rez-strategy-unlisted-unrezzed-ice-pauses-for-decision
+  (testing "an unrezzed ICE not in the --rez whitelist pauses (returns a rez decision) instead of silently auto-declining"
+    (let [sent (atom [])]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (with-out-str
+          (let [r (corp-handlers/handle-corp-rez-strategy
+                   ;; whitelist names Palisade; the run is approaching an unrezzed Tithe
+                   (rez-strategy-ctx-ice {:rez #{"Palisade"}} "Tithe"))]
+            (is (= :decision-required (:status r))
+                (str "an unrezzed ICE outside the --rez list is a real rez decision; must pause, got: " r))
+            (is (= "Tithe" (:ice r))
+                "should name the ICE the Corp must decide on")))
+        (is (not-any? #(= "continue" (:command %)) @sent)
+            "must NOT silently pass priority — pausing returns control to the Corp to decide on this ICE")))))
+
+(deftest rez-strategy-already-rezzed-unlisted-ice-still-continues
+  (testing "an ALREADY-rezzed ICE outside the --rez list just continues (no decision needed)"
+    (let [sent (atom [])]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (let [ctx (-> (rez-strategy-ctx-ice {:rez #{"Palisade"}} "Tithe")
+                      (assoc-in [:state :game-state :corp :servers :hq :ices 0 :rezzed] true))]
+          (with-out-str
+            (let [r (corp-handlers/handle-corp-rez-strategy ctx)]
+              (is (= :action-taken (:status r))
+                  (str "a rezzed unlisted ICE needs no decision; should continue, got: " r))))
+          (is (some #(= "continue" (:command %)) @sent)
+              "a rezzed ICE the Corp isn't rezzing should pass priority and proceed"))))))


### PR DESCRIPTION
## What
On a multi-ICE server, a Corp committing `monitor-run --persistent --rez "<outer ICE>"` had the persistent monitor reach each *inner* unrezzed ICE, hit the `:else` branch of `handle-corp-rez-strategy`, send `continue`, and return `:auto-declined-rez` **without handing control back**. The Corp never got to rez/fire its inner ICE.

## Why it matters
Found in **marquee Game 3** (Opus Corp vs GPT-5.5 Runner, forum `ai-netrunner` [112]). The Corp's inner **Tithe never fired** in the two runs that lost the game (`Strategy: --rez (not Tithe), declining` printed silently, no decision returned). This violates the documented `--persistent` contract (`seat-corp.md`: *"returns to you for a real rez/fire decision or when the run ends"*) — a 2nd unrezzed ICE the Corp hasn't spoken to **is** a real rez decision.

## The change
`handle-corp-rez-strategy`'s `:else` branch (unrezzed ICE not in the `--rez` whitelist) now **pauses** (`:decision-required`) and surfaces the decision — the same shape as the no-strategy approach-ice path (`handle-corp-rez-decision`) — instead of auto-declining. Each unrezzed un-whitelisted ICE gets its own decision; the Corp then rezzes it (plain `rez` / re-enter `--rez "<this>"`) or declines the rest of the run (`--no-rez`). Printed once per `(position, ice)` to avoid re-entry spam. Already-rezzed unlisted ICE still just continues (unchanged).

## ⚠️ This is a semantics change — leaving merge to Michael (PM call)
Per [112], `--rez "X"` previously meant "rez ONLY X, silently decline the rest this run." This PR makes it "rez X, **pause on any other unrezzed ICE**." That's option **(a)** from the forum question. Alternatives were (b) keep whitelist-decline + just document it, or (c) `--rez X --rez Y` lists + pause on anything unlisted. **Not self-merging** — this is the run-decision UX you're personally shaping ([096]/[099]).

## Tests
- `continue_run_rez_test`: red→green pause test + an already-rezzed guard (rezzed unlisted ICE still continues, no spurious pause).
- `ai_runs_test`: `test-corp-rez-declines-other-ice` (which codified the old auto-decline) updated to assert the pause; renamed `test-corp-rez-pauses-on-other-unrezzed-ice`.
- Gate: **356 tests, 819 assertions, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)