### PR TITLE
NAN credit tracking: turn checkpoints {Cn Rn} + per-action →C/→R totals

### DIFF
--- a/dev/game_logs/20260703/game4_log.txt
+++ b/dev/game_logs/20260703/game4_log.txt
@@ -1,0 +1,229 @@
+📜 GAME LOG (last 300 entries)
+Clamatius has created the game.
+ai-runner joined the game.
+Clamatius joined the game as a spectator.
+
+Clamatius keeps their hand.
+ai-runner keeps their hand.
+Clamatius started their turn 1 with 5 [Credit] and 5 cards in HQ.
+Clamatius makes their mandatory start of turn draw.
+Clamatius spends [Click] and pays 5 [Credits] to play Hedge Fund.
+Clamatius uses Hedge Fund to gain 9 [Credits].
+Clamatius spends [Click] and pays 0 [Credits] to install ice protecting R&D.
+Clamatius spends [Click] and pays 0 [Credits] to install ice protecting HQ.
+Clamatius is ending their turn 1 with 9 [Credit] and 3 cards in HQ.
+ai-runner started their turn 1 with 5 [Credit] and 5 cards in their Grip.
+ai-runner spends [Click] to make a run on R&D.
+ai-runner approaches ice protecting R&D at position 0.
+Clamatius pays 4 [Credits] to rez Karunā protecting R&D at position 0.
+Clamatius has no further action.
+ai-runner encounters Karunā protecting R&D at position 0.
+ai-runner indicates to fire all unbroken subroutines on Karunā.
+Clamatius uses Karunā to do 2 net damage.
+Clamatius trashes Mutual Favor and Overclock due to net damage.
+ai-runner uses Karunā to jack out.
+ai-runner jacks out.
+ai-runner spends [Click] and pays 1 [Credits] to play VRcation.
+ai-runner uses VRcation to draw 4 cards and lose [Click].
+ai-runner spends [Click] and pays 1 [Credits] to play Creative Commission.
+ai-runner uses Creative Commission to gain 5 [Credits].
+ai-runner is ending their turn 1 with 8 [Credit] and 5 cards in their Grip.
+Clamatius started their turn 2 with 5 [Credit] and 3 cards in HQ.
+Clamatius makes their mandatory start of turn draw.
+Clamatius spends [Click] and pays 0 [Credits] to install ice protecting Server 1 (new remote).
+Clamatius spends [Click] to install a card in the root of Server 1.
+Clamatius spends [Click] and pays 1 [Credits] to use Corp Basic Action Card to advance a card in Server 1.
+Clamatius is ending their turn 2 with 4 [Credit] and 2 cards in HQ.
+ai-runner started their turn 2 with 8 [Credit] and 5 cards in their Grip.
+ai-runner spends [Click] to make a run on Server 1.
+ai-runner approaches ice protecting Server 1 at position 0.
+Clamatius pays 1 [Credits] to rez Tithe protecting Server 1 at position 0.
+Clamatius has no further action.
+ai-runner encounters Tithe protecting Server 1 at position 0.
+Clamatius uses Tithe to do 1 net damage.
+Clamatius trashes Conduit due to net damage.
+Clamatius uses Tithe to gain 1 [Credits].
+Clamatius resolves 2 unbroken subroutines on Tithe (\"[subroutine] Do 1 net damage\" and \"[subroutine] Gain 1 [Credits]\").
+ai-runner passes Tithe protecting Server 1 at position 0.
+ai-runner approaches Server 1.
+ai-runner breaches Server 1.
+ai-runner accesses Offworld Office from Server 1.
+ai-runner steals Offworld Office and gains 2 agenda points.
+ai-runner spends [Click] and pays 3 [Credits] to install Carmen.
+ai-runner spends [Click] and pays 0 [Credits] to play Jailbreak.
+ai-runner uses Jailbreak to make a run on R&D.
+Clamatius has no further action.
+ai-runner approaches Karunā protecting R&D at position 0.
+ai-runner encounters Karunā protecting R&D at position 0.
+ai-runner pays 4 [Credits] to increase the strength of Carmen to 5 and break all 2 subroutines on Karunā.
+ai-runner has no further action.
+ai-runner has no further action.
+ai-runner passes Karunā protecting R&D at position 0.
+ai-runner approaches R&D.
+ai-runner uses Jailbreak to draw 1 card.
+ai-runner breaches R&D.
+ai-runner accesses an unseen card from R&D.
+ai-runner accesses Tithe from R&D.
+ai-runner accesses an unseen card from R&D.
+ai-runner accesses Public Trail from R&D.
+ai-runner spends [Click] to use Runner Basic Action Card to gain 1 [Credits].
+ai-runner is ending their turn 2 with 2 [Credit] and 3 cards in their Grip.
+Clamatius started their turn 3 with 4 [Credit] and 2 cards in HQ.
+Clamatius makes their mandatory start of turn draw.
+Clamatius spends [Click] to install a card in the root of Server 1.
+Clamatius spends [Click] and pays 1 [Credits] to use Corp Basic Action Card to advance a card in Server 1.
+Clamatius spends [Click] to use Corp Basic Action Card to gain 1 [Credits].
+Clamatius is ending their turn 3 with 4 [Credit] and 2 cards in HQ.
+ai-runner started their turn 3 with 2 [Credit] and 3 cards in their Grip.
+ai-runner spends [Click] and pays 1 [Credits] to play VRcation.
+ai-runner uses VRcation to draw 4 cards and lose [Click].
+ai-runner spends [Click] to use Runner Basic Action Card to gain 1 [Credits].
+ai-runner spends [Click] to make a run on Server 1.
+ai-runner approaches Tithe protecting Server 1 at position 0.
+Clamatius has no further action.
+guessing that's a wait bug
+we'll want to implement a wakeup ping in chat anyway
+ai-runner encounters Tithe protecting Server 1 at position 0.
+ai-runner pays 2 [Credits] to use Carmen to break all 2 subroutines on Tithe.
+ai-runner has no further action.
+ai-runner has no further action.
+ai-runner passes Tithe protecting Server 1 at position 0.
+ai-runner approaches Server 1.
+ai-runner breaches Server 1.
+ai-runner accesses Urtica Cipher from Server 1.
+Clamatius uses Urtica Cipher to do 3 net damage.
+Clamatius trashes Overclock, Red Team, and Wildcat Strike due to net damage.
+ai-runner is ending their turn 3 with 0 [Credit] and 3 cards in their Grip.
+Clamatius started their turn 4 with 4 [Credit] and 2 cards in HQ.
+Clamatius makes their mandatory start of turn draw.
+Clamatius spends [Click] to use Corp Basic Action Card to draw 1 card.
+Clamatius spends [Click] to install a card in the root of Server 1.
+Clamatius trashes a card in Server 1.
+Clamatius spends [Click] and pays 1 [Credits] to install ice protecting R&D.
+Clamatius is ending their turn 4 with 3 [Credit] and 2 cards in HQ.
+ai-runner started their turn 4 with 0 [Credit] and 3 cards in their Grip.
+ai-runner spends [Click] and pays 0 [Credits] to install Smartware Distributor.
+ai-runner spends [Click] to use Smartware Distributor to place 3 [Credits].
+ai-runner spends [Click] to use Runner Basic Action Card to draw 1 card.
+ai-runner spends [Click] to use Runner Basic Action Card to gain 1 [Credits].
+ai-runner is ending their turn 4 with 1 [Credit] and 3 cards in their Grip.
+Clamatius pays 2 [Credits] to rez Nico Campaign in Server 1.
+Clamatius started their turn 5 with 1 [Credit] and 2 cards in HQ.
+Clamatius uses Nico Campaign to gain 3 [Credits].
+Clamatius makes their mandatory start of turn draw.
+Clamatius spends [Click] to use Corp Basic Action Card to draw 1 card.
+Clamatius spends [Click] to use Corp Basic Action Card to draw 1 card.
+Clamatius spends [Click] to use Corp Basic Action Card to gain 1 [Credits].
+Clamatius is ending their turn 5 with 5 [Credit] and 5 cards in HQ.
+ai-runner started their turn 5 with 1 [Credit] and 3 cards in their Grip.
+ai-runner uses Smartware Distributor to gain 1 [Credits].
+ai-runner spends [Click] to use Runner Basic Action Card to gain 1 [Credits].
+ai-runner spends [Click] and pays 3 [Credits] to install Pennyshaver.
+ai-runner spends [Click] to use Runner Basic Action Card to draw 1 card.
+ai-runner spends [Click] to use Runner Basic Action Card to draw 1 card.
+ai-runner is ending their turn 5 with 0 [Credit] and 4 cards in their Grip.
+Clamatius started their turn 6 with 5 [Credit] and 5 cards in HQ.
+Clamatius uses Nico Campaign to gain 3 [Credits].
+Clamatius makes their mandatory start of turn draw.
+Clamatius spends [Click] and pays 0 [Credits] to install ice protecting Server 2 (new remote).
+Clamatius spends [Click] and pays 1 [Credits] to install ice protecting Server 2.
+Clamatius spends [Click] to install a card in the root of Server 2.
+Clamatius is ending their turn 6 with 7 [Credit] and 3 cards in HQ.
+ai-runner started their turn 6 with 0 [Credit] and 4 cards in their Grip.
+ai-runner uses Smartware Distributor to gain 1 [Credits].
+ai-runner spends [Click] to use Runner Basic Action Card to gain 1 [Credits].
+ai-runner spends [Click] to use Runner Basic Action Card to gain 1 [Credits].
+ai-runner spends [Click] to use Runner Basic Action Card to gain 1 [Credits].
+ai-runner spends [Click] to use Runner Basic Action Card to draw 1 card.
+ai-runner is ending their turn 6 with 4 [Credit] and 5 cards in their Grip.
+Clamatius started their turn 7 with 7 [Credit] and 3 cards in HQ.
+Clamatius uses Nico Campaign to gain 3 [Credits].
+Clamatius trashes Nico Campaign and draws 1 card.
+Clamatius makes their mandatory start of turn draw.
+Clamatius spends [Click] and pays 1 [Credits] to use Corp Basic Action Card to advance a card in Server 2.
+Clamatius spends [Click] and pays 1 [Credits] to use Corp Basic Action Card to advance a card in Server 2.
+Clamatius spends [Click] and pays 1 [Credits] to use Corp Basic Action Card to advance a card in Server 2.
+Clamatius scores Superconducting Hub and gains 1 agenda point.
+Clamatius uses Superconducting Hub to draw 2 cards.
+Clamatius is ending their turn 7 with 7 [Credit] and 7 cards in HQ.
+ai-runner started their turn 7 with 4 [Credit] and 5 cards in their Grip.
+ai-runner uses Smartware Distributor to gain 1 [Credits].
+ai-runner spends [Click] and pays 5 [Credits] to play Sure Gamble.
+ai-runner uses Sure Gamble to gain 9 [Credits].
+ai-runner spends [Click] and pays 2 [Credits] to install Docklands Pass.
+ai-runner spends [Click] to make a run on HQ.
+ai-runner approaches ice protecting HQ at position 0.
+Clamatius pays 2 [Credits] to rez Diviner protecting HQ at position 0.
+Clamatius has no further action.
+ai-runner encounters Diviner protecting HQ at position 0.
+Clamatius uses Diviner to do 1 net damage.
+Clamatius trashes Leech due to net damage.
+Clamatius uses Diviner to end the run.
+Clamatius resolves 1 unbroken subroutine on Diviner (\"[subroutine] Do 1 net damage\").
+ai-runner spends [Click] to use Runner Basic Action Card to draw 1 card.
+ai-runner is ending their turn 7 with 7 [Credit] and 3 cards in their Grip.
+Clamatius started their turn 8 with 5 [Credit] and 7 cards in HQ.
+Clamatius makes their mandatory start of turn draw.
+Clamatius spends [Click] and pays 5 [Credits] to play Hedge Fund.
+Clamatius uses Hedge Fund to gain 9 [Credits].
+Clamatius spends [Click] to install a card in the root of Server 2.
+Clamatius spends [Click] and pays 1 [Credits] to use Corp Basic Action Card to advance a card in Server 2.
+Clamatius is ending their turn 8 with 8 [Credit] and 6 cards in HQ.
+ai-runner started their turn 8 with 7 [Credit] and 3 cards in their Grip.
+ai-runner spends [Click] and pays 5 [Credits] to play Sure Gamble.
+ai-runner uses Sure Gamble to gain 9 [Credits].
+ai-runner spends [Click] and pays 1 [Credits] to play Tread Lightly.
+ai-runner uses Tread Lightly to make a run on Server 2.
+ai-runner approaches ice protecting Server 2 at position 1.
+Clamatius pays 5 [Credits] to rez Diviner protecting Server 2 at position 1.
+Clamatius has no further action.
+ai-runner encounters Diviner protecting Server 2 at position 1.
+Clamatius uses Diviner to do 1 net damage.
+Clamatius trashes Smartware Distributor due to net damage.
+Clamatius resolves 1 unbroken subroutine on Diviner (\"[subroutine] Do 1 net damage\").
+ai-runner passes Diviner protecting Server 2 at position 1.
+ai-runner approaches ice protecting Server 2 at position 0.
+Clamatius has no further action.
+ai-runner passes ice protecting Server 2 at position 0.
+ai-runner will continue the run.
+ai-runner approaches Server 2.
+ai-runner uses Pennyshaver to place 1 [Credits].
+ai-runner breaches Server 2.
+ai-runner accesses Offworld Office from Server 2.
+ai-runner steals Offworld Office and gains 2 agenda points.
+was kinda hoping to move in there ngl
+ai-runner spends [Click] to use Runner Basic Action Card to draw 1 card.
+ai-runner spends [Click] to use Runner Basic Action Card to draw 1 card.
+ai-runner is ending their turn 8 with 10 [Credit] and 2 cards in their Grip.
+Clamatius started their turn 9 with 3 [Credit] and 6 cards in HQ.
+Clamatius makes their mandatory start of turn draw.
+Clamatius spends [Click] and pays 0 [Credits] to play Predictive Planogram.
+Clamatius uses Predictive Planogram to gain 3 [Credits].
+Clamatius spends [Click] to use Corp Basic Action Card to gain 1 [Credits].
+Clamatius spends [Click] to use Corp Basic Action Card to gain 1 [Credits].
+Clamatius is ending their turn 9 with 8 [Credit] and 6 cards in HQ.
+ai-runner started their turn 9 with 10 [Credit] and 2 cards in their Grip.
+ai-runner spends [Click] and pays 3 [Credits] to install Unity.
+ai-runner spends [Click] and pays 0 [Credits] to play Jailbreak.
+ai-runner uses Jailbreak to make a run on HQ.
+Clamatius has no further action.
+ai-runner approaches Diviner protecting HQ at position 0.
+ai-runner encounters Diviner protecting HQ at position 0.
+ai-runner pays 2 [Credits] to increase the strength of Unity to 3 and break all  subroutines on Diviner.
+ai-runner has no further action.
+ai-runner has no further action.
+ai-runner passes Diviner protecting HQ at position 0.
+ai-runner approaches HQ.
+ai-runner uses Pennyshaver to place 1 [Credits].
+ai-runner uses Jailbreak to draw 1 card.
+ai-runner breaches HQ.
+ai-runner uses Docklands Pass to access 1 additional card from HQ.
+ai-runner accesses Palisade from HQ.
+ai-runner accesses Send a Message from HQ.
+ai-runner steals Send a Message and gains 3 agenda points.
+ai-runner wins the game.
+gg wp
+Clamatius uses Send a Message to rez Brân 1.0 protecting Server 2 at position 0 at no cost.
+ai-runner accesses Palisade from HQ.
+gg wp! Great game Michael — that Urtica got me good, but the Tread Lightly steal turn felt right. Thanks for the game!
+

--- a/dev/game_logs/20260703/game5_log.txt
+++ b/dev/game_logs/20260703/game5_log.txt
@@ -1,0 +1,215 @@
+
+📜 GAME LOG (last 300 entries)
+  Clamatius has created the game.
+  ai-corp joined the game.
+  
+  ai-corp keeps their hand.
+  Clamatius keeps their hand.
+  ai-corp started their turn 1 with 5 [Credit] and 5 cards in HQ.
+  ai-corp makes their mandatory start of turn draw.
+  ai-corp spends [Click] and pays 0 [Credits] to install facedown Diviner protecting R&D.
+  ai-corp spends [Click] and pays 0 [Credits] to install facedown Tithe protecting HQ.
+  ai-corp spends [Click] to use Corp Basic Action Card to gain 1 [Credits].
+  ai-corp is ending their turn 1 with 6 [Credit] and 4 cards in HQ.
+  Clamatius started their turn 1 with 5 [Credit] and 5 cards in their Grip.
+  Clamatius spends [Click] to use Runner Basic Action Card to draw 1 card.
+  Clamatius spends [Click] to use Runner Basic Action Card to draw 1 card.
+  Clamatius spends [Click] and pays 5 [Credits] to play Sure Gamble.
+  Clamatius uses Sure Gamble to gain 9 [Credits].
+  Clamatius spends [Click] and pays 1 [Credits] to play Creative Commission.
+  Clamatius uses Creative Commission to gain 5 [Credits].
+  Clamatius is ending their turn 1 with 13 [Credit] and 5 cards in their Grip.
+  ai-corp started their turn 2 with 6 [Credit] and 4 cards in HQ.
+  ai-corp makes their mandatory start of turn draw.
+  ai-corp spends [Click] to install facedown Regolith Mining License in the root of Server 1 (new remote).
+  ai-corp pays 2 [Credits] to rez Regolith Mining License in Server 1.
+  ai-corp spends [Click] to use Regolith Mining License to gain 3 [Credits].
+  ai-corp spends [Click] to use Regolith Mining License to gain 3 [Credits].
+  ai-corp is ending their turn 2 with 10 [Credit] and 4 cards in HQ.
+  Clamatius started their turn 2 with 13 [Credit] and 5 cards in their Grip.
+  Clamatius spends [Click] to use Runner Basic Action Card to draw 1 card.
+  Clamatius spends [Click] to make a run on Server 1.
+  Clamatius will continue the run.
+  Clamatius approaches Server 1.
+  Clamatius breaches Server 1.
+  Clamatius accesses Regolith Mining License from Server 1.
+  Clamatius pays 3 [Credits] to trash Regolith Mining License from Server 1.
+  Clamatius spends [Click] and pays 0 [Credits] to install Smartware Distributor.
+  Clamatius spends [Click] to use Smartware Distributor to place 3 [Credits].
+  Clamatius is ending their turn 2 with 10 [Credit] and 5 cards in their Grip.
+  ai-corp started their turn 3 with 10 [Credit] and 4 cards in HQ.
+  ai-corp makes their mandatory start of turn draw.
+  ai-corp spends [Click] to use Corp Basic Action Card to draw 1 card.
+  ai-corp spends [Click] and pays 0 [Credits] to play Predictive Planogram.
+  ai-corp uses Predictive Planogram to draw 3 cards.
+  ai-corp spends [Click] and pays 5 [Credits] to play Hedge Fund.
+  ai-corp uses Hedge Fund to gain 9 [Credits].
+  ai-corp discards 2 cards from HQ at end of turn.
+  ai-corp is ending their turn 3 with 14 [Credit] and 5 cards in HQ.
+  Clamatius started their turn 3 with 10 [Credit] and 5 cards in their Grip.
+  Clamatius uses Smartware Distributor to gain 1 [Credits].
+  Clamatius spends [Click] to make a run on HQ.
+  mental note: implement chat wake-up. we'll want to figure out why wait didn't fire here too
+  Clamatius approaches ice protecting HQ at position 0.
+  ai-corp pays 1 [Credits] to rez Tithe protecting HQ at position 0.
+  ai-corp has no further action.
+  Clamatius encounters Tithe protecting HQ at position 0.
+  Clamatius indicates to fire all unbroken subroutines on Tithe.
+  ai-corp uses Tithe to do 1 net damage.
+  ai-corp trashes DZMZ Optimizer due to net damage.
+  ai-corp uses Tithe to gain 1 [Credits].
+  ai-corp resolves 2 unbroken subroutines on Tithe (\"[subroutine] Do 1 net damage\" and \"[subroutine] Gain 1 [Credits]\").
+  Clamatius has no further action.
+  Clamatius passes Tithe protecting HQ at position 0.
+  Clamatius will continue the run.
+  Clamatius approaches HQ.
+  Clamatius breaches HQ.
+  Clamatius accesses Send a Message from HQ.
+  Clamatius steals Send a Message and gains 3 agenda points.
+  ai-corp uses Send a Message to rez Diviner protecting R&D at position 0 at no cost.
+  Clamatius spends [Click] and pays 0 [Credits] to play Mutual Favor.
+  Clamatius uses Mutual Favor to add Carmen from the stack to the grip and shuffle the stack.
+  Clamatius uses Mutual Favor to  install Carmen.
+  Clamatius pays 3 [Credits] to install Carmen from the Stack.
+  Clamatius spends [Click] to make a run on HQ.
+  Clamatius approaches Tithe protecting HQ at position 0.
+  Clamatius encounters Tithe protecting HQ at position 0.
+  Clamatius pays 2 [Credits] to use Carmen to break all 2 subroutines on Tithe.
+  Clamatius has no further action.
+  Clamatius passes Tithe protecting HQ at position 0.
+  Clamatius will continue the run.
+  Clamatius approaches HQ.
+  Clamatius breaches HQ.
+  Clamatius accesses Seamless Launch from HQ.
+  Clamatius spends [Click] and pays 1 [Credits] to play VRcation.
+  Clamatius uses VRcation to draw 4 cards.
+  Clamatius discards Overclock from their Grip at end of turn.
+  Clamatius is ending their turn 3 with 5 [Credit] and 5 cards in their Grip.
+  ai-corp started their turn 4 with 14 [Credit] and 4 cards in HQ.
+  ai-corp makes their mandatory start of turn draw.
+  ai-corp spends [Click] to use Corp Basic Action Card to draw 1 card.
+  ai-corp spends [Click] to use Corp Basic Action Card to draw 1 card.
+  ai-corp spends [Click] and pays 0 [Credits] to install facedown Karunā protecting Server 2 (new remote).
+  ai-corp discards 1 card from HQ at end of turn.
+  ai-corp is ending their turn 4 with 14 [Credit] and 5 cards in HQ.
+  Clamatius started their turn 4 with 5 [Credit] and 5 cards in their Grip.
+  Clamatius uses Smartware Distributor to gain 1 [Credits].
+  Clamatius spends [Click] and pays 5 [Credits] to play Sure Gamble.
+  Clamatius uses Sure Gamble to gain 9 [Credits].
+  Clamatius spends [Click] and pays 0 [Credits] to play Jailbreak.
+  Clamatius uses Jailbreak to make a run on HQ.
+  Clamatius approaches Tithe protecting HQ at position 0.
+  Clamatius encounters Tithe protecting HQ at position 0.
+  Clamatius pays 2 [Credits] to use Carmen to break all 2 subroutines on Tithe.
+  Clamatius has no further action.
+  Clamatius passes Tithe protecting HQ at position 0.
+  Clamatius will continue the run.
+  Clamatius approaches HQ.
+  Clamatius uses Jailbreak to draw 1 card.
+  Clamatius breaches HQ.
+  Clamatius accesses Orbital Superiority from HQ.
+  Clamatius steals Orbital Superiority and gains 2 agenda points.
+  Clamatius accesses Manegarm Skunkworks from HQ.
+  Clamatius pays 3 [Credits] to trash Manegarm Skunkworks from HQ.
+  Clamatius spends [Click] and pays 0 [Credits] to play Jailbreak.
+  Clamatius uses Jailbreak to make a run on HQ.
+  yeah it's another jailbreak, in case you're wondering
+  :)
+  another feature for hitl would be post-tool-use sound alert or something because model turns are much slower than human. hrm
+  but here it seems more like a bug in wait
+  Clamatius approaches Tithe protecting HQ at position 0.
+  Clamatius encounters Tithe protecting HQ at position 0.
+  Clamatius pays 2 [Credits] to use Carmen to break all 2 subroutines on Tithe.
+  Clamatius has no further action.
+  Clamatius passes Tithe protecting HQ at position 0.
+  Clamatius will continue the run.
+  Clamatius approaches HQ.
+  Clamatius uses Jailbreak to draw 1 card.
+  Clamatius breaches HQ.
+  Clamatius accesses Seamless Launch from HQ.
+  Clamatius accesses Government Subsidy from HQ.
+  Clamatius spends [Click] to use Runner Basic Action Card to draw 1 card.
+  Clamatius is ending their turn 4 with 3 [Credit] and 5 cards in their Grip.
+  ai-corp started their turn 5 with 14 [Credit] and 3 cards in HQ.
+  ai-corp makes their mandatory start of turn draw.
+  ai-corp spends [Click] to use Corp Basic Action Card to draw 1 card.
+  ai-corp spends [Click] to use Corp Basic Action Card to draw 1 card.
+  ai-corp spends [Click] to use Corp Basic Action Card to gain 1 [Credits].
+  ai-corp discards 1 card from HQ at end of turn.
+  ai-corp is ending their turn 5 with 15 [Credit] and 5 cards in HQ.
+  Clamatius started their turn 5 with 3 [Credit] and 5 cards in their Grip.
+  Clamatius uses Smartware Distributor to gain 1 [Credits].
+  Clamatius spends [Click] to use Runner Basic Action Card to draw 1 card.
+  Clamatius spends [Click] and pays 1 [Credits] to install Leech.
+  Clamatius spends [Click] to make a run on Archives.
+  Clamatius will continue the run.
+  Clamatius approaches Archives.
+  Clamatius uses Leech to place 1 virus counter on itself.
+  Clamatius breaches Archives.
+  Clamatius accesses everything else in Archives.
+  Clamatius spends [Click] to use Smartware Distributor to place 3 [Credits].
+  Clamatius is ending their turn 5 with 3 [Credit] and 5 cards in their Grip.
+  ai-corp started their turn 6 with 15 [Credit] and 5 cards in HQ.
+  ai-corp makes their mandatory start of turn draw.
+  ai-corp spends [Click] and pays 4 [Credits] to play Public Trail.
+  ai-corp uses Public Trail to give the runner 1 tag.
+  hi mum! I'm on tv!
+  ai-corp spends [Click] and pays 1 [Credits] to play Retribution.
+  :{
+  ai-corp uses Retribution to trash Carmen.
+  rude
+  ai-corp spends [Click] and pays 2 [Credits] to use Corp Basic Action Card to trash Smartware Distributor.
+  ai-corp is ending their turn 6 with 8 [Credit] and 4 cards in HQ.
+  Clamatius started their turn 6 with 3 [Credit] and 5 cards in their Grip.
+  Clamatius spends [Click] to use Runner Basic Action Card to draw 1 card.
+  Clamatius spends [Click] to use Runner Basic Action Card to gain 1 [Credits].
+  Clamatius spends [Click] to use Runner Basic Action Card to gain 1 [Credits].
+  Clamatius spends [Click] to use Runner Basic Action Card to gain 1 [Credits].
+  Clamatius discards Tread Lightly from their Grip at end of turn.
+  Clamatius is ending their turn 6 with 6 [Credit] and 5 cards in their Grip.
+  ai-corp started their turn 7 with 8 [Credit] and 4 cards in HQ.
+  ai-corp makes their mandatory start of turn draw.
+  ai-corp spends [Click] to use Corp Basic Action Card to draw 1 card.
+  ai-corp spends [Click] to use Corp Basic Action Card to draw 1 card.
+  ai-corp spends [Click] to install facedown Superconducting Hub in the root of Server 2.
+  ai-corp discards 1 card from HQ at end of turn.
+  ai-corp is ending their turn 7 with 8 [Credit] and 5 cards in HQ.
+  Clamatius started their turn 7 with 6 [Credit] and 5 cards in their Grip.
+  Clamatius spends [Click] and pays 2 [Credits] to play Wildcat Strike.
+  ai-corp uses Wildcat Strike to force the Runner to gain 6 [Credits].
+  Clamatius spends [Click] to use Runner Basic Action Card to draw 1 card.
+  Clamatius spends [Click] and pays 2 [Credits] to use Runner Basic Action Card to remove 1 tag.
+  Clamatius spends [Click] and pays 1 [Credits] to play Creative Commission.
+  Clamatius uses Creative Commission to gain 5 [Credits].
+  Clamatius is ending their turn 7 with 12 [Credit] and 4 cards in their Grip.
+  ai-corp started their turn 8 with 8 [Credit] and 5 cards in HQ.
+  ai-corp makes their mandatory start of turn draw.
+  ai-corp spends [Click] and pays 1 [Credits] to play Seamless Launch.
+  ai-corp uses Seamless Launch to place 2 advancement counters on facedown Superconducting Hub in Server 2.
+  ai-corp spends [Click] and pays 1 [Credits] to use Corp Basic Action Card to advance a card in Server 2.
+  ai-corp scores Superconducting Hub and gains 1 agenda point.
+  ai-corp uses Superconducting Hub to draw 2 cards.
+  ai-corp spends [Click] and pays 1 [Credits] to install facedown Funhouse protecting HQ.
+  ai-corp is ending their turn 8 with 5 [Credit] and 6 cards in HQ.
+  Clamatius started their turn 8 with 12 [Credit] and 4 cards in their Grip.
+  Clamatius spends [Click] and pays 3 [Credits] to install Unity.
+  Clamatius spends [Click] and pays 4 [Credits] to install Conduit.
+  Clamatius spends [Click] to make a run on R&D.
+  Clamatius approaches Diviner protecting R&D at position 0.
+  Clamatius encounters Diviner protecting R&D at position 0.
+  Clamatius spends 1 hosted virus counter from on Leech to use Leech to give -1 strength to Diviner.
+  Clamatius pays 2 [Credits] to increase the strength of Unity to 2 and break all  subroutines on Diviner.
+  Clamatius has no further action.
+  Clamatius passes Diviner protecting R&D at position 0.
+  Clamatius will continue the run.
+  Clamatius approaches R&D.
+  Clamatius uses Leech to place 1 virus counter on itself.
+  Clamatius breaches R&D.
+  Clamatius accesses an unseen card from R&D.
+  Clamatius steals Offworld Office and gains 2 agenda points.
+  Clamatius wins the game.
+  Clamatius uses Conduit to place 1 virus counter on itself.
+  gg wp
+  rough draw from the looks of it
+  GG! Well played — the Public Trail/Retribution rig wipe bought me three turns, but Unity+Conduit rebuilt faster than I could fortify R&D. 7-0, you swept the pair. (Also: two more wait-didn't-wake-on-run-start data points this game, plus your chat-wake and sound-alert notes — logging all three.)
+

--- a/dev/nan/docs/game4.nan
+++ b/dev/nan/docs/game4.nan
@@ -1,0 +1,18 @@
+Corp T1 [0-0] {C5 R5}: Hedge Fund →C9; ice R&D; ice HQ
+Runner T1 [0-0] {C9 R5}: run R&D; rez Karunā@0 R&D →C5; encounter Karunā@0; trash Mutual Favor and Overclock due to net damage; VRcation →R4; Creative Commission →R8
+Corp T2 [0-0] {C5 R8}: ice S1; install S1; advance S1 →C4
+Runner T2 [0-0] {C4 R8}: run S1; rez Tithe@0 S1 →C3; encounter Tithe@0; trash Conduit due to net damage; →C4; breach S1; access Offworld Office; steal Offworld Office; install Carmen →R5; Jailbreak; run R&D; encounter Karunā@0; →R1; breach R&D; access ?; access Tithe; access ?; access Public Trail; credit →R2
+Corp T3 [0-2] {C4 R2}: install S1; advance S1 →C3; credit →C4
+Runner T3 [0-2] {C4 R2}: VRcation →R1; credit →R2; run S1; encounter Tithe@0; →R0; breach S1; access Urtica Cipher; trash Overclock, Red Team, and Wildcat Strike due to net damage
+Corp T4 [0-2] {C4 R0}: draw; install S1; trash a card in Server 1; ice R&D →C3
+Runner T4 [0-2] {C3 R0}: install Smartware Distributor; use Smartware Distributor; draw; credit →R1; rez Nico Campaign S1 →C1
+Corp T5 [0-2] {C1 R1}: →C4; draw; draw; credit →C5
+Runner T5 [0-2] {C5 R1}: →R2; credit →R3; install Pennyshaver →R0; draw; draw
+Corp T6 [0-2] {C5 R0}: →C8; ice S2; ice S2 →C7; install S2
+Runner T6 [0-2] {C7 R0}: →R1; credit →R2; credit →R3; credit →R4; draw
+Corp T7 [0-2] {C7 R4}: →C10; trash Nico Campaign and draws 1 card; advance S2 →C9; advance S2 →C8; advance S2 →C7; score Superconducting Hub
+Runner T7 [1-2] {C7 R4}: →R5; Sure Gamble →R9; install Docklands Pass →R7; run HQ; rez Diviner@0 HQ →C5; encounter Diviner@0; trash Leech due to net damage; draw
+Corp T8 [1-2] {C5 R7}: Hedge Fund →C9; install S2; advance S2 →C8
+Runner T8 [1-2] {C8 R7}: Sure Gamble →R11; Tread Lightly →R10; run S2; rez Diviner@1 S2 →C3; encounter Diviner@1; trash Smartware Distributor due to net damage; breach S2; access Offworld Office; steal Offworld Office; draw; draw
+Corp T9 [1-4] {C3 R10}: Predictive Planogram →C6; credit →C7; credit →C8
+Runner T9 [1-4] {C8 R10}: install Unity →R7; Jailbreak; run HQ; encounter Diviner@0; →R5; breach HQ; access Palisade; access Send a Message; steal Send a Message; rez Brân 1.0@0 S2; access Palisade

--- a/dev/nan/docs/game5.nan
+++ b/dev/nan/docs/game5.nan
@@ -1,0 +1,16 @@
+Corp T1 [0-0] {C5 R5}: ice R&D; ice HQ; credit →C6
+Runner T1 [0-0] {C6 R5}: draw; draw; Sure Gamble →R9; Creative Commission →R13
+Corp T2 [0-0] {C6 R13}: install S1; rez Regolith Mining License S1 →C4; use Regolith Mining License →C7; use Regolith Mining License →C10
+Runner T2 [0-0] {C10 R13}: draw; run S1; breach S1; access Regolith Mining License; trash Regolith Mining License →R10; install Smartware Distributor; use Smartware Distributor
+Corp T3 [0-0] {C10 R10}: draw; Predictive Planogram; Hedge Fund →C14; discard 2 cards
+Runner T3 [0-0] {C14 R10}: →R11; run HQ; rez Tithe@0 HQ →C13; encounter Tithe@0; trash DZMZ Optimizer due to net damage; →C14; breach HQ; access Send a Message; steal Send a Message; rez Diviner@0 R&D; Mutual Favor; install Carmen →R8; run HQ; encounter Tithe@0; →R6; breach HQ; access Seamless Launch; VRcation →R5
+Corp T4 [0-3] {C14 R5}: draw; draw; ice S2; discard 1 card
+Runner T4 [0-3] {C14 R5}: →R6; Sure Gamble →R10; Jailbreak; run HQ; encounter Tithe@0; →R8; breach HQ; access Orbital Superiority; steal Orbital Superiority; access Manegarm Skunkworks; trash Manegarm Skunkworks →R5; Jailbreak; run HQ; encounter Tithe@0; →R3; breach HQ; access Seamless Launch; access Government Subsidy; draw
+Corp T5 [0-5] {C14 R3}: draw; draw; credit →C15; discard 1 card
+Runner T5 [0-5] {C15 R3}: →R4; draw; install Leech →R3; run Archives; breach Archives; use Smartware Distributor
+Corp T6 [0-5] {C15 R3}: Public Trail →C11; Retribution →C10; trash Carmen; trash Smartware Distributor →C8
+Runner T6 [0-5] {C8 R3}: draw; credit →R4; credit →R5; credit →R6
+Corp T7 [0-5] {C8 R6}: draw; draw; install S2; discard 1 card
+Runner T7 [0-5] {C8 R6}: Wildcat Strike →R10; draw; →R8; Creative Commission →R12
+Corp T8 [0-5] {C8 R12}: Seamless Launch →C7; advance S2 →C6; score Superconducting Hub; ice HQ →C5
+Runner T8 [1-5] {C5 R12}: install Unity →R9; install Conduit →R5; run R&D; encounter Diviner@0; →R3; breach R&D; access ?; steal Offworld Office

--- a/dev/nan/docs/nan_spec.md
+++ b/dev/nan/docs/nan_spec.md
@@ -7,8 +7,23 @@ NAN is a concise, human-readable, and machine-parsable format for recording Netr
 - The file consists of a series of turns.
 - Each turn starts with the player and turn number: `Player T#:`.
 - Optional score checkpoint in header: `Player T# [CorpScore-RunnerScore]:`.
+- Optional credit checkpoint in header: `Player T# [0-2] {C14 R10}:` — both
+  players' credit pools at the start of the turn (after the turn owner's
+  start-of-turn income/checkpoint).
 - Actions within a turn are separated by semicolons `;`.
 - The file ends with a newline.
+
+## Credit Annotations
+
+Actions that change a credit pool carry the acting side's *new total*:
+`credit →C6`, `Hedge Fund →C14`, `rez Karunā@0 R&D →C5` (a Corp rez during
+the Runner's turn shows the Corp total). Costs and payoffs on the same
+action fold together: `Sure Gamble →R9` is net (-5 play, +9 gain). A credit
+change with no rendered action (drip income, tag removal, subroutine
+credits) appears as a bare total: `→R7`. Totals are recomputed from log
+deltas and resynced against the authoritative "started/ending their turn
+with N [Credit]" log lines; disagreements are corrected and reported on
+stderr at generation time.
 
 ## Syntax
 

--- a/dev/nan/flat_log_to_nan.py
+++ b/dev/nan/flat_log_to_nan.py
@@ -1,0 +1,42 @@
+"""Adapter: flat send_command log dump -> NAN via log_parser.
+
+For games where the jinteki replay doesn't persist (a human web-UI seat
+can't be made to leave by save-replay.sh, so the replay never flushes to
+mongo), the AI client's cached log is the only transcript:
+
+    ./dev/send_command <side> log 300 > gameN_log.txt
+    python3 flat_log_to_nan.py gameN_log.txt > docs/gameN.nan
+
+This rebuilds the actor/[ts]/text triples that log_parser expects from the
+flat client log, exactly the way json_replay_to_nan.extract_log does it.
+"""
+import re
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from log_parser import parse_log_lines, generate_dsl
+
+
+def flat_to_triples(path):
+    lines = []
+    with open(path) as f:
+        for raw in f:
+            text = raw.strip()
+            if not text or text == "[hr]":
+                continue
+            m = re.match(r"([\w.-]+) ", text)
+            actor = m.group(1) if m else "System"
+            lines.append(actor)
+            lines.append("[00:00:00]")
+            lines.append(text)
+    return lines
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python flat_log_to_nan.py <flat_log.txt>", file=sys.stderr)
+        sys.exit(1)
+    triples = flat_to_triples(sys.argv[1])
+    events = parse_log_lines(triples)
+    print(generate_dsl(events))

--- a/dev/nan/log_parser.py
+++ b/dev/nan/log_parser.py
@@ -57,6 +57,65 @@ def parse_log(log_path):
         lines = [line.strip() for line in f.readlines()]
     return parse_log_lines(lines)
 
+_CREDIT_GAIN_RE = re.compile(r"gains? (\d+) \[Credit")
+_CREDIT_PAY_RE = re.compile(r"pays? (\d+) \[Credit")
+_CREDIT_LOSE_RE = re.compile(r"loses? (\d+) \[Credit")
+_CREDIT_CHECKPOINT_RE = re.compile(
+    r"(?:started|is ending) (?:his|her|their) turn \d+ with (\d+) \[Credit"
+)
+
+
+def _strip_quoted(action_text):
+    """Drop quoted card text: "resolves N unbroken subroutines on X
+    ("[subroutine] ... pay 4 [Credits]" ...)" quotes costs verbatim without
+    anyone paying them."""
+    return re.sub(r'"[^"]*"', "", action_text)
+
+
+def extract_credit_delta(action_text):
+    """Extract the acting player's credit change from a log action text.
+
+    Returns ("set", n) for authoritative turn-start/turn-end checkpoints
+    ("started their turn 3 with 10 [Credit]"), ("delta", n) for a net
+    gain/pay/lose amount, or None when the line doesn't touch credits.
+    Amounts hosted on cards (e.g. "place 3 [Credits]") are not the player's
+    pool and don't match any of these patterns.
+    """
+    action_text = _strip_quoted(action_text)
+    m = _CREDIT_CHECKPOINT_RE.search(action_text)
+    if m:
+        return ("set", int(m.group(1)))
+
+    net = 0
+    found = False
+    for m in _CREDIT_GAIN_RE.finditer(action_text):
+        net += int(m.group(1))
+        found = True
+    for m in _CREDIT_PAY_RE.finditer(action_text):
+        net -= int(m.group(1))
+        found = True
+    for m in _CREDIT_LOSE_RE.finditer(action_text):
+        net -= int(m.group(1))
+        found = True
+    return ("delta", net) if found else None
+
+
+_CREDIT_BENEFICIARY_RE = re.compile(
+    r"the (Runner|Corp) (?:to )?(?:gains?|loses?|pays?) \d+ \[Credit"
+)
+
+
+def credit_beneficiary(action_text):
+    """Side named as the credit recipient/victim, when it isn't the actor.
+
+    Covers third-party phrasings like "uses Wildcat Strike to force the
+    Runner to gain 6 [Credits]" where the log actor (ai-corp) is not whose
+    pool changes. Returns "Runner", "Corp", or None.
+    """
+    m = _CREDIT_BENEFICIARY_RE.search(_strip_quoted(action_text))
+    return m.group(1) if m else None
+
+
 def simplify_action(action_text):
     # Regex patterns
     
@@ -92,20 +151,20 @@ def simplify_action(action_text):
         return f"{match.group(1)}"
         
     # Install ICE
-    match = re.search(r"to install ice protecting (.+)\.$", action_text)
+    match = re.search(r"to install (?:ice|facedown .+) protecting (.+)\.$", action_text)
     if match:
         # Clean server name "Server 1 (new remote)" -> "S1"
         server = match.group(1).split(" (")[0].replace("Server ", "S")
         return f"ice {server}"
         
     # Install Card (Asset/Upgrade/Agenda)
-    match = re.search(r"to install a card in the root of (.+)\.$", action_text)
+    match = re.search(r"to install (?:a card|facedown .+) in the root of (.+)\.$", action_text)
     if match:
         server = match.group(1).split(" (")[0].replace("Server ", "S")
         return f"install {server}"
 
     # Install Program/Hardware/Resource
-    match = re.search(r"to install (.+)\.$", action_text)
+    match = re.search(r"to install (.+?)(?: from the Stack)?\.$", action_text)
     if match:
         card = match.group(1)
         # Filter out "ice protecting" which is caught above, but just in case
@@ -243,14 +302,26 @@ def generate_dsl(events):
     runner_score = 0
     turn_start_score = (0, 0)
 
+    # Running credit pools, resynced on turn-start/turn-end checkpoint lines.
+    credits = {"Corp": 5, "Runner": 5}
+    turn_start_credits = (5, 5)
+    # Side of the last appended action that carries a credit annotation, so a
+    # follow-up effect line ("uses Sure Gamble to gain 9 [Credits]") that
+    # simplifies to None folds its delta into its cause instead of dangling.
+    last_annotated_side = None
+
     # Track username -> side mapping as we discover it
     username_to_side = {}
 
     def flush_turn():
         if turn_actions:
             # Join actions with semicolon
-            # Format: Player T# [Corp-Runner]: ...
-            header = f"{active_player} T{current_turn} [{turn_start_score[0]}-{turn_start_score[1]}]"
+            # Format: Player T# [Corp-Runner] {Ccredits Rcredits}: ...
+            header = (
+                f"{active_player} T{current_turn}"
+                f" [{turn_start_score[0]}-{turn_start_score[1]}]"
+                f" {{C{turn_start_credits[0]} R{turn_start_credits[1]}}}"
+            )
             dsl_lines.append(f"{header}: {'; '.join(turn_actions)}")
             turn_actions.clear()
 
@@ -265,20 +336,13 @@ def generate_dsl(events):
         detected_side = detect_side_from_action(action)
         if detected_side and actor and actor not in username_to_side:
             username_to_side[actor] = detected_side
-            # Also map the other player
-            other_side = "Runner" if detected_side == "Corp" else "Corp"
-            for other_actor in username_to_side:
-                if username_to_side[other_actor] != detected_side:
-                    break
-            # We'll fill in the other side when we see them
 
         simplified = simplify_action(action)
+        credit_change = extract_credit_delta(action)
 
-        if not simplified:
-            continue
-
-        if simplified.startswith("Turn"):
+        if simplified and simplified.startswith("Turn"):
             flush_turn()
+            last_annotated_side = None
             parts = simplified.split(" ")
             current_turn = parts[1]
 
@@ -296,9 +360,60 @@ def generate_dsl(events):
                 else:
                     # Alternate from last known
                     active_player = "Runner" if active_player == "Corp" else "Corp"
+                username_to_side.setdefault(actor, active_player)
 
-            # Capture score at start of this turn
+            # The turn line itself is the authoritative credit checkpoint
+            # ("started their turn N with X [Credit]").
+            if credit_change and credit_change[0] == "set":
+                credits[active_player] = credit_change[1]
+
+            # Capture score and credits at start of this turn
             turn_start_score = (corp_score, runner_score)
+            turn_start_credits = (credits["Corp"], credits["Runner"])
+            continue
+
+        # Attribute the credit change: an explicitly named beneficiary ("force
+        # the Runner to gain 6 [Credits]") wins over the log actor. Otherwise
+        # fall back to the turn owner, which is right for everything except
+        # opponent paid effects — and those (rez, trash-on-access) are
+        # side-detected.
+        side = (
+            credit_beneficiary(action)
+            or username_to_side.get(actor)
+            or detected_side
+            or active_player
+        )
+        annotation = None
+        if credit_change and side:
+            kind, amount = credit_change
+            if kind == "set":
+                if credits[side] != amount:
+                    print(
+                        f"credit drift: {side} computed {credits[side]}, "
+                        f"log says {amount} ({action})",
+                        file=sys.stderr,
+                    )
+                    credits[side] = amount
+            elif amount != 0:
+                credits[side] += amount
+                annotation = f"→{side[0]}{credits[side]}"
+
+        if not simplified:
+            if annotation:
+                if last_annotated_side == side and turn_actions:
+                    # Effect of the previous action: refresh its total (the
+                    # cause may carry no annotation yet if it was zero-cost).
+                    if re.search(r"→[CR]\d+$", turn_actions[-1]):
+                        turn_actions[-1] = re.sub(
+                            r"→[CR]\d+$", annotation, turn_actions[-1]
+                        )
+                    else:
+                        turn_actions[-1] += f" {annotation}"
+                else:
+                    # No rendered cause to attach to (drip income, tag
+                    # removal, ...): emit the new total on its own.
+                    turn_actions.append(annotation)
+                    last_annotated_side = side
             continue
 
         # Track score updates
@@ -311,9 +426,19 @@ def generate_dsl(events):
                     corp_score += points
                 else:
                     runner_score += points
-            
-        turn_actions.append(simplified)
-        
+
+        if annotation:
+            turn_actions.append(f"{simplified} {annotation}")
+            last_annotated_side = side
+        else:
+            turn_actions.append(simplified)
+            # A zero-delta credit line ("pays 0 [Credits] to play X") is
+            # still a foldable cause for a follow-up payoff line.
+            is_zero_credit_action = (
+                credit_change is not None and credit_change[0] == "delta"
+            )
+            last_annotated_side = side if is_zero_credit_action else None
+
     flush_turn()
     return "\n".join(dsl_lines)
 

--- a/dev/nan/nan_parser.py
+++ b/dev/nan/nan_parser.py
@@ -18,9 +18,12 @@ class NANParser:
         return game_record
 
     def parse_line(self, line):
-        # Format: "Player T# [CorpScore-RunnerScore]: Action1; Action2; ..."
-        # Score checkpoint is optional
-        match = re.match(r"(Corp|Runner) T(\d+)(?: \[(\d+)-(\d+)\])?: (.+)", line)
+        # Format: "Player T# [CorpScore-RunnerScore] {Cn Rn}: Action1; ..."
+        # Score and credit checkpoints are optional
+        match = re.match(
+            r"(Corp|Runner) T(\d+)(?: \[(\d+)-(\d+)\])?(?: \{C(\d+) R(\d+)\})?: (.+)",
+            line,
+        )
         if not match:
             print(f"Warning: Could not parse line: {line}")
             return None
@@ -29,7 +32,9 @@ class NANParser:
         turn_number = int(match.group(2))
         corp_score = int(match.group(3)) if match.group(3) else None
         runner_score = int(match.group(4)) if match.group(4) else None
-        actions_str = match.group(5)
+        corp_credits = int(match.group(5)) if match.group(5) else None
+        runner_credits = int(match.group(6)) if match.group(6) else None
+        actions_str = match.group(7)
 
         actions = [self.parse_action(a.strip()) for a in actions_str.split(";")]
 
@@ -42,19 +47,35 @@ class NANParser:
         if corp_score is not None:
             result["score"] = {"corp": corp_score, "runner": runner_score}
 
+        if corp_credits is not None:
+            result["credits"] = {"corp": corp_credits, "runner": runner_credits}
+
         return result
 
     def parse_action(self, action_str):
+        # Peel a trailing credit annotation: "rez Palisade@0 S1 →C4" or a
+        # standalone total "→R7" (credit change with no rendered action).
+        credits_after = None
+        match = re.match(r"(.*?)\s*→([CR])(\d+)$", action_str)
+        if match:
+            credits_after = (match.group(2), int(match.group(3)))
+            stripped = match.group(1)
+        else:
+            stripped = action_str
+
         # Simple verb-object parsing
-        parts = action_str.split(" ", 1)
-        verb = parts[0]
+        parts = stripped.split(" ", 1) if stripped else [""]
+        verb = parts[0] or None
         target = parts[1] if len(parts) > 1 else None
-        
-        return {
+
+        result = {
             "raw": action_str,
             "verb": verb,
             "target": target
         }
+        if credits_after is not None:
+            result["credits_after"] = credits_after
+        return result
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:

--- a/dev/nan/nan_renderer.py
+++ b/dev/nan/nan_renderer.py
@@ -18,19 +18,23 @@ class NANRenderer:
             self.process_turn(line)
             
     def process_turn(self, line):
-        # Format: "Player T# [CorpScore-RunnerScore]: Actions" or "Player T#: Actions"
-        match = re.match(r"(Corp|Runner) T(\d+)(?: \[(\d+)-(\d+)\])?: (.+)", line)
+        # Format: "Player T# [CorpScore-RunnerScore] {Cn Rn}: Actions"
+        # (score and credit checkpoints optional)
+        match = re.match(
+            r"(Corp|Runner) T(\d+)(?: \[(\d+)-(\d+)\])?(?: \{C(\d+) R(\d+)\})?: (.+)",
+            line,
+        )
         if not match: return
-        
+
         player = match.group(1)
         turn = int(match.group(2))
-        
+
         # If scores are present in header, sync them
         if match.group(3) and match.group(4):
             self.corp_score = int(match.group(3))
             self.runner_score = int(match.group(4))
-            
-        actions_str = match.group(5)
+
+        actions_str = match.group(7)
         self.current_turn = turn
         actions = [a.strip() for a in actions_str.split(';')]
         
@@ -39,7 +43,13 @@ class NANRenderer:
 
     def apply_action(self, player, action):
         # Basic state tracking
-        
+
+        # Credit annotations ("credit →C6") are bookkeeping, not state the
+        # renderer tracks; a bare "→R7" token is a whole action's worth.
+        action = re.sub(r"\s*→[CR]\d+$", "", action)
+        if not action:
+            return
+
         # Install ICE
         # "ice S1" -> adds unrezzed ice to S1
         if action.startswith("ice "):

--- a/dev/nan/tests/test_nan.py
+++ b/dev/nan/tests/test_nan.py
@@ -5,7 +5,13 @@ import os
 # Add parent dir to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from log_parser import simplify_action, detect_side_from_action, parse_log_lines, generate_dsl
+from log_parser import (
+    simplify_action,
+    detect_side_from_action,
+    parse_log_lines,
+    generate_dsl,
+    extract_credit_delta,
+)
 from nan_parser import NANParser
 from nan_renderer import NANRenderer
 
@@ -146,6 +152,247 @@ class TestNANRenderer:
         renderer.process_turn("Corp T3 [2-1]: credit")
         assert renderer.corp_score == 2
         assert renderer.runner_score == 1
+
+
+class TestExtractCreditDelta:
+    """Credit deltas / checkpoints parsed from raw log action text."""
+
+    def test_basic_action_gain(self):
+        action = "spends [Click] to use Corp Basic Action Card to gain 1 [Credits]."
+        assert extract_credit_delta(action) == ("delta", 1)
+
+    def test_pay_to_play(self):
+        action = "spends [Click] and pays 5 [Credits] to play Sure Gamble."
+        assert extract_credit_delta(action) == ("delta", -5)
+
+    def test_use_to_gain(self):
+        action = "uses Sure Gamble to gain 9 [Credits]."
+        assert extract_credit_delta(action) == ("delta", 9)
+
+    def test_pay_to_rez(self):
+        action = "pays 4 [Credits] to rez Karunā protecting R&D at position 0."
+        assert extract_credit_delta(action) == ("delta", -4)
+
+    def test_lose_credits(self):
+        action = "loses 2 [Credits]."
+        assert extract_credit_delta(action) == ("delta", -2)
+
+    def test_agenda_points_not_credits(self):
+        action = "steals Offworld Office and gains 2 agenda points."
+        assert extract_credit_delta(action) is None
+
+    def test_no_credits(self):
+        action = "spends [Click] to make a run on HQ."
+        assert extract_credit_delta(action) is None
+
+    def test_turn_start_checkpoint(self):
+        action = "started their turn 3 with 10 [Credit] and 5 cards in their Grip."
+        assert extract_credit_delta(action) == ("set", 10)
+
+    def test_turn_end_checkpoint(self):
+        action = "is ending their turn 5 with 3 [Credit] and 5 cards in their Grip."
+        assert extract_credit_delta(action) == ("set", 3)
+
+    def test_zero_delta_still_reported(self):
+        action = "spends [Click] and pays 0 [Credits] to play Jailbreak."
+        assert extract_credit_delta(action) == ("delta", 0)
+
+    def test_quoted_subroutine_text_not_a_payment(self):
+        # "resolves unbroken subroutines" lines quote card text verbatim;
+        # nothing was actually paid or gained.
+        action = ('resolves 2 unbroken subroutines on Funhouse '
+                  '("[subroutine] Give the Runner 1 tag unless they pay '
+                  '4 [Credits]" and "[subroutine] End the run").')
+        assert extract_credit_delta(action) is None
+
+    def test_quoted_text_not_a_beneficiary(self):
+        from log_parser import credit_beneficiary
+        action = ('resolves 1 unbroken subroutine on Lamplighter '
+                  '("[subroutine] The Runner loses 2 [Credits]").')
+        assert credit_beneficiary(action) is None
+
+
+class TestCreditBeneficiary:
+    """Lines where the actor and the credit recipient differ."""
+
+    def test_forced_gain_names_the_runner(self):
+        from log_parser import credit_beneficiary
+        action = "uses Wildcat Strike to force the Runner to gain 6 [Credits]."
+        assert credit_beneficiary(action) == "Runner"
+
+    def test_forced_loss_names_the_corp(self):
+        from log_parser import credit_beneficiary
+        action = "uses Diversion of Funds to force the Corp to lose 5 [Credits]."
+        assert credit_beneficiary(action) == "Corp"
+
+    def test_plain_action_has_no_beneficiary(self):
+        from log_parser import credit_beneficiary
+        action = "spends [Click] and pays 5 [Credits] to play Sure Gamble."
+        assert credit_beneficiary(action) is None
+
+
+class TestOwnSideInstallPhrasing:
+    """Own-seat logs name the installed card; NAN stays canonical."""
+
+    def test_facedown_ice_install(self):
+        action = "spends [Click] and pays 0 [Credits] to install facedown Diviner protecting R&D."
+        assert simplify_action(action) == "ice R&D"
+
+    def test_facedown_root_install(self):
+        action = "spends [Click] to install facedown Superconducting Hub in the root of Server 2 (new remote)."
+        assert simplify_action(action) == "install S2"
+
+    def test_install_from_stack_suffix_stripped(self):
+        action = "pays 3 [Credits] to install Carmen from the Stack."
+        assert simplify_action(action) == "install Carmen"
+
+
+def _triples(texts):
+    """Build log_parser input lines (actor/timestamp/action) from action texts.
+
+    Actor is inferred from the leading token of the text, mirroring
+    json_replay_to_nan.extract_log.
+    """
+    import re as _re
+    lines = []
+    for text in texts:
+        m = _re.match(r"([\w.-]+) ", text)
+        actor = m.group(1) if m else "System"
+        lines.append(actor)
+        lines.append("[00:00:00]")
+        lines.append(text)
+    return lines
+
+
+class TestCreditTrackingDsl:
+    """generate_dsl emits credit checkpoints in headers and per-action totals."""
+
+    def _nan(self, texts):
+        return generate_dsl(parse_log_lines(_triples(texts)))
+
+    def test_header_credit_checkpoint(self):
+        nan = self._nan([
+            "ai-corp started their turn 1 with 5 [Credit] and 5 cards in HQ.",
+            "ai-corp spends [Click] to use Corp Basic Action Card to gain 1 [Credits].",
+        ])
+        assert nan.startswith("Corp T1 [0-0] {C5 R5}:")
+        assert "credit →C6" in nan
+
+    def test_annotation_on_play_cost(self):
+        nan = self._nan([
+            "ai-corp started their turn 1 with 5 [Credit] and 5 cards in HQ.",
+            "ai-runner started their turn 1 with 5 [Credit] and 5 cards in their Grip.",
+            "ai-runner spends [Click] and pays 5 [Credits] to play Sure Gamble.",
+            "ai-runner uses Sure Gamble to gain 9 [Credits].",
+        ])
+        # The dropped "uses Sure Gamble to gain 9" line folds its delta into
+        # the rendered play action: 5 - 5 + 9 = 9.
+        assert "Sure Gamble →R9" in nan
+        assert "→R0" not in nan
+
+    def test_checkpoint_resyncs_running_total(self):
+        # Deliberately inconsistent: log says turn 2 starts with 20.
+        nan = self._nan([
+            "ai-corp started their turn 1 with 5 [Credit] and 5 cards in HQ.",
+            "ai-corp spends [Click] to use Corp Basic Action Card to gain 1 [Credits].",
+            "ai-runner started their turn 1 with 5 [Credit] and 5 cards in their Grip.",
+            "ai-corp started their turn 2 with 20 [Credit] and 5 cards in HQ.",
+            "ai-corp spends [Click] to use Corp Basic Action Card to gain 1 [Credits].",
+        ])
+        rows = nan.splitlines()
+        assert rows[-1].startswith("Corp T2 [0-0] {C20 R5}:")
+        assert "credit →C21" in rows[-1]
+
+    def test_standalone_token_for_dropped_credit_line(self):
+        # Drip income at turn start: the "uses X to gain" line simplifies to
+        # None and nothing rendered precedes it, so a bare total is emitted.
+        nan = self._nan([
+            "ai-corp started their turn 1 with 5 [Credit] and 5 cards in HQ.",
+            "ai-runner started their turn 1 with 6 [Credit] and 5 cards in their Grip.",
+            "ai-runner uses Smartware Distributor to gain 1 [Credits].",
+            "ai-runner spends [Click] to make a run on HQ.",
+        ])
+        row = nan.splitlines()[-1]
+        assert "{C5 R6}" in row
+        assert "→R7; run HQ" in row
+
+    def test_zero_delta_not_annotated(self):
+        nan = self._nan([
+            "ai-corp started their turn 1 with 5 [Credit] and 5 cards in HQ.",
+            "ai-runner started their turn 1 with 5 [Credit] and 5 cards in their Grip.",
+            "ai-runner spends [Click] and pays 0 [Credits] to play Jailbreak.",
+        ])
+        assert "Jailbreak" in nan
+        assert "Jailbreak →" not in nan
+
+    def test_zero_cost_play_still_folds_its_payoff(self):
+        # "pays 0 to play X" then "uses X to gain 3": the play is a rendered
+        # credit-involving cause, so the payoff attaches to it.
+        nan = self._nan([
+            "ai-corp started their turn 1 with 5 [Credit] and 5 cards in HQ.",
+            "ai-corp spends [Click] and pays 0 [Credits] to play Predictive Planogram.",
+            "ai-corp uses Predictive Planogram to gain 3 [Credits].",
+        ])
+        assert "Predictive Planogram →C8" in nan
+        assert "; →C8" not in nan
+
+    def test_forced_gain_credits_the_beneficiary(self):
+        # ai-corp is the actor but the Runner receives the credits.
+        nan = self._nan([
+            "ai-corp started their turn 1 with 5 [Credit] and 5 cards in HQ.",
+            "ai-runner started their turn 1 with 5 [Credit] and 5 cards in their Grip.",
+            "ai-runner spends [Click] and pays 2 [Credits] to play Wildcat Strike.",
+            "ai-corp uses Wildcat Strike to force the Runner to gain 6 [Credits].",
+        ])
+        row = nan.splitlines()[-1]
+        # -2 to play, +6 forced gain folded in: net →R9, charged to the Runner.
+        assert "Wildcat Strike →R9" in row
+        assert "→C" not in row.split(":", 1)[1]
+
+    def test_opponent_action_annotated_with_own_side(self):
+        # Corp rezzes ice during the Runner's turn: annotation is Corp's total.
+        nan = self._nan([
+            "ai-corp started their turn 1 with 5 [Credit] and 5 cards in HQ.",
+            "ai-corp spends [Click] to use Corp Basic Action Card to gain 1 [Credits].",
+            "ai-runner started their turn 1 with 5 [Credit] and 5 cards in their Grip.",
+            "ai-runner spends [Click] to make a run on HQ.",
+            "ai-corp pays 1 [Credits] to rez Tithe protecting HQ at position 0.",
+        ])
+        row = nan.splitlines()[-1]
+        assert "rez Tithe@0 HQ →C5" in row
+
+
+class TestCreditAnnotationsRoundTrip:
+    """Parser and renderer accept credit-annotated NAN."""
+
+    def test_parse_header_with_credits(self):
+        parser = NANParser()
+        result = parser.parse_line("Corp T3 [0-2] {C14 R10}: credit →C15")
+        assert result["player"] == "Corp"
+        assert result["score"]["corp"] == 0
+        assert result["credits"] == {"corp": 14, "runner": 10}
+
+    def test_parse_action_strips_annotation(self):
+        parser = NANParser()
+        action = parser.parse_action("rez Palisade@0 S1 →C4")
+        assert action["verb"] == "rez"
+        assert action["target"] == "Palisade@0 S1"
+        assert action["credits_after"] == ("C", 4)
+
+    def test_parse_standalone_credit_token(self):
+        parser = NANParser()
+        action = parser.parse_action("→R7")
+        assert action["verb"] is None
+        assert action["credits_after"] == ("R", 7)
+
+    def test_renderer_ignores_annotations(self):
+        renderer = NANRenderer()
+        renderer.parse_nan(
+            "Corp T1 [0-0] {C5 R5}: ice S1; credit →C6\n"
+            "Runner T1 [0-0] {C6 R5}: →R6; run S1; rez Palisade@0 S1 →C3"
+        )
+        assert renderer.servers["S1"][0]["name"] == "Palisade"
+        assert renderer.servers["S1"][0]["rezzed"] == True
 
 
 class TestIntegration:

--- a/dev/nan/tests/test_replay.py
+++ b/dev/nan/tests/test_replay.py
@@ -90,10 +90,11 @@ class TestEndToEnd:
         nan = generate_dsl(parse_log_lines(lines))
         rows = nan.splitlines()
 
-        assert rows[0].startswith("Corp T1 [0-0]:")
+        assert rows[0].startswith("Corp T1 [0-0] {C5 R5}:")
         assert "ice S1" in rows[0]
-        assert rows[1].startswith("Runner T1 [0-0]:")
+        # Corp clicked for a credit on T1, reflected in the Runner T1 header.
+        assert rows[1].startswith("Runner T1 [0-0] {C6 R5}:")
         assert "run R&D" in rows[1] and "steal Hostile Takeover" in rows[1]
         # Runner stole 1 point on T1, so Corp's T2 checkpoint reflects 0-1.
-        assert rows[2].startswith("Corp T2 [0-1]:")
+        assert rows[2].startswith("Corp T2 [0-1] {C5 R5}:")
         assert "score Offworld Office" in rows[2]


### PR DESCRIPTION
Adds click-by-click credit totals to NAN output, per Michael's game-1 post-mortem ask ("I think we need turn-by-turn or maybe even click-by-click credit totals when they change in NAN").

## What
- **Turn headers** get a start-of-turn credit checkpoint: `Corp T8 [1-2] {C5 R7}:`
- **Credit-changing actions** carry the acting side's new total: `rez Diviner@1 S2 →C3`. Payoff lines fold into their cause (`Sure Gamble →R9` = -5 play +9 gain)
- **Untracked-action credit changes** (drip income, tag removal, subroutine credits) emit a bare total: `→R7`
- Running totals **resync** against the authoritative "started/ending their turn with N [Credit]" lines; drift warns on stderr
- `flat_log_to_nan.py` adapter folded in from session scratchpad (human web-seat games recur, so it's now a first-class citizen)
- `docs/game4.nan` regenerated with credits; `docs/game5.nan` added (today's game 2); raw logs archived under `dev/game_logs/20260703/`

## Review
Codex guest review caught 2 real bugs, both fixed + test-pinned:
1. **CRITICAL**: quoted subroutine text (`"...unless they pay 4 [Credits]"` in resolves-subs lines) parsed as an actual payment → quoted spans now stripped before delta parsing
2. **MAJOR**: zero-cost plays (`pays 0 [Credits] to play Predictive Planogram`) couldn't receive their payoff fold → zero-delta credit actions remain foldable causes

Also fixed from real-log validation: `force the Runner to gain 6 [Credits]` (Wildcat Strike) was credited to the log actor (Corp) instead of the named beneficiary.

## Tests
64 pass (was 34). Both game docs regenerate with zero drift warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)