### PR TITLE
fix: multi-choose! stops reporting "Selection complete" on an unresolved prompt

### DIFF
--- a/dev/src/clj/ai_prompts.clj
+++ b/dev/src/clj/ai_prompts.clj
@@ -381,16 +381,41 @@
           (do
             (println "❌ No valid cards found to select")
             (core/with-cursor {:status :error :reason "No valid cards found"}))
-          (do
+          (let [select? (state/select-prompt-type? (:prompt-type prompt))]
             (println (format "📇 Selecting %d card(s)..." (count cards-to-select)))
             (doseq [{:keys [card ref]} cards-to-select]
               (println (format "   → %s" (:title card)))
               (ws/select-card! card eid)
               (Thread/sleep core/short-delay))
-            ;; Wait for prompt to change after all selections
-            (wait-for-prompt-change! eid)
-            (println "✅ Selection complete")
-            (core/with-cursor {:status :success :selected (count cards-to-select)})))))))
+            ;; Don't claim completion before the prompt confirms it. Only report
+            ;; success once the prompt actually moves/resolves. If it stays put the
+            ;; selection did NOT resolve — saying "Selection complete" there is the
+            ;; misleading-output bug that drove a marquee discard-to-5 misplay
+            ;; (cards still in hand, prompt still open). Mirrors choose-card! (#40).
+            (cond
+              (wait-for-prompt-change! eid)
+              (do
+                (println "✅ Selection complete")
+                (core/with-cursor {:status :success :selected (count cards-to-select)}))
+
+              ;; Select-type prompt still open: cards were toggled but :max not yet
+              ;; reached. wait-for-prompt-change! already printed the steer.
+              select?
+              (do
+                (println (format "⏳ %d card(s) toggled but the prompt is still open — selection not resolved."
+                                (count cards-to-select)))
+                (println "   → Select the remaining card(s), or use choose-value \"Done\" if the count is already right.")
+                (core/with-cursor {:status :waiting-input :selected (count cards-to-select)}))
+
+              ;; Non-select prompt that didn't move: multi-choose was the wrong verb.
+              :else
+              (do
+                (println "↪️  multi-choose did not register — this prompt isn't a card-select.")
+                (if (seq (:choices prompt))
+                  (println "   → It's a numbered CHOICE prompt. Use:  choose <N>")
+                  (println "   → Use 'prompt' to inspect, then choose / choose-value."))
+                (core/with-cursor {:status :error
+                                   :reason "Not a card-select prompt — use choose"})))))))))
 
 ;; ============================================================================
 ;; Mulligan

--- a/dev/test/ai_prompts_test.clj
+++ b/dev/test/ai_prompts_test.clj
@@ -166,6 +166,71 @@
             (is (not (str/includes? out "No select prompt active")))))))))
 
 ;; ============================================================================
