### PR TITLE
polish: send_command rough edges from marquee pair (#37 #38 #39 #40)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 	@echo "  make check         - Quick AI code compile check"
 	@echo "                       (~1s with REPL+bb, ~30s cold start)"
 	@echo "  make test          - Run unit tests (~2s)"
-	@echo "  make verify        - check + test"
+	@echo "  make verify        - check + test + test-shell"
 	@echo ""
 	@echo "  make reset         - Fresh game (bounce REPLs, new game)"
 	@echo "  make resume        - Reload code, keep game state"
@@ -40,6 +40,7 @@ test:
 test-shell:
 	@echo "Running shell tests..."
 	@./dev/test/send_command_filter_test.sh
+	@./dev/test/ai_eval_charset_test.sh
 
 # Run behavioral tests (slow, requires game server)
 test-behavioral:
@@ -73,7 +74,7 @@ watch-corp:
 watch-runner:
 	@./dev/watch_game.sh runner
 
-# Combo: check + test (pre-commit quality gate)
+# Combo: check + test + test-shell (pre-commit quality gate)
 verify: check test test-shell
 	@echo "✅ All checks passed"
 

--- a/dev/ai-eval.sh
+++ b/dev/ai-eval.sh
@@ -60,12 +60,18 @@ if command -v bb &> /dev/null; then
     trap "rm -f '$EXPR_FILE'" EXIT
 
     bb -e "(require '[bencode.core :as b] '[clojure.java.io :as io])
+          ;; Pin UTF-8 for BOTH the slurp of our code (which may carry accented
+          ;; card names like \"Karunā\") and the decode of the nREPL response.
+          ;; Under a C locale a JVM default charset mis-decodes multibyte chars
+          ;; into replacement chars, so the card lookup sees \"Karun\" + garbage
+          ;; and fails (issue #37). bb itself defaults to UTF-8, but pinning makes
+          ;; this robust regardless of host charset.
           (let [expr-file \"$EXPR_FILE\"
-                expr-code (slurp expr-file)]
+                expr-code (slurp expr-file :encoding \"UTF-8\")]
             (with-open [sock (java.net.Socket. \"localhost\" $REPL_PORT)]
               (let [in (java.io.PushbackInputStream. (io/input-stream sock))
                     out (io/output-stream sock)
-                    bytes->str #(when % (String. (bytes %)))
+                    bytes->str #(when % (String. (bytes %) \"UTF-8\"))
                     result-value (atom nil)]
                 (b/write-bencode out {\"op\" \"eval\" \"code\" expr-code})
               (.flush out)
@@ -105,7 +111,11 @@ if command -v bb &> /dev/null; then
                         (System/exit 1)))
                     (catch Exception _ nil))))))"
 else
-    # Fallback to lein repl :connect (slower, for compatibility)
+    # Fallback to lein repl :connect (slower, for compatibility). Unlike bb, this
+    # is a stock JVM that honors file.encoding — under a C locale it defaults to a
+    # non-UTF-8 charset and mangles accented card names piped on stdin (issue #37).
+    # Pin UTF-8 so multibyte input/output survives this path too.
+    export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS:-} -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8"
     timeout "$TIMEOUT" lein repl :connect localhost:$REPL_PORT <<EOF 2>&1 | \
         grep -v "^user=>" | \
         grep -v "find-doc" | \

--- a/dev/src/clj/ai_display.clj
+++ b/dev/src/clj/ai_display.clj
@@ -375,16 +375,21 @@
    The engine :ices vector is ordered innermost-first: index 0 is closest to the
    server (encountered LAST), the highest index is outermost (encountered FIRST).
    This is the reverse of the obvious low-to-high reading order, which silently
-   inverted run-budget planning (issue #39). We surface the encounter ordinal so
-   the static board view matches the run-time 'position N' prompt.
+   inverted run-budget planning (issue #39).
+
+   We also surface the run-time :position the Runner will see in the encounter
+   prompt. That position is 1-based (current-run-ice maps position->ice[pos-1]),
+   so it is `idx + 1` — NOT the 0-based board `#idx`. Spelling out 'position N/M'
+   bridges the two numberings so the board and the run prompt agree.
 
    `idx` is the engine index of the ICE; `total` is the ICE count on the server."
   [idx total]
-  (cond
-    (<= total 1) ""  ;; only ICE on the server: no ordering ambiguity
-    (= idx (dec total)) " ⟵ outermost — Runner encounters this 1st"
-    (= idx 0) " ⟵ innermost — encountered last (guards server)"
-    :else (str " ⟵ encountered #" (- total idx) " of " total)))
+  (let [pos (inc idx)]  ;; run prompt shows 1-based :position (idx+1)
+    (cond
+      (<= total 1) ""  ;; only ICE on the server: no ordering ambiguity
+      (= idx (dec total)) (format " ⟵ outermost — Runner encounters this 1st (run prompt: position %d/%d)" pos total)
+      (= idx 0) (format " ⟵ innermost — encountered last, guards server (position %d/%d)" pos total)
+      :else (format " ⟵ encounter #%d of %d (position %d/%d)" (- total idx) total pos total))))
 
 (defn show-board
   "Display full game board: all servers with ICE, Corp installed cards, Runner rig"
@@ -414,7 +419,8 @@
 
           ;; Show ICE — listed in Runner encounter order (outermost first), which
           ;; is the REVERSE of the engine :ices vector. The #idx label keeps the
-          ;; engine index so it matches the run-time "position N" prompt. (issue #39)
+          ;; 0-based engine index; the annotation spells out the 1-based run-time
+          ;; "position N/M" (idx+1) so the board and the run prompt agree. (#39)
           (if (seq ice-list)
             (let [ice-total (count ice-list)]
               (when (> ice-total 1)
@@ -1139,18 +1145,24 @@
         (when-let [card (:card prompt)]
           (println (str "  Card: " (:title card)
                         (when (:type card) (str " (" (:type card) ")")))))
-        ;; When BOTH a Choices and a Selectable block are present (e.g. Mutual
-        ;; Favor), name the verb each block uses so the player doesn't reach for
-        ;; the wrong one: `choose <N>` for Choices, `choose-card <N>` for
-        ;; Selectable. (issue #40)
-        (when (and has-choices has-selectable)
-          (println "  ⚠️  This prompt has TWO selectors — pick the right verb:")
-          (println "     • Choices block below → use `choose <N>`")
-          (println "     • Selectable cards block → use `choose-card <N>`"))
-        (when has-choices
-          (println (str "  Choices:" (when has-selectable "  (use `choose <N>`)")))
-          (doseq [[idx choice] (map-indexed vector (:choices prompt))]
-            (println (str "    " idx ". " (core/format-choice choice)))))
+        ;; When BOTH a Choices and a Selectable block are present, name the verb
+        ;; each block uses so the player doesn't reach for the wrong one. The
+        ;; Choices verb DEPENDS ON prompt type: on a "select" prompt the :choices
+        ;; are meta-buttons (e.g. Done) and `choose-option!` REJECTS `choose <N>`
+        ;; there — they're pressed by name via `choose-value`. Only a non-select
+        ;; prompt (e.g. Mutual Favor's "other") takes `choose <N>`. (issue #40,
+        ;; codex review of PR #41)
+        (let [choices-verb (if (state/select-prompt-type? (:prompt-type prompt))
+                             "`choose-value \"<label>\"`"
+                             "`choose <N>`")]
+          (when (and has-choices has-selectable)
+            (println "  ⚠️  This prompt has TWO selectors — pick the right verb:")
+            (println (str "     • Choices block below → use " choices-verb))
+            (println "     • Selectable cards block → use `choose-card <N>`"))
+          (when has-choices
+            (println (str "  Choices:" (when has-selectable (str "  (use " choices-verb ")"))))
+            (doseq [[idx choice] (map-indexed vector (:choices prompt))]
+              (println (str "    " idx ". " (core/format-choice choice))))))
         (when has-selectable
           (let [selectable (:selectable prompt)
                 prompt-msg (or (:msg prompt) "")

--- a/dev/src/clj/ai_display.clj
+++ b/dev/src/clj/ai_display.clj
@@ -1139,8 +1139,16 @@
         (when-let [card (:card prompt)]
           (println (str "  Card: " (:title card)
                         (when (:type card) (str " (" (:type card) ")")))))
+        ;; When BOTH a Choices and a Selectable block are present (e.g. Mutual
+        ;; Favor), name the verb each block uses so the player doesn't reach for
+        ;; the wrong one: `choose <N>` for Choices, `choose-card <N>` for
+        ;; Selectable. (issue #40)
+        (when (and has-choices has-selectable)
+          (println "  ⚠️  This prompt has TWO selectors — pick the right verb:")
+          (println "     • Choices block below → use `choose <N>`")
+          (println "     • Selectable cards block → use `choose-card <N>`"))
         (when has-choices
-          (println "  Choices:")
+          (println (str "  Choices:" (when has-selectable "  (use `choose <N>`)")))
           (doseq [[idx choice] (map-indexed vector (:choices prompt))]
             (println (str "    " idx ". " (core/format-choice choice)))))
         (when has-selectable

--- a/dev/src/clj/ai_display.clj
+++ b/dev/src/clj/ai_display.clj
@@ -369,6 +369,23 @@
                            (or whose-turn "?")
                            (if (some? clicks) clicks "?"))))))))
 
+(defn ice-encounter-label
+  "Annotation describing WHEN the Runner encounters this ICE during a run.
+
+   The engine :ices vector is ordered innermost-first: index 0 is closest to the
+   server (encountered LAST), the highest index is outermost (encountered FIRST).
+   This is the reverse of the obvious low-to-high reading order, which silently
+   inverted run-budget planning (issue #39). We surface the encounter ordinal so
+   the static board view matches the run-time 'position N' prompt.
+
+   `idx` is the engine index of the ICE; `total` is the ICE count on the server."
+  [idx total]
+  (cond
+    (<= total 1) ""  ;; only ICE on the server: no ordering ambiguity
+    (= idx (dec total)) " ⟵ outermost — Runner encounters this 1st"
+    (= idx 0) " ⟵ innermost — encountered last (guards server)"
+    :else (str " ⟵ encountered #" (- total idx) " of " total)))
+
 (defn show-board
   "Display full game board: all servers with ICE, Corp installed cards, Runner rig"
   []
@@ -395,27 +412,33 @@
         (when (or (seq ice-list) (seq content-list))
           (println (str "\n📍 " (clojure.string/upper-case server-name)))
 
-          ;; Show ICE
+          ;; Show ICE — listed in Runner encounter order (outermost first), which
+          ;; is the REVERSE of the engine :ices vector. The #idx label keeps the
+          ;; engine index so it matches the run-time "position N" prompt. (issue #39)
           (if (seq ice-list)
-            (doseq [[idx ice] (map-indexed vector ice-list)]
-              (let [rezzed (:rezzed ice)
-                    title (core/format-card-name-with-index ice ice-list)
-                    subtypes (:subtypes ice)
-                    subtype-str (if (seq subtypes)
-                                  (clojure.string/join " " (map name subtypes))
-                                  "?")
-                    strength (:current-strength ice)
-                    status-icon (if rezzed "🔴" "⚪")
-                    ;; Corp sees their own unrezzed ICE, Runner sees "Unrezzed ICE"
-                    display-name (cond
-                                   rezzed title
-                                   is-corp? (str title " [unrezzed]")
-                                   :else "Unrezzed ICE")]
-                (println (str "  ICE #" idx ": " status-icon " "
-                             display-name
-                             (when rezzed (str " (" subtype-str ")"))
-                             (when (and rezzed strength) (str " (str: " strength ")"))
-                             (format-counters ice)))))
+            (let [ice-total (count ice-list)]
+              (when (> ice-total 1)
+                (println "  (top→bottom = Runner encounter order: outermost first)"))
+              (doseq [[idx ice] (reverse (map-indexed vector ice-list))]
+                (let [rezzed (:rezzed ice)
+                      title (core/format-card-name-with-index ice ice-list)
+                      subtypes (:subtypes ice)
+                      subtype-str (if (seq subtypes)
+                                    (clojure.string/join " " (map name subtypes))
+                                    "?")
+                      strength (:current-strength ice)
+                      status-icon (if rezzed "🔴" "⚪")
+                      ;; Corp sees their own unrezzed ICE, Runner sees "Unrezzed ICE"
+                      display-name (cond
+                                     rezzed title
+                                     is-corp? (str title " [unrezzed]")
+                                     :else "Unrezzed ICE")]
+                  (println (str "  ICE #" idx ": " status-icon " "
+                               display-name
+                               (when rezzed (str " (" subtype-str ")"))
+                               (when (and rezzed strength) (str " (str: " strength ")"))
+                               (format-counters ice)
+                               (ice-encounter-label idx ice-total))))))
             (println "  (No ICE)"))
 
           ;; Show Content (assets/agendas)

--- a/dev/src/clj/ai_display.clj
+++ b/dev/src/clj/ai_display.clj
@@ -1226,11 +1226,22 @@
                       (when (= run-phase "approach-ice")
                         (println "    → This is the ICE rez window: continue --rez <ice> to rez, or --no-rez to decline.")))
                     (println "    → Use 'continue' to pass priority (advance the run)."))))
-              ;; Not in a run
-              (do
-                (println "  Action: Paid ability window")
-                (println "    → No choices required")
-                (println "    → Use 'continue' command to pass priority"))))))
+              ;; Not in a run. `continue` is RUN-ONLY (errors "No active run to
+              ;; monitor") — never advertise it here. A "waiting" prompt means the
+              ;; opponent is deciding (e.g. Wildcat Strike); the player takes no
+              ;; pass action and other actions may still be available. (issue #38)
+              (let [waiting? (state/waiting-prompt-type? (:prompt-type prompt))
+                    opp (if (= my-side "runner") "Corp" "Runner")]
+                (if waiting?
+                  (do
+                    (println (str "  Action: Waiting on " opp " — no action required from you."))
+                    (println (str "    → Other actions may still be available; use 'wait' to block until "
+                                  opp " decides."))
+                    (println "    → ('continue' is run-only and won't help here.)"))
+                  (do
+                    (println "  Action: Paid ability window (no run active)")
+                    (println "    → No choices required.")
+                    (println "    → 'continue' is run-only here — take your next action, or 'wait'."))))))))
       ;; No prompt object. "No active prompt" alone is technically true but
       ;; misleads at a turn boundary (a reader concludes the game isn't waiting on
       ;; them when it's actually their turn to start). Append the turn-aware next

--- a/dev/src/clj/ai_prompts.clj
+++ b/dev/src/clj/ai_prompts.clj
@@ -241,20 +241,43 @@
                    (core/find-card-by-cid cid-or-card)
                    cid-or-card)]
         (if card
-          (do
-            (println (format "📇 Selecting card: %s (index %d)" (:title card) index))
+          ;; Don't claim success before the prompt confirms registration: print
+          ;; the confirmation only AFTER the prompt moves. A non-select prompt
+          ;; that doesn't move means choose-card was the WRONG verb (the engine
+          ;; wanted a text choice) — error + steer to `choose`, instead of the
+          ;; old "📇 Selecting card …" + spurious :success on a stall. (issue #40)
+          (let [select? (state/select-prompt-type? (:prompt-type prompt))]
             (ws/select-card! card eid)
-            ;; Wait for prompt to change instead of fixed sleep. Gate the
-            ;; auto-end-turn hook on the prompt ACTUALLY moving: a partial
-            ;; multi-select (e.g. discard-to-N) leaves the prompt put while the
-            ;; server toggles toward :max — nothing resolved — so firing the hook
-            ;; would print a spurious "⚠️ Cannot auto-end turn: resolve the prompt"
-            ;; whose "use 'choose'" tip contradicts the `multi-choose` steer
-            ;; printed just above. When unchanged the prompt is still blocking, so
-            ;; auto-end could never fire anyway — gating loses nothing. (#18 tail)
-            (when (wait-for-prompt-change! eid)
-              (maybe-auto-end-turn-after-prompt!))
-            (core/with-cursor {:status :success :card card}))
+            (cond
+              ;; Prompt moved → selection registered and resolved. Only here is it
+              ;; safe to run the auto-end-turn hook (a partial multi-select leaves
+              ;; the prompt put — see the select? branch). (#18 tail)
+              (wait-for-prompt-change! eid)
+              (do
+                (println (format "📇 Selected card: %s (index %d)" (:title card) index))
+                (maybe-auto-end-turn-after-prompt!)
+                (core/with-cursor {:status :success :card card}))
+
+              ;; Unchanged but a genuine multi-select toggle (discard-to-N): the
+              ;; server accumulates selections to :max and only then resolves.
+              ;; wait-for-prompt-change! already printed the multi-choose tip.
+              select?
+              (do
+                (println (format "📇 Toggled card: %s (index %d) — more selections needed"
+                                (:title card) index))
+                (core/with-cursor {:status :success :card card}))
+
+              ;; Unchanged on a NON-select prompt: choose-card is the wrong verb
+              ;; here (this prompt resolves by text choice). (issue #40)
+              :else
+              (do
+                (println (format "↪️  choose-card %d did not register — this prompt isn't a card-select."
+                                index))
+                (if (seq (:choices prompt))
+                  (println "   → It's a numbered CHOICE prompt. Use:  choose <N>")
+                  (println "   → Use 'prompt' to inspect, then choose / choose-value."))
+                (core/with-cursor {:status :error
+                                   :reason "Not a card-select prompt — use choose"}))))
           (let [{:keys [pickable]} (core/resolve-selectable selectable)
                 pickable-idxs (map :idx pickable)]
             (println (format "❌ Index %d isn't a card you can select — it's hidden/opponent (not in your view)." index))

--- a/dev/test/ai_display_test.clj
+++ b/dev/test/ai_display_test.clj
@@ -762,3 +762,32 @@
             (str "Choices block must name the `choose <N>` verb when selectable also present:\n" out))
         (is (str/includes? out "choose-card")
             (str "Selectable block keeps its choose-card verb:\n" out))))))
+
+;; ============================================================================
+;; Non-run paid-ability / waiting prompt — don't advertise run-only `continue`
+;; (issue #38)
+;; ============================================================================
+;; After Wildcat Strike (a non-run paid-ability window), the prompt said
+;; "Use 'continue' command to pass priority" — but `continue` is run-only and
+;; errors "No active run to monitor". And "Waiting for Corp to make a decision"
+;; read as a hard block though Runner actions still worked.
+
+(deftest show-prompt-detailed-non-run-waiting-does-not-advertise-continue
+  (testing "a non-run waiting prompt steers to wait, not the run-only `continue` (#38)"
+    (with-mock-state
+      (mock-client-state
+       :side "runner"
+       :game-state {:active-player "runner" :turn 6
+                    :runner {:hand []
+                             :prompt-state {:prompt-type "waiting"
+                                            :eid "wc-1"
+                                            :msg "Waiting for Corp to make a decision"
+                                            :card {:title "Wildcat Strike"}}}
+                    :corp {:hand []}})
+      (let [out (with-out-str (display/show-prompt-detailed))]
+        (is (not (str/includes? out "Use 'continue' command to pass priority"))
+            (str "must NOT advertise run-only `continue` in a non-run window:\n" out))
+        (is (str/includes? out "Corp")
+            (str "should name the opponent we're waiting on:\n" out))
+        (is (or (str/includes? out "wait") (str/includes? out "Other actions"))
+            (str "should tell the player they can wait / still have actions:\n" out))))))

--- a/dev/test/ai_display_test.clj
+++ b/dev/test/ai_display_test.clj
@@ -731,3 +731,34 @@
             "Palisade keeps engine index #0 (innermost = position 0)")
         (is (str/includes? (nth lines karuna-idx) "outermost"))
         (is (str/includes? (nth lines palisade-idx) "innermost"))))))
