### PR TITLE
fix: strip raw EDN return-map tail on monitor-run rez/tank decision blocks

### DIFF
--- a/dev/send_command
+++ b/dev/send_command
@@ -515,9 +515,13 @@ execute() {
             echo "$RESULT"
         fi
     else
-        # Suppress all status map noise - we print human-readable messages instead
-        # Filter out any line starting with {:status (success, error, waiting, etc.)
-        echo "$RESULT" | grep -v '^{:status ' | grep -v '^nil$' || true
+        # Suppress all status map noise - we print human-readable messages instead.
+        # Two shapes leak as the REPL's return value: maps that LEAD with :status
+        # (success/error/waiting), and run-decision maps that lead with another key
+        # (e.g. {:wake-reason ... :status :fire-decision-required ...} from
+        # monitor-run rez/tank windows). Strip any single-line EDN map carrying a
+        # :status key in any position. Human output never starts with "{".
+        echo "$RESULT" | grep -vE '^\{[^}]*:status[ ,}]' | grep -v '^nil$' || true
     fi
 
     return $RET


### PR DESCRIPTION
## What

`monitor-run` rez/tank decision blocks printed a clean human block **and then dumped the raw EDN return-value map**:

```
Rez decision: Palisade
   continue --rez "Palisade"  - rez it
   continue --no-rez      - decline
{:wake-reason :rez-decision, :cursor 12, :status :decision-required, ...}   ← leaked
```

```
⚠️  Palisade has 1 unbroken sub - authorization required
   → tank "Palisade" ...
{:wake-reason :decision-required, :cursor 15, :status :fire-decision-required, ...}   ← leaked
```

## Why it leaked

`send_command` captures REPL eval output (clean `println` human lines **plus** the handler's EDN return map as the last line) and strips the machine map. The old filter only matched lines starting with `^{:status `. These decision maps lead with `:wake-reason`, so they slipped through — a distinct case from the previously-handled leading-`:status` maps (memory: *misleading-output bug class* / the "EDN-tail" splinter; this is the non-`:status`-leading variant the prior filter never covered).

## Fix

Strip any single-line EDN map carrying a `:status` key **in any position**:

```bash
echo "$RESULT" | grep -vE '^\{[^}]*:status[ ,}]' | grep -v '^nil$' || true
```

One regex subsumes both shapes (leading-`:status` and `:wake-reason …:status`), replacing the two prior greps.

## Verification

- **Shell red→green** on the two real captured leak strings + a `{:status :success}` map + `nil`: all machine maps stripped, every human line (warning, tank/jack-out options, "Run complete") preserved.
- **Live** on the shared dev REPLs: Corp `monitor-run` rez-decision and Runner tank/fire-decision blocks both render clean (no EDN tail).
- **Full gate green**: 360 tests / 832 assertions, 0 fail (bash-only change).
- **Codex review**: adopted its single-regex simplification; over-strip / multi-line concerns are theoretical (human output never starts with `{`; these handler maps are single-line with `:status` before any `}`).

Found while doing the run-priority-ladder (#33) live both-seat hand-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)