### PR TITLE
fix: EDN-tail filter handles nested maps before :status (+ committed shell test)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-behavioral check check-full clean reset resume status help compile-deps watch-corp watch-runner
+.PHONY: test test-shell test-behavioral check check-full clean reset resume status help compile-deps watch-corp watch-runner
 
 # Default target
 help:
@@ -36,6 +36,11 @@ test:
 	@echo "Running unit tests..."
 	lein test ai-actions-test ai-actions-sad-path-test ai-basic-actions-test ai-heuristic-corp-test ai-heuristic-runner-test ai-runs-test ai-run-corp-decisions-test ai-stall-test ai-websocket-diff-test ai-websocket-error-recovery-test ai-display-test ai-state-test ai-prompts-test ai-pure-functions-test ai-turn-validation-test ai-wait-test continue-run-rez-test
 
+# Run shell-level tests (fast, no REPL/server needed) — e.g. send_command output filters
+test-shell:
+	@echo "Running shell tests..."
+	@./dev/test/send_command_filter_test.sh
+
 # Run behavioral tests (slow, requires game server)
 test-behavioral:
 	@echo "Running behavioral tests (slow, ~30s per test)..."
@@ -69,7 +74,7 @@ watch-runner:
 	@./dev/watch_game.sh runner
 
 # Combo: check + test (pre-commit quality gate)
-verify: check test
+verify: check test test-shell
 	@echo "✅ All checks passed"
 
 # AOT compile stable dependencies (one-time, speeds up cold start check)

--- a/dev/MARQUEE_RUNBOOK.md
+++ b/dev/MARQUEE_RUNBOOK.md
@@ -54,13 +54,15 @@ Both model strings are valid: `gpt-5.5`, `claude-opus-4.8`.
 4. **Spawn the Runner seat** (GPT-5.5) — run in background via Bash:
    ```bash
    DEVIN_PERMISSION_MODE=dangerous devin -p --model gpt-5.5 \
-     --prompt-file dev/seat-runner-devin.md
+     --prompt-file dev/seat-runner-devin.md > logs/marquee-runner-devin.log 2>&1
    ```
    `DEVIN_PERMISSION_MODE=dangerous` is REQUIRED (no human to approve tool calls;
    without it the seat hangs on the first `send_command`). devin runs in repo cwd,
    so it gets `send_command` + the local server for free. **devin output BUFFERS to
    process end** — you won't see incremental output; rely on the game log/watcher
-   for live state.
+   for live state. Capture the buffered output to a file so the Runner's final
+   report survives — use repo-root `logs/` (it exists; `dev/logs/` does NOT, a
+   redirect there fails).
 
 ## Monitor (read-only, fog-of-war intact)
 - NEVER peek into either seat's hidden info; only read the shared log / public state.

