### PR TITLE
fix: monitor-run --persistent rides through its own rez/event statuses (#36)

### DIFF
--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -1012,8 +1012,10 @@
 ;;
 ;; The loop calls continue-run! repeatedly until:
 ;; - Run completes (:run-complete)
-;; - Real decision required (:decision-required)
+;; - Real decision required (:decision-required / :fire-decision-required)
 ;; - Notable event occurs (:ice-rezzed, :ability-used, :subs-fired, :tag-or-damage)
+;;   — EXCEPT in --persistent mode during an active run, where the loop's own
+;;   notable events are routine and it keeps owning the run (see #36 below)
 ;; - Max iterations reached (safety guard)
 ;; - Timeout reached
 ;;
@@ -1112,16 +1114,23 @@
            ;; its own per-tick stall tracker (which nudges/bails) instead of being
            ;; swallowed by up to ~100s of internal polling.
            return-on-runner-signal false
-           ;; When true (monitor-run --persistent), an empty opponent-priority
-           ;; window (:waiting-for-opponent family) during an ACTIVE run is NOT
-           ;; terminal — sleep persistent-wait-delay-ms and recheck, keeping the
-           ;; defender loop alive so a cross-model seat doesn't have to re-issue
-           ;; monitor-run through every symmetric priority pass. Real decisions
-           ;; (:decision-required / :fire-decision-required / rez/event statuses)
-           ;; are terminal-status? and return ABOVE this branch, so persistence
-           ;; only ever sleeps through genuinely-empty windows. Bounded by
-           ;; timeout-ms. The idle wait does not advance `iteration`, so it never
-           ;; trips the action-oriented max-iterations guard.
+           ;; When true (monitor-run --persistent), during an ACTIVE run two
+           ;; status families that are terminal for hand-driven monitor-run are
+           ;; NOT terminal here, keeping the defender loop alive so a cross-model
+           ;; seat doesn't have to re-issue monitor-run:
+           ;;   (a) empty opponent-priority windows (:waiting-for-opponent
+           ;;       family) — sleep persistent-wait-delay-ms and recheck (idle
+           ;;       wait; does NOT advance `iteration`, bounded by timeout-ms);
+           ;;   (b) the loop's own notable events (should-pause-for-event?:
+           ;;       :ice-rezzed / :ability-used / :subs-fired / :tag-or-damage) —
+           ;;       sleep quick-delay and recur, ADVANCING `iteration` so the
+           ;;       max-iterations backstop still bounds a degenerate event spin
+           ;;       (#36). Only genuine decisions (:decision-required /
+           ;;       :fire-decision-required) — which are NOT should-pause-for-
+           ;;       event? — plus run-end remain terminal under --persistent, so
+           ;;       it "wakes only for a real rez/fire/access decision or run
+           ;;       end". Both branches are below; the event branch returns ABOVE
+           ;;       terminal-status?.
            persistent false
            persistent-wait-delay-ms 1000}}]
   (let [start-time (System/currentTimeMillis)
@@ -1158,6 +1167,35 @@
               current-state-key (get-run-state-key)
               new-history (cons current-state-key (take (dec stuck-threshold) state-history))]
           (cond
+            ;; Persistent mode: a notable-but-routine event the loop produced
+            ;; itself (its own ICE rez, an ability/subs firing, tag/damage
+            ;; dealt) is NOT a decision — the seat delegated the whole run.
+            ;; These statuses are terminal-status? for hand-driven monitor-run
+            ;; (where pausing to show the user is the point), but in --persistent
+            ;; mode treating them as terminal DROPPED the defender loop after a
+            ;; rez commit (#36): the auto-rez returns :action-taken, then the
+            ;; next iteration sees "Corp rezzes X" in the log and handle-events
+            ;; returns :ice-rezzed → loop exits, leaving the Runner holding
+            ;; priority at a window the Corp is no longer watching (soft
+            ;; deadlock; the Runner could only recover by jacking out). The
+            ;; documented --persistent contract is "wakes only for a real
+            ;; rez/fire/access decision or run end", and a notable event is none
+            ;; of those, so while the run is still active we keep owning it: the
+            ;; event was already printed by handle-events; just continue.
+            ;; Genuine decisions (:decision-required / :fire-decision-required)
+            ;; are NOT should-pause-for-event? and still terminate below.
+            ;; Spin-safe: iteration advances (max-iterations backstop stays
+            ;; live), and once the run moves past the event the rez line scrolls
+            ;; out of the 3-entry recent-log window — if it doesn't move, the
+            ;; next status is :waiting-for-opponent (persistent sleep), not a
+            ;; re-fired event.
+            (and persistent
+                 (should-pause-for-event? status)
+                 (some? (get-in @state/client-state [:game-state :run])))
+            (do
+              (Thread/sleep core/quick-delay)
+              (recur (inc iteration) state-history))  ; Keep OLD history; event isn't run-phase progress
+
             ;; Terminal status - stop loop.
             ;; Bug #3 fix: if the run completed and we burned the last click on
             ;; it, fire check-auto-end-turn! — otherwise the runner never sends

--- a/dev/test/continue_run_rez_test.clj
+++ b/dev/test/continue_run_rez_test.clj
@@ -7,6 +7,10 @@
   (:require [clojure.test :refer :all]
             [test-helpers :refer :all]
             [ai-actions :as ai]
+            [ai-runs :as runs]
+            [ai-core :as core]
+            [ai-basic-actions :as basic]
+            [ai-run-runner-handlers :as runner-handlers]
             [ai-run-corp-handlers :as corp-handlers]
             [ai-websocket-client-v2 :as ws]))
 
@@ -306,3 +310,109 @@
                   (str "a rezzed unlisted ICE needs no decision; should continue, got: " r))))
           (is (some #(= "continue" (:command %)) @sent)
               "a rezzed ICE the Corp isn't rezzing should pass priority and proceed"))))))
