### PR TITLE
fix: run-initiation both-pass stall — Runner already-passed hint + jack-out recovery (issue #31, partial)

### DIFF
--- a/dev/instructions/runner_play_structure.md
+++ b/dev/instructions/runner_play_structure.md
@@ -267,6 +267,20 @@ When you only want to break some subroutines:
 ./dev/send_command runner continue                     # Pass priority
 ```
 
+### If a run seems stuck at "priority / paid-ability window"
+
+Run **initiation**, **movement**, and **approach-server** are *both-must-pass*
+windows: the run only advances after **both** players pass priority. Once you've
+sent `continue` there, `prompt` / `diagnose-blocker` will say *"You have already
+passed priority here"* — re-sending `continue` does **nothing** (it's a no-op
+loop). You're waiting on the Corp to also pass.
+
+In cross-model play the Corp seat must be actively running `monitor-run` to pass
+an empty window. If it isn't, the run stalls and `wait` never resolves. To break
+out, **`jack-out`** ends the run cleanly. (If you have a real reason to be in the
+run, give the Corp seat a moment to pass first; only `jack-out` if it's clearly
+not coming.)
+
 ---
 
 ## Keep Your Options Open

--- a/dev/src/clj/ai_display.clj
+++ b/dev/src/clj/ai_display.clj
@@ -980,9 +980,18 @@
     (cond
       ;; I have already passed — waiting on the opponent; no action from me.
       (= na my-side)
-      [(str "    ⏸️  You have already passed priority here — waiting for " opp
-            " to pass before the run advances.")
-       (str "      (No action needed from you; use 'wait'. Re-sending 'continue' does nothing.)")]
+      (into
+        [(str "    ⏸️  You have already passed priority here — waiting for " opp
+              " to pass before the run advances.")
+         (str "      (No action needed from you; use 'wait'. Re-sending 'continue' does nothing.)")]
+        ;; Stall recovery (issue #31): a both-must-pass window only advances once
+        ;; the opponent also passes. In cross-model play the opposing seat must be
+        ;; actively monitoring the run to pass an empty window; if it isn't, the
+        ;; run stalls here and 'wait' never resolves. The Runner can break out with
+        ;; 'jack-out' (the marquee g3 escape hatch — "only jack-out cleared it").
+        (when (= my-side "runner")
+          [(str "      If " opp " isn't actively monitoring the run, it can stall here — "
+                "'jack-out' ends the run to recover.")]))
 
       ;; Opponent already passed — my continue advances the run now.
       (and na (not= na my-side))
@@ -1145,7 +1154,14 @@
                 ;; spell out whose move it is and what continuing does, so neither
                 ;; seat assumes the run advances on its own (the symmetric
                 ;; 'pass priority' text deadlocked cross-model play).
-                (if (contains? #{"movement" "approach-server"} run-phase)
+                ;; `initiation` is a both-must-pass window too (issue #31): the
+                ;; Runner routes through the already-passed-aware hint so a passed
+                ;; Runner is told to wait / jack-out rather than re-`continue` (a
+                ;; no-op loop). The Corp keeps its rich rez/decline guidance below.
+                (if (contains? (if (= my-side "runner")
+                                 #{"initiation" "movement" "approach-server"}
+                                 #{"movement" "approach-server"})
+                               run-phase)
                   (doseq [line (run-priority-hint-lines run my-side)]
                     (println line))
                   ;; Other run windows (initiation / approach-ice / encounter).
@@ -1616,7 +1632,15 @@
         (println (format "⏸️  Run priority / paid-ability window%s: %s"
                          (if run-phase (str " (" run-phase ")") "") (:msg prompt)))
         (println "   → Owner: this is a both-must-pass priority window, not a choose prompt.")
-        (if (contains? #{"movement" "approach-server"} run-phase)
+        ;; `initiation` is a both-must-pass window too (engine: continue :initiation
+        ;; needs BOTH sides), but only the Runner gets the already-passed-aware hint
+        ;; here — once it has passed, "use continue" is a no-op loop (issue #31 / g3).
+        ;; The Corp keeps the generic continue/monitor-run steer at initiation (it
+        ;; may still want to rez/fire a paid ability there).
+        (if (contains? (if (= my-side-lc "runner")
+                         #{"initiation" "movement" "approach-server"}
+                         #{"movement" "approach-server"})
+                       run-phase)
           (doseq [line (run-priority-hint-lines run my-side-lc)]
             (println line))
           (println "   → Use: continue (to pass priority) — or monitor-run to participate in the run.")))

--- a/dev/test/ai_display_test.clj
+++ b/dev/test/ai_display_test.clj
@@ -432,6 +432,44 @@
         (is (str/includes? out "breach R&D") (str "should explain what continue yields, got: " out))
         (is (not (str/includes? out "ACTIONABLE")))))))
 
+(deftest test-blocker-diagnosis-initiation-already-passed-runner
+  (testing "Runner that already passed the run-initiation both-pass window is told
+            it has passed (wait / jack-out), NOT to re-send a no-op 'continue'
+            — marquee g3 stall (issue #31): a Runner that passed initiation kept
+            being told 'use continue', which loops back to the same wait."
+    (with-mock-state (mock-client-state
+                      :side "runner"
+                      :game-state {:active-player "runner" :turn 6
+                                   :run {:phase "initiation" :position 1
+                                         :server ["hq"] :no-action "runner"}
+                                   :runner {:click 1 :credit 5 :hand []
+                                            :prompt-state {:msg "You are running on HQ"
+                                                           :prompt-type "run"}}
+                                   :corp {:click 0 :credit 5 :hand []}})
+      (let [out (with-out-str (display/show-blocker-diagnosis))]
+        (is (str/includes? out "already passed priority")
+            (str "should tell the Runner it already passed, got: " out))
+        (is (str/includes? out "jack-out")
+            (str "should offer jack-out as the stall recovery, got: " out))
+        (is (not (str/includes? out "ACTIONABLE")))))))
+
+(deftest test-priority-hint-runner-already-passed-suggests-jackout
+  (testing "Runner already-passed hint names jack-out as recovery if the opponent
+            seat isn't monitoring (issue #31: 'only jack-out cleared it')"
+    (let [out (str/join "\n" (display/run-priority-hint-lines
+                              {:phase "initiation" :position 1 :server ["hq"] :no-action "runner"}
+                              "runner"))]
+      (is (str/includes? out "already passed priority"))
+      (is (str/includes? out "jack-out")))))
+
+(deftest test-priority-hint-corp-already-passed-no-jackout
+  (testing "Corp already-passed hint does NOT suggest jack-out (Corp can't jack out)"
+    (let [out (str/join "\n" (display/run-priority-hint-lines
+                              {:phase "movement" :position 0 :server ["hq"] :no-action "corp"}
+                              "corp"))]
+      (is (str/includes? out "already passed priority"))
+      (is (not (str/includes? out "jack-out"))))))
+
 (deftest test-blocker-diagnosis-turn-not-started
   (testing "my-turn boundary with 0 clicks steers to start-turn"
     (with-mock-state (mock-client-state


### PR DESCRIPTION
## What

Addresses the **Runner-side run-initiation stall** from the marquee g3 report (issue #31) — the one GPT-5.5 called *"the biggest friction… likely affected competitive play."* Messaging/diagnostic only; **no run-state-machine logic changed.**

## Root cause

`initiation` is a **both-must-pass** priority window — the engine's `continue :initiation` (`src/clj/game/core/runs.clj:172`) advances the phase only after **both** sides pass (it records the first passer in the run's `:no-action`). But the client's `diagnose-blocker` and `prompt` displays only routed `movement`/`approach-server` through the already-passed-aware `run-priority-hint-lines`. At `initiation` they fell through to the naive **"→ Use: continue"**.

So a Runner that had **already passed** initiation (`:no-action = "runner"`) was told to `continue` — but the smart `continue` (`continue-run!`) sees `should-i-act?` = false (it already passed) and just returns `:waiting-for-opponent` again. Net effect: `continue`/`ping` loop forever; **only `jack-out` recovered**, exactly as g3 reported (T6/T15/T16, "likely cost several potential winning accesses").

## Fix (messaging only)

- Route the **Runner's** `initiation` phase through `run-priority-hint-lines` in both `show-prompt-detailed` and `diagnose-blocker`. A passed Runner now gets *"You have already passed priority here… re-sending 'continue' does nothing"* instead of a no-op `continue` steer. The **Corp** keeps its richer rez/decline guidance at initiation (it may legitimately rez / fire a paid ability there).
- Add a **Runner-only** stall-recovery line to the "already passed" branch: if the opposing seat isn't actively monitoring the run, it can stall — **`jack-out` recovers** (the g3 escape hatch).
- Document the both-must-pass stall + `jack-out` recovery in `runner_play_structure.md`.

## What this does NOT do

It does **not** auto-advance the window — the run still genuinely needs the **Corp seat to pass** an empty initiation window (no engine-level Corp auto-pass exists at initiation; `corp-auto-no-action` defaults false and doesn't cover initiation). That deeper coordination fix is a **PM call** documented in issue #31 (auto-advance options + my recommendation). This PR makes the stall **legible and recoverable** rather than a silent no-op loop.

## Tests

Red→green: 3 new tests in `ai_display_test.clj` (the first reproduces the exact g3 "→ Use: continue while already passed" output). Full gate: **359 tests, 826 assertions, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)