--- a/dev/send_command
+++ b/dev/send_command
@@ -516,12 +516,19 @@ execute() {
         fi
     else
         # Suppress all status map noise - we print human-readable messages instead.
-        # Two shapes leak as the REPL's return value: maps that LEAD with :status
-        # (success/error/waiting), and run-decision maps that lead with another key
-        # (e.g. {:wake-reason ... :status :fire-decision-required ...} from
-        # monitor-run rez/tank windows). Strip any single-line EDN map carrying a
-        # :status key in any position. Human output never starts with "{".
-        echo "$RESULT" | grep -vE '^\{[^}]*:status[ ,}]' | grep -v '^nil$' || true
+        # The REPL return value leaks in several shapes: maps that LEAD with :status
+        # (success/error/waiting), run-decision maps that lead with another key
+        # (e.g. {:wake-reason ... :status :fire-decision-required ...}), and
+        # decision maps whose :status sits AFTER a NESTED map, e.g.
+        # {:wake-reason :rez-ice, :prompt {:msg "..." :eid {:eid 124099}}, :status :decision-required ...}.
+        # The old `[^}]*` stopped at the nested map's first "}" and let that last
+        # shape leak (caught live in cross-model marquee g1). Match `.*` instead so
+        # a :status anywhere on the line is stripped. Player-facing command output
+        # never starts with "{" (we print human text), so this only ever hits the
+        # REPL's machine map. Caveat: `eval` of a raw single-line map that carries
+        # a :status key is also suppressed here — an accepted tradeoff for the dev
+        # escape hatch (use a wrapping form if you must see such a map verbatim).
+        echo "$RESULT" | grep -vE '^\{.*:status[ ,}]' | grep -v '^nil$' || true
     fi
 
     return $RET

--- a/dev/test/send_command_filter_test.sh
+++ b/dev/test/send_command_filter_test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# send_command_filter_test.sh — regression guard for the EDN-tail noise filter.
+#
+# Why this exists: dev/send_command strips the REPL's machine return-map from
+# user-facing output (we print human-readable messages instead). This filter has
+# regressed twice via too-narrow regexes:
+#   - the original only matched maps LEADING with :status   (PR before #34)
+#   - #34's `^\{[^}]*:status` stopped at the first nested "}", so a decision map
+#     whose :status sits AFTER a nested map (e.g. {:prompt {:eid {...}} :status …})
+#     LEAKED — caught live in the cross-model marquee (forum ai-netrunner [125]).
+# Each regression shipped because there was no committed test. This is that test.
+#
+# It runs the captured real-world cases through the ACTUAL regex extracted from
+# dev/send_command, so the test cannot silently drift from the source.
+#
+# Inputs are passed as function ARGUMENTS (not here-strings) so the test does not
+# depend on temp-file creation, and every assertion guards that its input is
+# non-empty — so a broken input path fails loudly instead of false-passing.
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SEND_CMD="$SCRIPT_DIR/../send_command"
+
+# Extract the live filter regex from send_command (the pattern inside grep -vE '...').
+PATTERN=$(grep -oE "grep -vE '\^\\\\\{[^']*'" "$SEND_CMD" | head -1 | sed -E "s/^grep -vE '//; s/'$//")
+if [[ -z "$PATTERN" ]]; then
+    echo "FAIL: could not extract EDN filter regex from $SEND_CMD" >&2
+    exit 1
+fi
+echo "Using live filter regex from send_command: $PATTERN"
+
+# Apply the real filter exactly as send_command does. Input arrives on stdin.
+filt() { grep -vE "$PATTERN" | grep -v '^nil$' || true; }
+
+fails=0
+# assert_empty NAME INPUT  → filter must strip everything to empty
+assert_empty() {
+    local name="$1" input="$2" out
+    if [[ -z "$input" ]]; then echo "FAIL [$name]: test input was empty (broken setup)"; fails=$((fails+1)); return; fi
+    out=$(printf '%s\n' "$input" | filt)
+    if [[ -n "$out" ]]; then
+        echo "FAIL [$name]: expected STRIP, but leaked:"; printf '%s\n' "$out" | sed 's/^/    /'
+        fails=$((fails+1))
+    else
+        echo "ok   [$name] stripped"
+    fi
+}
+# assert_keeps NAME WANT INPUT → filter must preserve exactly WANT non-empty lines
+assert_keeps() {
+    local name="$1" want="$2" input="$3" out got
+    if [[ -z "$input" ]]; then echo "FAIL [$name]: test input was empty (broken setup)"; fails=$((fails+1)); return; fi
+    out=$(printf '%s\n' "$input" | filt); got=$(printf '%s\n' "$out" | grep -c . || true)
+    if [[ "$got" != "$want" ]]; then
+        echo "FAIL [$name]: expected $want preserved line(s), got $got:"; printf '%s\n' "$out" | sed 's/^/    /'
+        fails=$((fails+1))
+    else
+        echo "ok   [$name] preserved $got line(s)"
+    fi
+}
+
+# --- machine maps: must be stripped ---
+assert_empty "nested-map-before-status (#34 regression)" '{:wake-reason :rez-ice, :cursor 153, :prompt {:msg "x", :eid {:eid 124099}}, :status :decision-required, :ice "Tithe"}'
+assert_empty "leading-status"        '{:status :success}'
+assert_empty "flat-wakereason-status" '{:wake-reason :decision-required, :cursor 12, :status :fire-decision-required}'
+assert_empty "nil"                   'nil'
+
+# --- human output and non-status maps: must be preserved ---
+assert_keeps "human-decision-block" 3 $'Rez decision: Palisade\n   continue --rez "Palisade"  - rez it\n   continue --no-rez      - decline'
+assert_keeps "emoji-human-line"     1 '⏸️  Waiting for corp rez decision'
+assert_keeps "edn-map-without-status" 1 '{:server ["remote2"], :position 3, :phase "encounter-ice"}'
+
+echo "---"
+if [[ "$fails" -ne 0 ]]; then
+    echo "send_command_filter_test: $fails FAILED"; exit 1
+fi
+echo "send_command_filter_test: ALL PASSED"


### PR DESCRIPTION
## What
Follow-up to #34. The `^\{[^}]*:status` filter still leaked decision maps whose `:status` sits **after** a nested map — `[^}]*` stops at the nested map's first `}`:

\`\`\`
{:wake-reason :rez-ice, :prompt {:msg "..." :eid {:eid 124099}}, :status :decision-required ...}
\`\`\`

Caught **live in cross-model marquee Game 1** (Opus Corp seat): every rez-decision wake dumped this raw map under the human-readable block — exactly the transcript pollution #34 set out to kill. Fix: `[^}]*` → `.*`.

## Why a test now
#34 shipped with no committed test and regressed this same cycle. Added `dev/test/send_command_filter_test.sh`, which **extracts the live regex from `send_command`** (can't drift from source) and runs the captured leak shapes + human-output-preservation cases. Wired into `make test-shell` and `make verify`. Verified **red on the #34 regex, green on the fix**.

## Review (REVIEW_SOP)
Codex (GPT-5.5) read-only review, both findings addressed:
- test hardened to pass inputs as args (no here-strings/temp files) + guard non-empty input so a broken setup fails loudly rather than false-passing;
- `send_command` comment softened re: the accepted `eval` over-strip (a raw single-line `:status` map via the dev `eval` escape hatch is also suppressed — consistent with the existing filter tradeoff).

## Also
`MARQUEE_RUNBOOK.md` devin-spawn redirect now uses repo-root `logs/` (`dev/logs/` doesn't exist) so the Runner's buffered report survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)