+
+;; =============================================================================
+;; Test: monitor-run --persistent must NOT drop the defender loop after a rez
+;; commit (#36, cross-model marquee g1).
+;;
+;; The --rez auto-rez returns :action-taken, but the NEXT iteration sees
+;; "Corp rezzes X" in the log and handle-events returns :ice-rezzed. That
+;; status is terminal-status? — correct for hand-driven monitor-run (pausing to
+;; show the user IS the point), but in --persistent mode it dropped the loop
+;; after the Corp's OWN rez, leaving the Runner holding priority at a window the
+;; Corp was no longer watching (soft deadlock; the Runner could only recover by
+;; jacking out, abandoning HQ pressure). The --persistent contract is "wakes
+;; only for a real rez/fire/access decision or run end", so a notable event must
+;; NOT terminate the persistent loop while the run is still active.
+;; =============================================================================
+
+(defn- scripted-continue-run
+  "A continue-run! stand-in that pops one scripted result per call (clamping to
+   the last once exhausted) and records the call count."
+  [results call-count]
+  (fn [& _]
+    (let [i @call-count]
+      (swap! call-count inc)
+      (nth results i (last results)))))
+
+(defn- run-active-corp-state []
+  (mock-client-state
+   :side "corp"
+   :game-state {:run {:phase "approach-ice" :position 1 :server [:hq]}
+                :corp {:prompt-state nil}
+                :runner {:prompt-state nil}
+                :log []}))
+
+(deftest persistent-monitor-survives-own-rez-event
+  (testing "--persistent rides through its own :ice-rezzed event and terminates only on run end (#36)"
+    (let [calls (atom 0)
+          ;; iteration 1: the rez event the loop's own auto-rez produced;
+          ;; iteration 2: the run finishes. Persistent mode must ride through #1.
+          script [{:status :ice-rezzed :wake-reason :ice-rezzed}
+                  {:status :run-complete :wake-reason :run-complete}]]
+      (with-mock-state (run-active-corp-state)
+        (with-redefs [runs/continue-run! (scripted-continue-run script calls)
+                      basic/check-auto-end-turn! (fn [] nil)
+                      runner-handlers/reset-state! (fn [] nil)]
+          (with-out-str
+            (let [result (runs/auto-continue-loop! :persistent true)]
+              (is (= :run-complete (:status result))
+                  (str "persistent loop must ride through its own rez event to run end, got: " result))
+              (is (>= @calls 2)
+                  "loop must have continued past the :ice-rezzed iteration to reach run-complete"))))))))
+
+(deftest hand-driven-monitor-still-pauses-on-rez-event
+  (testing "without --persistent, an :ice-rezzed event is still terminal (hand-driven pause is the point)"
+    (let [calls (atom 0)
+          script [{:status :ice-rezzed :wake-reason :ice-rezzed}
+                  {:status :run-complete :wake-reason :run-complete}]]
+      (with-mock-state (run-active-corp-state)
+        (with-redefs [runs/continue-run! (scripted-continue-run script calls)
+                      basic/check-auto-end-turn! (fn [] nil)
+                      runner-handlers/reset-state! (fn [] nil)]
+          (with-out-str
+            (let [result (runs/auto-continue-loop!)]   ; non-persistent
+              (is (= :ice-rezzed (:status result))
+                  (str "hand-driven monitor-run must still pause on a rez event, got: " result))
+              (is (= 1 @calls)
+                  "should stop after the first (rez-event) iteration"))))))))
+
+(deftest persistent-monitor-still-pauses-on-real-decision
+  (testing "--persistent still terminates on a genuine rez DECISION (not a should-pause-for-event? status)"
+    (let [calls (atom 0)
+          script [{:status :decision-required :wake-reason :rez-ice :ice "Tithe"}]]
+      (with-mock-state (run-active-corp-state)
+        (with-redefs [runs/continue-run! (scripted-continue-run script calls)
+                      basic/check-auto-end-turn! (fn [] nil)
+                      runner-handlers/reset-state! (fn [] nil)]
+          (with-out-str
+            (let [result (runs/auto-continue-loop! :persistent true)]
+              (is (= :decision-required (:status result))
+                  (str "a real rez decision must still wake the persistent seat, got: " result))
+              (is (= 1 @calls)
+                  "should return immediately on the decision"))))))))
+
+;; Spin-safety (Codex review of #36): a degenerate event that NEVER advances —
+;; continue-run! keeps returning :ice-rezzed with the run still active and the
+;; log unchanged — must NOT livelock the persistent loop. Because the event
+;; branch advances `iteration`, the max-iterations backstop bounds it. (In real
+;; play this never happens — the run moves and the rez line scrolls out of the
+;; 3-entry recent-log window, or the next status is :waiting-for-opponent — but
+;; the bound must hold regardless.)
+(deftest persistent-monitor-event-spin-is-bounded-by-max-iterations
+  (testing "a never-advancing :ice-rezzed in --persistent terminates via the max-iterations backstop, not a livelock"
+    (let [calls (atom 0)
+          ;; Always :ice-rezzed, run never ends — the pathological case.
+          always-rezzed (fn [& _] (swap! calls inc) {:status :ice-rezzed :wake-reason :ice-rezzed})]
+      (with-mock-state (run-active-corp-state)
+        (with-redefs [runs/continue-run! always-rezzed
+                      basic/check-auto-end-turn! (fn [] nil)
+                      runner-handlers/reset-state! (fn [] nil)
+                      ;; keep the test fast: tiny delay, low ceiling
+                      core/quick-delay 0]
+          (with-out-str
+            (let [result (runs/auto-continue-loop! :persistent true :max-iterations 5)]
+              (is (= :max-iterations (:status result))
+                  (str "an unending event must hit the max-iterations backstop, got: " result))
+              (is (<= @calls 6)
+                  (str "must be bounded near max-iterations, not spinning unbounded; calls=" @calls)))))))))


### PR DESCRIPTION
Fixes #36 — the headline un-babysat-play robustness gap from cross-model marquee g1.

## The bug
`monitor-run --persistent` is the autonomous Corp "defender loop": it should own a whole Runner run and **wake only for a real rez/fire/access decision or run end**. But `:ice-rezzed` / `:ability-used` / `:subs-fired` / `:tag-or-damage` are in `terminal-status?` — correct for hand-driven `monitor-run` (pausing to show the user *is* the point), wrong for `--persistent`.

The drop sequence:
1. `--rez "Tithe"` auto-rezzes Tithe → `:action-taken` (loop continues).
2. Next iteration: the log now reads "Corp rezzes Tithe"; `handle-events` returns `:ice-rezzed` (terminal) → **the persistent loop exits after its own rez commit.**
3. The Runner is left holding priority at a window the Corp stopped watching → soft deadlock. In marquee g1 the Runner could only recover by **jacking out**, abandoning HQ pressure — outcome-affecting, not just annoying. Both seats reported this from opposite sides.

## The fix
In `auto-continue-loop!`, a branch **before** `terminal-status?`: in persistent mode a `should-pause-for-event?` status with an active `:run` is non-terminal — sleep `quick-delay` and recur, **advancing `iteration`** so the `max-iterations` backstop still bounds a degenerate event spin. Genuine decisions (`:decision-required` / `:fire-decision-required`) are *not* `should-pause-for-event?` and still terminate, so the contract now actually holds.

Spin-safety: in real play the run advances (the rez line scrolls out of the 3-entry `recent-log` window) or the next status is `:waiting-for-opponent` (persistent sleep) — never a re-fired event. The max-iterations bound holds regardless.

## Tests (`continue-run-rez-test`, red→green verified by disabling the branch)
- persistent rides through its own `:ice-rezzed` to run-complete (the regression)
- hand-driven (non-persistent) still pauses on `:ice-rezzed` (scope guard)
- persistent still wakes on a genuine `:decision-required` (scope guard)
- a never-advancing `:ice-rezzed` is bounded by `max-iterations` (spin-safety)

## Review
Codex (GPT-5.5) read-only panel per the multi-model SOP: **no CRITICAL/MAJOR**. Both MINORs addressed in this PR — (1) stale persistent-mode doc comments corrected; (2) the spin-bound test added at Codex's suggestion.

`make verify`: 371 tests / 870 assertions / 0 failures; `make check` + `make test-shell` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)