+
+;; ============================================================================
+;; Prompt with BOTH Choices and Selectable blocks — label which verb (issue #40)
+;; ============================================================================
+;; Mutual Favor showed a Choices: block AND a Selectable cards: block with no
+;; signal which selector applied; both seats reached for the wrong verb. When
+;; both blocks are present the display must say `choose <N>` belongs to Choices
+;; and `choose-card <N>` belongs to Selectable.
+
+(deftest show-prompt-detailed-disambiguates-both-blocks
+  (testing "a prompt with both Choices and Selectable labels each block's verb"
+    (with-mock-state
+      (mock-client-state
+       :side "runner"
+       :game-state {:active-player "runner" :turn 5
+                    :runner {:hand []
+                             :prompt-state {:prompt-type "other"
+                                            :eid "mf-1"
+                                            :msg "Choose an Icebreaker"
+                                            :choices [{:value "Unity"} {:value "Cleaver"}]
+                                            :selectable [{:cid "c1" :title "Unity"}
+                                                         {:cid "c2" :title "Cleaver"}]}}
+                    :corp {:hand []}})
+      (let [out (with-out-str (display/show-prompt-detailed))
+            lines (str/split-lines out)
+            choices-line (first (filter #(str/includes? % "Choices:") lines))]
+        (is choices-line "renders a Choices header")
+        (is (str/includes? choices-line "choose <N>")
+            (str "Choices block must name the `choose <N>` verb when selectable also present:\n" out))
+        (is (str/includes? out "choose-card")
+            (str "Selectable block keeps its choose-card verb:\n" out))))))

--- a/dev/test/ai_display_test.clj
+++ b/dev/test/ai_display_test.clj
@@ -694,17 +694,24 @@
 (deftest ice-encounter-label-marks-ends
   (testing "single ICE has no ordering ambiguity"
     (is (= "" (display/ice-encounter-label 0 1))))
-  (testing "outermost (highest index) is encountered first"
+  (testing "outermost (highest index) is encountered first, with its 1-based run position"
     (let [lbl (display/ice-encounter-label 1 2)]
       (is (str/includes? lbl "outermost"))
-      (is (str/includes? lbl "1st"))))
+      (is (str/includes? lbl "1st"))
+      ;; run prompt is 1-based: outermost of 2 = position 2/2 (idx+1), NOT #1
+      (is (str/includes? lbl "position 2/2")
+          (str "outermost must show the run-time 1-based position 2/2: " lbl))))
   (testing "innermost (index 0) is encountered last and guards the server"
     (let [lbl (display/ice-encounter-label 0 2)]
       (is (str/includes? lbl "innermost"))
-      (is (str/includes? lbl "last"))))
-  (testing "middle ICE gets its encounter ordinal (outermost-first counting)"
-    ;; 3 ICE: idx2=1st, idx1=2nd, idx0=3rd/last
-    (is (str/includes? (display/ice-encounter-label 1 3) "2"))))
+      (is (str/includes? lbl "last"))
+      (is (str/includes? lbl "position 1/2")
+          (str "innermost = run-time position 1/2 (idx+1): " lbl))))
+  (testing "middle ICE gets its encounter ordinal and 1-based position"
+    ;; 3 ICE: idx2=1st, idx1=2nd, idx0=3rd/last; idx1 run position = 2/3
+    (let [lbl (display/ice-encounter-label 1 3)]
+      (is (str/includes? lbl "2"))
+      (is (str/includes? lbl "position 2/3")))))
 
 (deftest show-board-lists-ice-in-encounter-order
   (testing "board renders outermost ICE first and annotates encounter order"
@@ -762,6 +769,35 @@
             (str "Choices block must name the `choose <N>` verb when selectable also present:\n" out))
         (is (str/includes? out "choose-card")
             (str "Selectable block keeps its choose-card verb:\n" out))))))
