### PR TITLE
fix: persistent monitor returns Corp on-steal/on-score trigger prompts instead of sleeping to timeout (#43)

### DIFF
--- a/dev/seat-corp.md
+++ b/dev/seat-corp.md
@@ -118,6 +118,15 @@ Then commit your decision by re-entering the monitor with a strategy flag
 - **Low-stakes run, just let it play out:** `./dev/send_command corp monitor-run --persistent --fire-if-asked`
   (auto-fires unbroken subs, auto-continues, wakes you only for rez decisions)
 
+**Non-rez trigger decisions.** Some agendas fire a Corp ability when the Runner
+*steals* them (or when you score them) — e.g. Send a Message ("you may rez a
+piece of ice, ignoring all costs"). The monitor returns with `🛑 You have a
+pending decision to resolve (agenda trigger / choice)`. This is NOT a rez window,
+so don't answer it with `--rez`: read it with `./dev/send_command corp prompt`,
+then resolve it directly — `choose-value "Done"` to decline (e.g. nothing worth a
+free rez / all your ICE already rezzed), or `choose-card "<ICE>"` to pick a
+target. Then, if the run is still live, re-enter `monitor-run --persistent`.
+
 `monitor-run` returns at the next real decision or when the run ends (it prints
 `run ended` / `no active run`). When the run is over, go back to the `wait` loop
 above. Several runs can happen in one Runner turn — keep looping.

--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -479,6 +479,29 @@
   (and prompt
        (not (is-waiting-prompt? prompt))))
 
+(defn seat-owns-trigger-decision?
+  "True if `my-prompt` is a decision THIS seat must resolve itself — an
+   on-steal/on-score agenda trigger or similar choice (e.g. Send a Message's
+   'you may rez a piece of ice, ignoring all costs') — as opposed to a
+   run-priority paid-ability window (prompt-type \"run\", handled by the
+   rez/continue path) or a passive \"waiting\" prompt.
+
+   The persistent monitor's :no-action heuristic (handle-waiting-for-opponent)
+   can mislabel such a trigger as an opponent-wait — it looks at run priority,
+   not at whether WE are holding an unresolved prompt — and then sleep on it
+   until the 300s timeout while the opponent is hard-blocked on our pending
+   trigger (#43). A `select` prompt with no valid targets (all our ICE already
+   rezzed) is the sharpest case: has-real-decision? is false (no selectable, only
+   an implicit Done), so nothing upstream surfaces it. This predicate lets the
+   loop return it as a decision so the seat can resolve it (rez a target / Done)."
+  [my-prompt]
+  (and my-prompt
+       (not= "run" (:prompt-type my-prompt))
+       (not= "waiting" (:prompt-type my-prompt))
+       (or (= "select" (:prompt-type my-prompt))
+           (seq (:choices my-prompt))
+           (seq (:selectable my-prompt)))))
+
 (defn should-i-act?
   "True if it's my turn to act during a run.
    Uses :no-action state as source of truth.
@@ -1248,14 +1271,37 @@
                 (= status :waiting-for-corp-rez)
                 (= status :waiting-for-corp-fire)
                 (= status :waiting-for-opponent-paid-abilities))
-            (if (and persistent
-                     (some? (get-in @state/client-state [:game-state :run])))
-              ;; Idle wait: don't advance `iteration` (timeout governs the bound,
-              ;; not the action-stuck max-iterations guard); reset stuck history.
-              (do
-                (Thread/sleep persistent-wait-delay-ms)
-                (recur iteration []))
-              (if persistent
+            (let [cur-state @state/client-state
+                  my-side (:side cur-state)
+                  my-prompt (get-in cur-state [:game-state (keyword my-side) :prompt-state])
+                  run-active? (some? (get-in cur-state [:game-state :run]))]
+              (cond
+                ;; #43: continue-run! mislabeled this as an opponent-wait, but THIS
+                ;; seat is holding its own on-steal/on-score agenda-trigger prompt
+                ;; (e.g. Send a Message) that only WE can resolve. Sleeping on it
+                ;; strands the game — the opponent is hard-blocked on "waiting for
+                ;; Corp to resolve pending triggers" and (in cross-model marquee g1)
+                ;; gave up after the 300s timeout. Surface it as a decision so the
+                ;; seat resolves it (rez a target / choose Done). Fires in both
+                ;; persistent and hand-driven mode — a real seat decision beats a
+                ;; misleading opponent-wait either way.
+                (seat-owns-trigger-decision? my-prompt)
+                (do
+                  (when persistent (print-while-you-slept! start-log-count))
+                  (println "🛑 You have a pending decision to resolve (agenda trigger / choice) — returning it.")
+                  (assoc result
+                         :status :decision-required
+                         :wake-reason :agenda-trigger-decision
+                         :iterations (inc iteration)
+                         :elapsed-ms (- (System/currentTimeMillis) start-time)))
+
+                ;; Idle wait: don't advance `iteration` (timeout governs the bound,
+                ;; not the action-stuck max-iterations guard); reset stuck history.
+                (and persistent run-active?)
+                (do
+                  (Thread/sleep persistent-wait-delay-ms)
+                  (recur iteration []))
+
                 ;; Persistent, but the run object is GONE (nil). The run already
                 ;; ended — typically the access boundary, where the run tears down
                 ;; while the Runner still resolves access. Marquee game-2 surfaced
@@ -1263,6 +1309,7 @@
                 ;; monitor-run" tip, which then immediately said "No active run to
                 ;; monitor" — a self-contradicting double-step. Return a CLEAN
                 ;; :no-run terminal so the seat goes straight back to its wait loop.
+                persistent
                 (do
                   (print-while-you-slept! start-log-count)
                   (println "✅ Run ended — no further Corp decision. Back to the wait loop.")
@@ -1270,6 +1317,8 @@
                          :status :no-run
                          :iterations (inc iteration)
                          :elapsed-ms (- (System/currentTimeMillis) start-time)))
+
+                :else
                 (do
                   ;; Side-aware tip. This loop just passed THIS seat's window and
                   ;; is now waiting on the opponent. The advice depends on who's

--- a/dev/test/continue_run_rez_test.clj
+++ b/dev/test/continue_run_rez_test.clj
@@ -416,3 +416,122 @@
                   (str "an unending event must hit the max-iterations backstop, got: " result))
               (is (<= @calls 6)
                   (str "must be bounded near max-iterations, not spinning unbounded; calls=" @calls)))))))))
+
+;; =============================================================================
+;; Test: monitor-run --persistent must RETURN on this seat's own on-steal/on-score
+;; agenda-trigger prompt, not sleep on it until the 300s timeout (#43, cross-model
+;; marquee g1 terminal wedge).
+;;
+;; When the Runner steals an agenda with an on-steal Corp ability (e.g. Send a
+;; Message: "you may rez a piece of ice, ignoring all costs"), the engine opens a
+;; CORP `select` prompt. If all Corp ICE are already rezzed the prompt has no
+;; selectable targets and only an implicit Done — so has-real-decision? is false
+;; and handle-real-decision doesn't fire. handle-waiting-for-opponent then labels
+;; it an opponent-wait via the :no-action heuristic (which ignores that the CORP
+;; itself is holding the prompt). In --persistent mode the loop slept & rechecked
+;; that "wait" forever, hitting the 300000ms timeout, while the Runner was hard-
+;; blocked on "Waiting for Corp to resolve pending triggers" and eventually gave
+;; up (game stranded at Corp 6 – Runner 5). The persistent loop must instead
+;; surface such a seat-owned trigger prompt as a decision.
+;; =============================================================================
+
+(defn- corp-state-with-prompt
+  "Run-active Corp mock state carrying a given Corp prompt-state."
+  [corp-prompt]
+  (mock-client-state
+   :side "corp"
+   :game-state {:run {:phase "access" :position 0 :server [:remote1]}
+                :corp {:prompt-state corp-prompt}
+                :runner {:prompt-state {:msg "Waiting for Corp to resolve pending triggers"
+                                        :prompt-type "waiting"}}
+                :log []}))
+
+(deftest persistent-monitor-returns-on-corp-on-steal-trigger-prompt
+  (testing "--persistent surfaces the Corp's own on-steal trigger select prompt as a decision instead of looping to timeout (#43)"
+    (let [calls (atom 0)
+          ;; continue-run! mislabels the trigger as an opponent wait
+          ;; (handle-waiting-for-opponent via the :no-action heuristic).
+          script [{:status :waiting-for-opponent :wake-reason :waiting-for-opponent}]]
+      (with-mock-state (corp-state-with-prompt
+                        {:msg "Choose a target for Send a Message"
+                         :prompt-type "select"
+                         :choices []
+                         :selectable []})   ; no valid rez targets — all ICE already rezzed
+        (with-redefs [runs/continue-run! (scripted-continue-run script calls)
+                      basic/check-auto-end-turn! (fn [] nil)
+                      runner-handlers/reset-state! (fn [] nil)
+                      core/quick-delay 0]
+          (with-out-str
+            (let [result (runs/auto-continue-loop! :persistent true
+                                                   :timeout-ms 2000
+                                                   :persistent-wait-delay-ms 0)]
+              (is (= :decision-required (:status result))
+                  (str "persistent loop must return the Corp's own trigger as a decision, not timeout, got: " result))
+              (is (= 1 @calls)
+                  "should return on the first waiting status that reveals our pending trigger"))))))))
+
+(deftest persistent-monitor-empty-wait-without-trigger-still-rides-through
+  (testing "--persistent with NO seat-owned prompt still sleeps through an empty opponent wait to run end (no #43 false positive)"
+    (let [calls (atom 0)
+          script [{:status :waiting-for-opponent :wake-reason :waiting-for-opponent}
+                  {:status :run-complete :wake-reason :run-complete}]]
+      (with-mock-state (corp-state-with-prompt nil)   ; Corp holds no prompt
+        (with-redefs [runs/continue-run! (scripted-continue-run script calls)
+                      basic/check-auto-end-turn! (fn [] nil)
+                      runner-handlers/reset-state! (fn [] nil)
+                      core/quick-delay 0]
+          (with-out-str
+            (let [result (runs/auto-continue-loop! :persistent true
+                                                   :persistent-wait-delay-ms 0)]
+              (is (= :run-complete (:status result))
+                  (str "an empty opponent wait with no seat prompt must ride through to run end, got: " result))
+              (is (>= @calls 2)
+                  "must recheck past the empty wait to reach run-complete"))))))))
+
+(deftest persistent-monitor-normal-defender-wait-rides-through
+  (testing "the normal Corp defender wait (passed priority mid-encounter, holding a 'run' window) is NOT a trigger decision — persistent rides through (no #36/#42 regression)"
+    (let [calls (atom 0)
+          script [{:status :waiting-for-opponent :wake-reason :waiting-for-opponent}
+                  {:status :run-complete :wake-reason :run-complete}]]
+      ;; Representative shape of "Corp passed, waiting for Runner to break ICE":
+      ;; mid-encounter run, Corp already passed (:no-action corp), holding the
+      ;; run paid-ability window (prompt-type "run"). This is exactly the window
+      ;; the persistent loop must sleep through, not surface as a decision.
+      (with-mock-state
+        (mock-client-state
+         :side "corp"
+         :game-state {:run {:phase "encounter-ice" :position 1 :server [:hq] :no-action "corp"}
+                      :corp {:prompt-state {:msg "Paid ability window" :prompt-type "run"
+                                            :choices [] :selectable []}}
+                      :runner {:prompt-state nil}
+                      :log []})
+        (with-redefs [runs/continue-run! (scripted-continue-run script calls)
+                      basic/check-auto-end-turn! (fn [] nil)
+                      runner-handlers/reset-state! (fn [] nil)
+                      core/quick-delay 0]
+          (with-out-str
+            (let [result (runs/auto-continue-loop! :persistent true
+                                                   :persistent-wait-delay-ms 0)]
+              (is (= :run-complete (:status result))
+                  (str "a normal defender wait must ride through to run end, not return a decision, got: " result))
+              (is (>= @calls 2)
+                  "must recheck past the empty defender wait to reach run-complete"))))))))
+
+(deftest persistent-monitor-run-type-window-is-not-a-trigger-decision
+  (testing "a Corp 'run'-type paid-ability window during an opponent wait is NOT a seat-owned trigger — rides through (no #43 false positive)"
+    (let [calls (atom 0)
+          script [{:status :waiting-for-opponent :wake-reason :waiting-for-opponent}
+                  {:status :run-complete :wake-reason :run-complete}]]
+      (with-mock-state (corp-state-with-prompt
+                        {:msg "Paid ability window" :prompt-type "run" :choices [] :selectable []})
+        (with-redefs [runs/continue-run! (scripted-continue-run script calls)
+                      basic/check-auto-end-turn! (fn [] nil)
+                      runner-handlers/reset-state! (fn [] nil)
+                      core/quick-delay 0]
+          (with-out-str
+            (let [result (runs/auto-continue-loop! :persistent true
+                                                   :persistent-wait-delay-ms 0)]
+              (is (= :run-complete (:status result))
+                  (str "a 'run'-type window must not be mistaken for a trigger decision, got: " result))
+              (is (>= @calls 2)
+                  "must recheck past the empty run-window wait to reach run-complete"))))))))


### PR DESCRIPTION
Fixes #43. Found live in cross-model marquee Game 1 (Opus 4.8 Corp vs GPT-5.5 Runner) — forum `ai-netrunner` [133].

## The bug
The Runner stole *Send a Message* (turn 16), whose on-steal Corp ability opens a `select` prompt ("you may rez a piece of ice, ignoring all costs"). With all Corp ICE already rezzed, the prompt had **no selectable targets** and only an implicit Done, so `has-real-decision?` was false and `handle-real-decision` never fired. `handle-waiting-for-opponent` then labeled it an opponent-wait via the `:no-action` heuristic (which ignores that the **Corp itself** holds the prompt), and `monitor-run --persistent` slept & rechecked that "wait" until the **300000ms timeout** — while the Runner was hard-blocked on "Waiting for Corp to resolve pending triggers" and eventually gave up. Game stranded at Corp 6 – Runner 5.

Same family as #36/#42 (a real decision that returns via timeout instead of via the decision) but a **distinct path**: the run has already ended, so it is NOT the #42 plain-waiting-while-run-active signature.

## The fix
`seat-owns-trigger-decision?` recognizes a seat-owned **non-run, non-waiting** prompt (a `select`, or any prompt carrying choices/selectable) in the persistent `:waiting-for-opponent` branch of `auto-continue-loop!`, and returns `:decision-required` so the seat resolves it (rez a target / choose Done). It **excludes** `"run"` paid-ability windows and `"waiting"` prompts, so the normal defender wait (Corp passed, waiting for Runner to break ICE) is unaffected — preserving the #36/#42 contract.

## Tests (red→green verified by reverting the branch)
- persistent returns `:decision-required` on a Corp on-steal `select` prompt with no targets, instead of spinning to timeout (the #43 regression)
- persistent with no seat prompt still rides an empty wait through to run-complete
- a normal defender wait (encounter phase, Corp passed, `"run"` window) rides through — no #36/#42 regression
- a Corp `"run"`-type paid-ability window is NOT mistaken for a trigger decision

`make verify`: **374 tests / 876 assertions / 0 failures**; check + shell tests green.

## Review (multi-model SOP)
Codex was out of credits; routed to the switchable guest backend **GPT-5.5 (devin)**, read-only. Verdict: **merge**, no blocking findings. One MINOR (test-strength) addressed by adding the representative normal-defender-wait scope-guard test.

Also documents non-rez trigger resolution (`choose-value "Done"` / `choose-card`) in `dev/seat-corp.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)