+;; multi-choose! — no premature "Selection complete" on an unresolved prompt
+;;
+;; multi-choose! sent every select then UNCONDITIONALLY printed "✅ Selection
+;; complete" + returned :success, ignoring wait-for-prompt-change!. Found live on
+;; a Corp discard-to-5 (marquee g1): `multi-choose 0 1` reported success while the
+;; hand still held 7 cards and the prompt stayed open — directly under the ℹ️
+;; "select prompt still open" tip, contradicting it. Same misleading-output class
+;; already fixed for choose-card! (#40). Fix: only claim completion once the
+;; prompt actually moves; a select that stays put is "toggled, not resolved"
+;; (:waiting-input), and an unmoved NON-select prompt is the wrong verb (:error).
+;; ============================================================================
+
+(deftest multi-choose-unresolved-select-does-not-claim-complete
+  (testing "a select prompt that stays open (not resolved) must NOT report Selection complete / :success"
+    (with-mock-state (mock-client-state
+                      :side "corp"
+                      :prompt {:prompt-type "select" :eid "disc-1"
+                               :msg "Discard down to 5 cards"
+                               :selectable [{:cid "c1" :title "Hedge Fund"}
+                                            {:cid "c2" :title "IPO"}]})
+      (with-redefs [ws/select-card! (fn [_card _eid] true)
+                    ;; server toggled the cards but the prompt did not resolve
+                    prompts/wait-for-prompt-change! (fn [_eid & _] false)]
+        (let [out (with-out-str
+                    (let [r (prompts/multi-choose! 0 1)]
+                      ;; pin the contract: an unresolved real select is :waiting-input,
+                      ;; not :success (and not silently downgraded to :error either).
+                      (is (= :waiting-input (:status r))
+                          (str "unresolved select must report :waiting-input, got: " r))))]
+          (is (not (str/includes? out "Selection complete"))
+              (str "must not print 'Selection complete' when the prompt is still open, got: " out)))))))
+
+(deftest multi-choose-resolving-select-reports-complete
+  (testing "a select that RESOLVES the prompt (moved) still reports Selection complete + :success"
+    (with-mock-state (mock-client-state
+                      :side "corp"
+                      :prompt {:prompt-type "select" :eid "disc-1"
+                               :msg "Discard down to 5 cards"
+                               :selectable [{:cid "c1" :title "Hedge Fund"}
+                                            {:cid "c2" :title "IPO"}]})
+      (with-redefs [ws/select-card! (fn [_card _eid] true)
+                    prompts/wait-for-prompt-change! (fn [_eid & _] true)]
+        (let [out (with-out-str
+                    (let [r (prompts/multi-choose! 0 1)]
+                      (is (= :success (:status r)) (str "expected success, got: " r))))]
+          (is (str/includes? out "Selection complete")))))))
+
+(deftest multi-choose-unmoved-nonselect-is-wrong-verb
+  (testing "multi-choose on a non-select prompt that doesn't move errors and steers to choose"
+    (with-mock-state (mock-client-state
+                      :side "runner"
+                      :prompt {:prompt-type "other" :eid "mf-1"
+                               :msg "Choose an icebreaker"
+                               :choices [{:value "Corroder"}]
+                               :selectable [{:cid "c1" :title "Corroder"}]})
+      (with-redefs [ws/select-card! (fn [_card _eid] true)
+                    prompts/wait-for-prompt-change! (fn [_eid & _] false)]
+        (let [out (with-out-str
+                    (let [r (prompts/multi-choose! 0)]
+                      (is (= :error (:status r)) (str "expected error, got: " r))))]
+          (is (not (str/includes? out "Selection complete")))
+          (is (str/includes? out "choose")
+              (str "should steer to choose, got: " out)))))))
+
+;; ============================================================================
 ;; choose-card! — partial multi-select must not trigger the auto-end-turn hook
 ;;
 ;; choose-card! fires maybe-auto-end-turn-after-prompt! after every select. On a


### PR DESCRIPTION
## Problem

`multi-choose!` sent every select then **unconditionally** printed `✅ Selection complete` and returned `{:status :success}`, ignoring `wait-for-prompt-change!` (which returns `true` iff the prompt actually moved/resolved).

When the prompt stayed open — a partial multi-select (`:max` not yet reached) or the wrong verb entirely — it lied. Found live on a Corp discard-to-5 in **marquee g1 (Opus Corp vs GPT-5.5 Runner)**: `multi-choose 0 1` reported success while the hand still held 7 cards and the prompt stayed open, printed *directly under* the ℹ️ "select prompt still open" steer — contradicting it, and contributing to a misplay.

Misleading-output class; the same shape was already fixed for `choose-card!` in #40.

## Fix

Gate the confirmation on `wait-for-prompt-change!`, mirroring `choose-card!`:
- **prompt moved** → `✅ Selection complete` + `:success` (unchanged happy path)
- **select-type, still open** → toggled but not resolved → `:waiting-input`, steer to finish the selection (`choose-value "Done"` / more selects)
- **non-select, unmoved** → wrong verb → `:error`, steer to `choose`

## Tests (red→green, verified red against prior code)
- unresolved select → `:waiting-input`, no "Selection complete"
- resolving select → `:success` + "Selection complete" (scope guard)
- unmoved non-select → `:error` + steer to `choose`

`make verify`: green (checks + full suite + shell tests).

## Panel (multi-model review SOP)
GPT-5.5 (`codex exec`, read-only): **no CRITICAL/MAJOR.** One MINOR — pin the unresolved-select assertion to `= :waiting-input` (applied). Noted a theoretical regression risk for a hypothetical non-`"select"`-typed *multi-accumulate* prompt; accepted as an intentional consistency choice with the merged `choose-card!` #40 logic (no such engine prompt is known).

🤖 Generated with [Claude Code](https://claude.com/claude-code)