+
+(deftest show-prompt-detailed-select-both-blocks-uses-choose-value
+  ;; Codex review of PR #41: on a "select"-typed prompt the :choices are
+  ;; meta-buttons (e.g. Done) and `choose-option!` REJECTS `choose <N>` there,
+  ;; demanding `choose-value "<label>"`. The both-blocks help must NOT tell the
+  ;; player to use `choose <N>` for a select prompt's Choices block.
+  (testing "select prompt with both blocks steers Choices to choose-value, not choose <N>"
+    (with-mock-state
+      (mock-client-state
+       :side "corp"
+       :game-state {:active-player "corp" :turn 5
+                    :corp {:hand []
+                           :prompt-state {:prompt-type "select"
+                                          :eid "sel-1"
+                                          :msg "Select cards to trash"
+                                          :choices [{:value "Done"}]
+                                          :selectable [{:cid "c1" :title "Hedge Fund"}
+                                                       {:cid "c2" :title "IPO"}]}}
+                    :runner {:hand []}})
+      (let [out (with-out-str (display/show-prompt-detailed))
+            lines (str/split-lines out)
+            choices-line (first (filter #(str/includes? % "Choices:") lines))]
+        (is choices-line "renders a Choices header")
+        (is (str/includes? out "choose-value")
+            (str "select-prompt Choices/meta block must steer to choose-value:\n" out))
+        (is (not (str/includes? choices-line "choose <N>"))
+            (str "must NOT advertise `choose <N>` for a select prompt's Choices block:\n" out))
+        (is (str/includes? out "choose-card")
+            (str "selectable cards still use choose-card:\n" out))))))
 
 ;; ============================================================================
 ;; Non-run paid-ability / waiting prompt — don't advertise run-only `continue`

--- a/dev/test/ai_display_test.clj
+++ b/dev/test/ai_display_test.clj
@@ -681,3 +681,53 @@
   (testing "absent/unrecognised phase yields nil (caller falls back to bare line)"
     (is (nil? (display/run-phase-ladder-lines {:phase nil :server-name "R&D"})))
     (is (nil? (display/run-phase-ladder-lines {:phase "bogus" :server-name "R&D"})))))
+
+;; ============================================================================
+;; Board ICE encounter order (issue #39)
+;; ============================================================================
+;; The :ices vector is engine order: index 0 = innermost (closest to server,
+;; encountered LAST), highest index = outermost (encountered FIRST). The board
+;; used to list them low-index-first, so the line you read first was the ICE the
+;; Runner meets last — inverting run-budget planning. The board must read in
+;; Runner encounter order and label outermost/innermost.
+
+(deftest ice-encounter-label-marks-ends
+  (testing "single ICE has no ordering ambiguity"
+    (is (= "" (display/ice-encounter-label 0 1))))
+  (testing "outermost (highest index) is encountered first"
+    (let [lbl (display/ice-encounter-label 1 2)]
+      (is (str/includes? lbl "outermost"))
+      (is (str/includes? lbl "1st"))))
+  (testing "innermost (index 0) is encountered last and guards the server"
+    (let [lbl (display/ice-encounter-label 0 2)]
+      (is (str/includes? lbl "innermost"))
+      (is (str/includes? lbl "last"))))
+  (testing "middle ICE gets its encounter ordinal (outermost-first counting)"
+    ;; 3 ICE: idx2=1st, idx1=2nd, idx0=3rd/last
+    (is (str/includes? (display/ice-encounter-label 1 3) "2"))))
+
+(deftest show-board-lists-ice-in-encounter-order
+  (testing "board renders outermost ICE first and annotates encounter order"
+    (with-mock-state
+      (mock-client-state
+       :side "runner"
+       :game-state {:active-player "runner" :turn 12
+                    :corp {:servers {:remote1
+                                     {:ices [{:title "Palisade" :rezzed true :subtypes [:barrier]}
+                                             {:title "Karuna" :rezzed true :subtypes [:sentry]}]
+                                      :content [{:title "Project Atlas" :rezzed false}]}}}
+                    :runner {:rig {}}})
+      (let [out (with-out-str (display/show-board))
+            lines (str/split-lines out)
+            karuna-idx (first (keep-indexed (fn [i l] (when (str/includes? l "Karuna") i)) lines))
+            palisade-idx (first (keep-indexed (fn [i l] (when (str/includes? l "Palisade") i)) lines))]
+        (is (and karuna-idx palisade-idx) "both ICE lines render")
+        (is (< karuna-idx palisade-idx)
+            (str "outermost (Karuna, encountered 1st) must list ABOVE innermost (Palisade):\n" out))
+        ;; #idx must still equal engine position (runtime prompt shows "position N")
+        (is (str/includes? (nth lines karuna-idx) "#1")
+            "Karuna keeps engine index #1 (outermost = position 1)")
+        (is (str/includes? (nth lines palisade-idx) "#0")
+            "Palisade keeps engine index #0 (innermost = position 0)")
+        (is (str/includes? (nth lines karuna-idx) "outermost"))
+        (is (str/includes? (nth lines palisade-idx) "innermost"))))))

--- a/dev/test/ai_eval_charset_test.sh
+++ b/dev/test/ai_eval_charset_test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# ai_eval_charset_test.sh — regression guard for UTF-8 handling in ai-eval.sh.
+#
+# Why this exists: card-text "Karunā" reported "Card not found: Karun" in the
+# cross-model marquee (issue #37). Under a C locale a JVM-default-charset decode
+# turns the 2-byte ā into replacement chars, so the card lookup sees "Karun" +
+# garbage and fails. ai-eval.sh sends our Clojure code and decodes the nREPL
+# response, so it must pin UTF-8 on BOTH legs regardless of host locale.
+#
+# Two checks:
+#   1. behavioral — round-trip a multibyte string through the SAME transport
+#      ai-eval.sh uses (slurp :encoding UTF-8 → bencode write → bencode read →
+#      String. … "UTF-8"); the accented name must survive byte-exact.
+#   2. source pin-guard — the explicit UTF-8 pins must still be present in
+#      ai-eval.sh, so the fix can't silently regress (the bug shipped twice in
+#      the sibling EDN filter precisely because nothing guarded the source).
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AI_EVAL="$SCRIPT_DIR/../ai-eval.sh"
+fails=0
+
+# --- 1. behavioral round-trip through the real bencode transport ------------
+if command -v bb >/dev/null 2>&1; then
+    EXPR_FILE=$(mktemp)
+    printf '%s' '(ai-actions/show-card-text "Karunā")' > "$EXPR_FILE"
+    trap "rm -f '$EXPR_FILE'" EXIT
+    roundtrip=$(bb -e "(require '[bencode.core :as b])
+      (let [code (slurp \"$EXPR_FILE\" :encoding \"UTF-8\")
+            baos (java.io.ByteArrayOutputStream.)]
+        (b/write-bencode baos {\"code\" code})
+        (let [arr (.toByteArray baos)
+              in (java.io.PushbackInputStream. (java.io.ByteArrayInputStream. arr))
+              decoded (b/read-bencode in)]
+          (print (String. ^bytes (get decoded \"code\") \"UTF-8\"))))" 2>/dev/null)
+    if [[ "$roundtrip" == '(ai-actions/show-card-text "Karunā")' ]]; then
+        echo "ok   [bencode-roundtrip] accented name survives slurp+bencode+decode"
+    else
+        echo "FAIL [bencode-roundtrip] expected the accented name intact, got: $roundtrip" >&2
+        fails=$((fails+1))
+    fi
+else
+    echo "skip [bencode-roundtrip] bb not on PATH"
+fi
+
+# --- 2. source pin-guard: explicit UTF-8 must be present in ai-eval.sh -------
+assert_pinned() {
+    local name="$1" pattern="$2"
+    if grep -qF -- "$pattern" "$AI_EVAL"; then
+        echo "ok   [$name] UTF-8 pin present"
+    else
+        echo "FAIL [$name] missing UTF-8 pin '$pattern' in ai-eval.sh (issue #37 would recur)" >&2
+        fails=$((fails+1))
+    fi
+}
+# bb path: slurp our code as UTF-8 and decode the response as UTF-8
+assert_pinned "bb-slurp-utf8"   'slurp expr-file :encoding \"UTF-8\"'
+assert_pinned "bb-decode-utf8"  '(String. (bytes %) \"UTF-8\")'
+# lein fallback: stock JVM honors file.encoding, so pin it
+assert_pinned "lein-file-encoding" '-Dfile.encoding=UTF-8'
+
+echo "---"
+if [[ "$fails" -ne 0 ]]; then
+    echo "ai_eval_charset_test: $fails FAILED"; exit 1
+fi
+echo "ai_eval_charset_test: ALL PASSED"

--- a/dev/test/ai_prompts_test.clj
+++ b/dev/test/ai_prompts_test.clj
@@ -216,6 +216,52 @@
               "a resolving select must still run the auto-end-turn check"))))))
 
 ;; ============================================================================
+;; choose-card! — both-blocks ambiguity & no premature success (issue #40)
+;;
+;; Mutual Favor's "Choose an Icebreaker" carried BOTH a :choices block AND
+;; :selectable cards. `choose-card <n>` printed "📇 Selecting card: X", fired
+;; select-card!, then TIMED OUT (the engine wanted a text choice) — but still
+;; returned :success, and the only right verb was `choose <n>`. Near game-losing
+;; on both seats. Fix: a non-select prompt that doesn't move after a select means
+;; choose-card was the wrong verb → error + steer to `choose`, and the
+;; confirmation prints only AFTER the prompt actually moves.
+;; ============================================================================
+
+(deftest choose-card-on-nonselect-stall-steers-to-choose
+  (testing "choose-card on a non-select prompt that doesn't move errors and steers to `choose` (#40)"
+    (with-mock-state (mock-client-state
+                      :side "runner"
+                      :prompt {:prompt-type "other" :eid "mf-1"
+                               :msg "Choose an Icebreaker"
+                               :choices [{:value "Unity"} {:value "Cleaver"}]
+                               :selectable [{:cid "c1" :title "Unity"}
+                                            {:cid "c2" :title "Cleaver"}]})
+      (with-redefs [ws/select-card! (fn [_card _eid] true)
+                    ;; engine wanted a text choice; the select never registered
+                    prompts/wait-for-prompt-change! (fn [_eid & _] false)]
+        (let [out (with-out-str
+                    (let [r (prompts/choose-card! 0)]
+                      (is (= :error (:status r))
+                          (str "non-select stall must report error, not success: " r))))]
+          (is (str/includes? out "choose <N>")
+              (str "must steer to `choose <N>`: " out))
+          (is (not (str/includes? out "📇 Selected"))
+              (str "must not claim it selected the card: " out)))))))
+
+(deftest choose-card-confirms-only-after-registration
+  (testing "choose-card prints the card confirmation only AFTER the prompt moves (#40)"
+    (with-mock-state (mock-client-state
+                      :side "runner" :prompt other-typed-card-select-prompt)
+      (with-redefs [ws/select-card! (fn [_card _eid] true)
+                    prompts/wait-for-prompt-change! (fn [_eid & _] true)
+                    basic/check-auto-end-turn! (fn [] nil)]
+        (let [out (with-out-str
+                    (let [r (prompts/choose-card! 1)]
+                      (is (= :success (:status r)))))]
+          (is (str/includes? out "Selected")
+              (str "confirms the selection after registration: " out)))))))
+
+;; ============================================================================
 ;; keep-hand / mulligan — opening-mulligan ergonomics (polish round 2026-06-22)
 ;;
 ;; Two related rough edges, both surfaced by playing a real game:


### PR DESCRIPTION
Autonomous polish round addressing four send_command rough edges surfaced by the cross-model marquee pair (GPT-5.5 vs Opus 4.8). Each was a documentation/tooling error that produced model-looking misplays — fixing them removes a class of false "model errors" from future writeups.

## Fixes

**#39 — board ICE encounter order.** The engine `:ices` vector is innermost-first (index 0 = closest to server = encountered LAST). The board listed ICE low-index-first, so the line you read first was the ICE the Runner meets last — silently inverting run-budget planning (Opus mis-budgeted a T12 run off this). Board now renders ICE in Runner encounter order (outermost first) with explicit outermost/innermost + encounter-ordinal annotation. `#idx` keeps the engine index so it still matches the run-time "position N" prompt. *(ai_display.clj — tested)*

**#40 — choose-card false success + both-blocks ambiguity.** On Mutual Favor's "Choose an Icebreaker" (a numbered-CHOICE prompt that also carried selectable cards), `choose-card <n>` printed "Selecting card: X", fired select-card!, timed out (engine wanted a text choice), yet still returned `:success`. The only working verb was `choose <n>`. Near game-losing on both seats. Now: confirmation prints only AFTER the prompt moves; a non-select prompt that doesn't move → `:error` + steer to `choose <N>` (select-type prompts that stay put are still the legit multi-select toggle, so discard-to-N is unbroken). Display also labels which verb each block uses when both are present. *(ai_prompts.clj + ai_display.clj — tested)*

**#38 — non-run paid-ability/waiting prompt advertised run-only `continue`.** After Wildcat Strike, the prompt said "Use 'continue' to pass priority", but continue errors "No active run to monitor". A waiting prompt also read as a hard block though actions remained. Now: waiting-type prompts name the opponent + point to `wait` (noting other actions may remain) and never advertise run-only `continue`. *(ai_display.clj — tested)*

**#37 — accented card names truncated in transport.** `card-text "Karunā"` → "Card not found: Karun": under a C locale a JVM-default-charset decode turns the 2-byte ā into replacement chars. bb (GraalVM) defaults to UTF-8 so it doesn't repro in the current path, but the lein fallback is a stock JVM that honors file.encoding. Defensive root-cause fix: pin UTF-8 on the bb slurp + response decode, and `-Dfile.encoding/-Dsun.jnu.encoding=UTF-8` for the lein fallback. Verified live. *(ai-eval.sh + shell regression guard)*

## Tests
- `make test`: 366 tests, 855 assertions, 0 failures (added unit tests for #38/#39/#40).
- `make test-shell`: new `ai_eval_charset_test.sh` (#37) — bencode round-trip + source pin-guard (goes red if the UTF-8 pin is removed).
- Also: merged updated `ai-player/main` (brings #35); fixed Codex's #35 nit (verify help text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Fixes #37
Fixes #38
Fixes #39
Fixes #40
