### PR TITLE
fix: run priority windows render as 2-sub-step ladder, active player first (forum [118]/[120])

### DIFF
--- a/dev/src/clj/ai_display.clj
+++ b/dev/src/clj/ai_display.clj
@@ -972,6 +972,13 @@
         na        (let [v (:no-action run)]
                     (cond (keyword? v) (name v) (string? v) v :else nil))
         opp       (if (= my-side "runner") "Corp" "Runner")
+        ;; The run timing splits each priority window into two sub-steps: the
+        ;; ACTIVE player passes first, then the opponent (forum [118]). During a
+        ;; run the active player is ALWAYS the Runner — runs only happen on the
+        ;; Runner's turn (rule invariant, memory run-priority-active-player-first),
+        ;; so we encode that directly rather than trusting the volatile
+        ;; :active-player wire field. Render: Runner = first sub-step, Corp = second.
+        i-am-active? (= my-side "runner")
         ;; What the Runner specifically gains by continuing this window.
         gain      (when (= my-side "runner")
                     (if past-ice?
@@ -998,11 +1005,21 @@
       [(str "    → It's YOUR move: " opp " has already passed priority. Use 'continue' to "
             (or gain "advance the run") ".")]
 
-      ;; Fresh window — nobody has passed yet.
-      :else
-      [(str "    → It's YOUR move: use 'continue' to pass priority"
+      ;; Fresh window — nobody has passed yet. Render the two sub-steps explicitly
+      ;; so each seat knows whether it's the first passer (active player) or the
+      ;; second (forum [118]/[120]).
+      i-am-active?
+      ;; Active player (Runner): your sub-step is FIRST.
+      [(str "    → YOUR sub-step (active player goes first): use 'continue' to pass priority"
             (when gain (str " (this is what gets you your access: " gain ")")) ".")
-       (str "      (BOTH players must pass for the run to advance — after you continue, expect to wait for " opp ".)")])))
+       (str "      (Both players pass to advance — " opp " gets its sub-step AFTER you pass.)")]
+
+      ;; Opponent of the active player (Corp): your sub-step is SECOND. You do NOT
+      ;; act in the Runner's sub-step — if you want to rez / fire a paid ability,
+      ;; you do it in your own sub-step, AFTER the Runner has passed (forum [120]).
+      :else
+      [(str "    ⏸️  " opp " (active player) has priority first here and hasn't passed yet.")
+       (str "      → Your sub-step comes next: wait for the " opp " to 'continue', then you 'continue' to advance the run.")])))
 
 (def ^:private run-ladder-rungs
   "Conceptual run-timing ladder (jinteki run structure), in order. Steps #2–#4

--- a/dev/test/ai_display_test.clj
+++ b/dev/test/ai_display_test.clj
@@ -499,14 +499,16 @@
 ;; ============================================================================
 
 (deftest test-priority-hint-fresh-window-runner-naked-server
-  (testing "Runner, nobody passed yet, no ICE left: continue -> breach & access"
+  (testing "Runner (active player), nobody passed yet, no ICE left: continue ->
+            breach & access, framed as the FIRST sub-step (forum [118]/[120])"
     (let [lines (display/run-priority-hint-lines
                  {:phase "movement" :position 0 :server ["hq"] :no-action false}
                  "runner")
           out (str/join "\n" lines)]
-      (is (str/includes? out "YOUR move"))
+      (is (str/includes? out "active player goes first"))
       (is (str/includes? out "breach HQ and access cards"))
-      (is (str/includes? out "BOTH players must pass")))))
+      ;; The opponent's sub-step comes AFTER the active player passes.
+      (is (str/includes? out "AFTER you pass")))))
 
 (deftest test-priority-hint-fresh-window-runner-more-ice
   (testing "Runner, fresh window, ICE still ahead: continue -> approach next ICE"
@@ -535,13 +537,31 @@
       (is (str/includes? out "breach R&D and access cards")))))
 
 (deftest test-priority-hint-corp-side-no-access-language
-  (testing "Corp seat gets whose-move guidance but no Runner 'access' phrasing"
+  (testing "Corp seat (non-active) in a fresh window is told the Runner (active
+            player) passes first and to wait — no Runner 'access' phrasing, and
+            (per [120]) NO 'you may rez / fire a paid ability now': the Corp acts
+            in its OWN sub-step, after the Runner has passed."
     (let [out (str/join "\n" (display/run-priority-hint-lines
                               {:phase "movement" :position 0 :server ["hq"] :no-action false}
                               "corp"))]
-      (is (str/includes? out "YOUR move"))
-      (is (str/includes? out "wait for Runner"))
-      (is (not (str/includes? out "access cards"))))))
+      (is (str/includes? out "active player"))
+      (is (str/includes? out "has priority first"))
+      (is (str/includes? out "wait for the Runner"))
+      (is (not (str/includes? out "access cards")))
+      ;; [120] correction: the Corp does not rez / fire paid abilities during the
+      ;; Runner's sub-step — that happens in the Corp's own sub-step afterwards.
+      (is (not (re-find #"(?i)rez" out)))
+      (is (not (re-find #"(?i)paid abilit" out))))))
+
+(deftest test-priority-hint-corp-fresh-window-is-second-passer
+  (testing "Corp fresh window does not claim 'it's YOUR move' — the Runner
+            (active player) passes first, the Corp passes second (forum [118])"
+    (let [out (str/join "\n" (display/run-priority-hint-lines
+                              {:phase "approach-server" :position 0 :server ["rd"] :no-action nil}
+                              "corp"))]
+      (is (not (str/includes? out "YOUR move")))
+      (is (str/includes? out "Runner (active player) has priority first"))
+      (is (str/includes? out "Your sub-step comes next")))))
 
 ;; ============================================================================
 ;; show-prompt-detailed with no prompt — turn-aware "what now?"


### PR DESCRIPTION
Implements Michael's [118] reframe + [120] go-ahead: **option A (display-only)** — render every run both-must-pass priority window as the two timing sub-steps the run structure defines, with the **active player passing first**.

## Problem
The fresh (nobody-passed) window printed an identical `→ It's YOUR move: use 'continue' to pass priority` to **both** seats. Neither was told it was the *second* passer, so at a both-must-pass window each seat could read "it's my move" — the canonical who-goes-first ordering was invisible. This is the residual ambiguity #31 / marquee-g3 surfaced from both seats (PR #32 fixed the *already-passed* loop; this fixes the *fresh window*).

## Change (display-only)
During a run the active player is **always the Runner** (runs only happen on the Runner's turn), so the fresh window now splits:

```
Runner (active):  → YOUR sub-step (active player goes first): use 'continue' to pass priority
                    (this is what gets you your access: breach R&D and access cards).
                    (Both players pass to advance — Corp gets its sub-step AFTER you pass.)

Corp (opponent):  ⏸️  Runner (active player) has priority first here and hasn't passed yet.
                    → Your sub-step comes next: wait for the Runner to 'continue', then you 'continue'.
```

- The active-player invariant is **encoded client-side** (`i-am-active? (= my-side "runner")`), not read from the volatile `:active-player` wire field.
- **Engine unchanged.** `continue :initiation` still records whichever side passes first (no side check); we only *render* the rules-canonical order so cross-model play reads deterministically. Engine enforcement deferred per [120] (upstream-merge cost).
- **[120] correction applied:** the Corp's waiting message does **not** say "you may still rez / fire a paid ability now" — the Corp acts in its own sub-step *after* the Runner passes, not during the Runner's sub-step.

## Tests (red→green)
- Updated the two fresh-window tests to assert sub-step framing.
- Added `test-priority-hint-corp-fresh-window-is-second-passer` (Corp never claims "YOUR move" in a fresh window; output contains no rez / paid-ability text).
- Gate 359→360, 0 fail. Codex review: **APPROVE** (no nits, all 4 cond branches reachable, both call sites compatible, coverage complete).

## Next (per [120])
Hand-run a couple of games to confirm it reads well live on both seats, then return to e2e marquee games.

🤖 Generated with [Claude Code](https://claude.com/claude-code)