### PR TITLE
fix: wait handles lobby (#46) and wakes on pending ICE encounter (#47)

### DIFF
--- a/dev/src/clj/ai_core.clj
+++ b/dev/src/clj/ai_core.clj
@@ -1239,8 +1239,10 @@
    opponent run-transition; this predicate is the authoritative source
    of truth for the `wait` command (via `relevance-reason`)."
   [state side]
-  (let [my-side (keyword side)
-        active-player (get-in state [:game-state :active-player])
+  ;; nil-safe on side: in the lobby / pre-game the seat may have no :side yet,
+  ;; and `(name nil)` would NPE (#46). No side => not our turn.
+  (when-let [my-side (keyword side)]
+   (let [active-player (get-in state [:game-state :active-player])
         my-clicks (get-in state [:game-state my-side :click] 0)
         end-turn (get-in state [:game-state :end-turn])
         turn-number (get-in state [:game-state :turn] 0)]
@@ -1252,7 +1254,7 @@
       (and end-turn (not= (name my-side) active-player))
       ;; Turn 0 with 0 clicks = post-mulligan, Corp needs to start
       ;; (Corp always goes first)
-      (and (= 0 turn-number) (= 0 my-clicks) (= my-side :corp)))))
+      (and (= 0 turn-number) (= 0 my-clicks) (= my-side :corp))))))
 
 (defn- turn-awaiting-start?
   "True when it's our turn at a boundary but the turn has NOT been started yet
@@ -1264,8 +1266,9 @@
    trying to act before starting (and so a boundary doesn't read like a stall).
    Both seats hit this confusion in the first rung-2 game (laundry-list #1)."
   [state side]
-  (let [my-side (keyword side)
-        active-player (get-in state [:game-state :active-player])
+  ;; nil-safe on side (see my-turn-to-act?): no side => no pending turn start.
+  (when-let [my-side (keyword side)]
+   (let [active-player (get-in state [:game-state :active-player])
         my-clicks (get-in state [:game-state my-side :click] 0)
         end-turn (get-in state [:game-state :end-turn])
         turn-number (get-in state [:game-state :turn] 0)]
@@ -1274,7 +1277,7 @@
            ;; Opponent ended their turn; active-player is still them until I start
            (and end-turn (not= (name my-side) active-player))
            ;; Post-mulligan turn 0: Corp goes first but hasn't started
-           (and (= 0 turn-number) (= my-side :corp))))))
+           (and (= 0 turn-number) (= my-side :corp)))))))
 
 (defn- ping-message?
   "Check if a log entry is a 'ping' wake signal.
@@ -1287,6 +1290,56 @@
     (when-let [msg-part (second (re-find #":\s*(.+)" text))]
       (= "ping" (clojure.string/lower-case (clojure.string/trim msg-part))))))
 
+(declare current-run-ice)
+
+(defn- in-active-game?
+  "True once a game has actually started: we hold a :side AND the game-state
+   reports an :active-player. False in the lobby / pre-game, where the seat may
+   have no :side yet and the turn predicates would `(name nil)` NPE (#46).
+   `wait` uses this to poll for game-start instead of crashing or steering off
+   nil turn data."
+  [state]
+  (boolean (and (:side state)
+                (get-in state [:game-state :active-player]))))
+
+(defn- runner-passed-encounter?
+  "True when the Runner has already passed priority in the current ICE
+   encounter — i.e. they have resolved their break/tank/jack-out choice and are
+   now waiting on the Corp to fire subs. The engine records encounter pass-state
+   on the current encounter, serialized to the client under
+   [:game-state :encounters :no-action]; the run also carries a SEPARATE
+   run-level :no-action for earlier phases. We check the encounter first and
+   fall back to run-level for wire-shape tolerance."
+  [state]
+  (let [enc-no-action (get-in state [:game-state :encounters :no-action])
+        run-no-action (get-in state [:game-state :run :no-action])]
+    (boolean (or (contains? #{:runner "runner"} enc-no-action)
+                 (contains? #{:runner "runner"} run-no-action)))))
+
+(defn- runner-encounter-decision-pending?
+  "True when the Runner is stopped at an ICE encounter that needs a break /
+   tank / jack-out decision from us, but which the engine did NOT surface as a
+   server :prompt — so `has-prompt?` misses it. Without this, a plain `wait`
+   sleeps the full timeout and the pending 'N unbroken sub(s) - authorization
+   required' only appears on the next `continue` (#47).
+
+   Wakes when: Runner side, encounter-ice phase, a rezzed current ICE with
+   unbroken+unfired subs, and the Runner has NOT already passed this encounter
+   (once we pass, the decision is made and we're merely waiting on the Corp to
+   fire — that is :waiting-for-opponent, not a pending decision). Strategy-level
+   pre-auth (:tank) is intentionally NOT consulted — `wait` carries no strategy,
+   and a live encounter is worth waking on regardless of how we'll resolve it."
+  [state side]
+  (boolean
+    (and (= (keyword side) :runner)
+         (= (run-phase state) "encounter-ice")
+         (let [current-ice (current-run-ice state)
+               subs (:subroutines current-ice)
+               unbroken (filter #(and (not (:broken %)) (not (:fired %))) subs)]
+           (and current-ice (:rezzed current-ice)
+                (seq unbroken)
+                (not (runner-passed-encounter? state)))))))
+
 (defn- relevance-reason
   "Determine why we should wake up (or nil if not relevant).
    Returns keyword indicating wake reason.
@@ -1295,6 +1348,9 @@
      :run-started        — a run started this poll cycle
      :has-prompt         — we have an actionable prompt (encounter, rez
                            window, paid-ability window, access decision)
+     :encounter-decision — Runner is at an ICE encounter with unbroken subs
+                           that needs a break/tank/jack-out call, but which the
+                           engine did NOT surface as a server prompt (#47)
      :run-ended          — a run that was in progress has ended
      :run-phase-change   — run still active but phase transitioned
                            (approach-ice → encounter-ice → movement →
@@ -1338,6 +1394,13 @@
        ;; We have a prompt to respond to
        has-actionable-prompt?
        :has-prompt
+
+       ;; Runner is at an ICE encounter with unbroken subs that needs our
+       ;; break/tank/jack-out decision, but which the engine did NOT model as a
+       ;; server :prompt. `has-prompt?` misses it, so wait would otherwise sleep
+       ;; through the whole encounter (#47). Ranks just below a real prompt.
+       (runner-encounter-decision-pending? state side)
+       :encounter-decision
 
        ;; Run just ended - might need cleanup
        (and initial-run-active? (not current-run-active?))
@@ -1391,9 +1454,13 @@
      (wait-for-relevant-diff {:since 847})     ;; cursor-based wait
 
    Returns a map with :status (:relevant-change | :ping | :already-advanced
-   | :timeout), :reason (keyword), :cursor (long), :run-active? (bool),
-   :has-prompt? (bool), and :new-log-entries (vector of log entries since
-   the wait began)."
+   | :timeout | :game-started), :reason (keyword), :cursor (long),
+   :run-active? (bool), :has-prompt? (bool), and :new-log-entries (vector of
+   log entries since the wait began).
+
+   Called in the lobby / pre-game (no active game yet) it polls for game-start
+   and returns :status :game-started, or :status :timeout with :reason :no-game
+   if the timeout expires still in the lobby (#46)."
   ([]
    (wait-for-relevant-diff 300))
   ([timeout-or-opts]
@@ -1405,6 +1472,42 @@
          current-cursor (state/get-cursor)
          side (:side @state/client-state)]
 
+     (cond
+       ;; Lobby / pre-game guard (#46). `wait` is often the first thing a seat
+       ;; calls after joining; if the game hasn't started there is no :side and
+       ;; the turn predicates used to `(name nil)` NPE. Honour the "wake me when
+       ;; something relevant happens" contract by polling for game-start (which
+       ;; IS the relevant event here) and waking with :game-started; if the
+       ;; timeout expires still in the lobby, return :timeout/:no-game cleanly.
+       (not (in-active-game? @state/client-state))
+       (let [deadline (+ (System/currentTimeMillis) (* timeout-seconds 1000))]
+         (when (:verbose opts)
+           (println (format "🕓 Not in an active game yet (lobby/pre-game) — waiting up to %ds for the game to start..."
+                            timeout-seconds)))
+         (loop []
+           (cond
+             (in-active-game? @state/client-state)
+             (do
+               (when (:verbose opts) (println "🎬 Game started."))
+               {:status :game-started
+                :reason :game-started
+                :cursor (state/get-cursor)
+                :new-log-entries []
+                :run-active? (run-active? @state/client-state)
+                :has-prompt? false})
+
+             (> (System/currentTimeMillis) deadline)
+             (do
+               (when (:verbose opts) (println "⏱️  Timeout - still in the lobby / no game started"))
+               {:status :timeout
+                :reason :no-game
+                :cursor (state/get-cursor)
+                :new-log-entries []})
+
+             :else
+             (do (Thread/sleep polling-delay) (recur)))))
+
+       :else
      ;; Fast path: if the cursor advanced past :since AND something we actually
      ;; care about already happened in the race window, return immediately. A
      ;; bare cursor advance with no relevant reason is NOT a wake — the cursor
@@ -1467,6 +1570,8 @@
                      (println (format "⚡ Woke up: %s" (name reason)))
                      (when (= reason :my-turn-start)
                        (println "   👉 Turn boundary: call `start-turn` before acting (0 clicks until you do)"))
+                     (when (= reason :encounter-decision)
+                       (println "   👉 ICE encounter with unbroken subs: `continue` to see options, then break / tank / jack-out"))
                      (when (= reason :game-over)
                        (let [winner (get-in current-state [:game-state :winner])]
                          (println (format "   🏁 Game over%s — stop acting; call `game-over-status` for the result, then tear down."
@@ -1524,7 +1629,7 @@
 
                ;; No change yet
                :else
-               (recur last-log-count))))))))))
+               (recur last-log-count)))))))))))
 
 ;; ============================================================================
 ;; Run Helper Functions

--- a/dev/test/ai_wait_test.clj
+++ b/dev/test/ai_wait_test.clj
@@ -137,3 +137,98 @@
           (is (= :already-advanced (:status result)))
           (is (= :game-over (:reason result))
               (str "expected :game-over, got: " result)))))))
+
+;; ---------------------------------------------------------------------------
+;; #46 — wait must not NPE in the lobby / pre-game (nil :side, no active game)
+;; ---------------------------------------------------------------------------
+
+(deftest test-wait-in-lobby-does-not-npe
+  ;; Repro for #46: calling `wait` after joining a lobby but before the game
+  ;; starts. client-state has no :side and no :game-state, so the turn
+  ;; predicates used to `(name nil)` and NPE. It must instead return cleanly.
+  (testing "wait in lobby (nil side, nil game-state) returns cleanly, no NPE"
+    (with-redefs [state/get-cursor (fn [] 0)]
+      (with-mock-state {:connected true :uid "test" :side nil :game-state nil}
+        (let [result (core/wait-for-relevant-diff {:timeout 0 :verbose false})]
+          (is (= :timeout (:status result))
+              (str "lobby wait must not NPE, got: " result))
+          (is (= :no-game (:reason result))
+              (str "lobby timeout should be flagged :no-game, got: " result)))))))
+
+(deftest test-wait-not-in-game-when-active-player-absent
+  ;; A game-state exists but no :active-player yet (still resolving the lobby /
+  ;; pre-mulligan). Treat as not-yet-started rather than acting on nil turn data.
+  (testing "game-state present but no active-player -> lobby-safe :no-game"
+    (with-redefs [state/get-cursor (fn [] 0)]
+      (with-mock-state {:connected true :uid "test" :side "runner"
+                        :game-state {:turn 0}}
+        (let [result (core/wait-for-relevant-diff {:timeout 0 :verbose false})]
+          (is (= :timeout (:status result)))
+          (is (= :no-game (:reason result))))))))
+
+;; ---------------------------------------------------------------------------
+;; #47 — wait must wake on an already-pending encounter decision (unbroken subs
+;; requiring break/tank/jack-out) that is NOT modelled as a server prompt.
+;; ---------------------------------------------------------------------------
+
+(def ^:private encounter-game-state
+  {:active-player "runner" :turn 3
+   :runner {:click 0}
+   :run {:phase "encounter-ice" :position 1 :server ["remote1"]}
+   :corp {:click 0
+          :servers {:remote1 {:ices [{:title "Tithe" :rezzed true
+                                      :subroutines [{:broken false :fired false}
+                                                    {:broken false :fired false}]}]}}}})
+
+(deftest test-wait-wakes-on-runner-encounter-decision
+  ;; Repro for #47: Runner at encounter-ice with a rezzed ICE that still has
+  ;; unbroken subs. There is no server :prompt, so the old wait slept the full
+  ;; timeout; the very next `continue` surfaced "N unbroken subs - authorization
+  ;; required". wait must now wake immediately with :encounter-decision.
+  (testing "Runner encounter with unbroken subs wakes wait (#47)"
+    (with-redefs [state/get-cursor (fn [] 10)]
+      (with-mock-state (mock-game "runner" encounter-game-state)
+        (let [result (core/wait-for-relevant-diff {:timeout 0 :verbose false})]
+          (is (= :relevant-change (:status result))
+              (str "encounter decision must wake, not time out, got: " result))
+          (is (= :encounter-decision (:reason result))
+              (str "expected :encounter-decision, got: " result)))))))
+
+(deftest test-wait-no-encounter-wake-when-runner-passed
+  ;; Once the Runner has passed priority in the encounter (encounter
+  ;; :no-action = runner), the break/tank/jack-out choice is already made and we
+  ;; are merely waiting on the Corp to fire subs — waiting-for-opponent, NOT a
+  ;; pending Runner decision. Must not re-wake as :encounter-decision (Codex
+  ;; review catch: previously suppressed on the wrong side + wrong state path).
+  (testing "Runner already passed the encounter -> no wake, times out"
+    (with-redefs [state/get-cursor (fn [] 10)]
+      (with-mock-state (mock-game "runner"
+                          (assoc encounter-game-state :encounters {:no-action "runner"}))
+        (let [result (core/wait-for-relevant-diff {:timeout 0 :verbose false})]
+          (is (= :timeout (:status result))
+              (str "runner-passed encounter must not wake, got: " result)))))))
+
+(deftest test-wait-encounter-wake-when-corp-passed
+  ;; Corp passed first (encounter :no-action = corp) but the Runner has NOT — the
+  ;; Runner can still break before their own pass ends the encounter, so this is
+  ;; a live decision and must still wake. Regression guard against suppressing on
+  ;; the corp side (the pre-review behaviour, which was backwards).
+  (testing "Corp passed, Runner has not -> still wakes :encounter-decision"
+    (with-redefs [state/get-cursor (fn [] 10)]
+      (with-mock-state (mock-game "runner"
+                          (assoc encounter-game-state :encounters {:no-action "corp"}))
+        (let [result (core/wait-for-relevant-diff {:timeout 0 :verbose false})]
+          (is (= :encounter-decision (:reason result))
+              (str "corp-passed (runner active) must still wake, got: " result)))))))
+
+(deftest test-wait-no-encounter-wake-when-subs-broken
+  ;; All subs broken -> nothing to authorize. No wake.
+  (testing "all subs broken -> no encounter wake"
+    (with-redefs [state/get-cursor (fn [] 10)]
+      (with-mock-state (mock-game "runner"
+                          (assoc-in encounter-game-state
+                                    [:corp :servers :remote1 :ices 0 :subroutines]
+                                    [{:broken true :fired false} {:broken true :fired false}]))
+        (let [result (core/wait-for-relevant-diff {:timeout 0 :verbose false})]
+          (is (= :timeout (:status result))
+              (str "all-broken encounter must not wake, got: " result)))))))


### PR DESCRIPTION
Two `send_command` polish fixes surfaced by the human-vs-Fable game (both filed by fable5), each landed red→green with a decorrelated Codex review pass.

## #46 — `wait` NPE in the lobby/pre-game
Joining a lobby and calling `wait` before the game starts NPE'd: with no `:side` yet, `my-turn-to-act?` hit `(name nil)`.

- Make `my-turn-to-act?` / `turn-awaiting-start?` nil-safe on `side`.
- Add a lobby guard to `wait-for-relevant-diff`: if there's no active game it polls for game-start (waking `:game-started`) or returns `:timeout`/`:reason :no-game` cleanly — honouring the "wake me when something relevant happens" contract and removing the shell status-polling workaround.

## #47 — `wait` slept through an already-pending ICE encounter
An encounter with unbroken subs (needing break/tank/jack-out) is client-derived, not a server `:prompt`, so `has-prompt?` missed it and `wait` burned the full timeout; the next `continue` instantly surfaced the decision.

- New `runner-encounter-decision-pending?` predicate → new `relevance-reason` wake `:encounter-decision`.

## Codex review hardening (both Major findings confirmed against engine source)
- Encounter pass-state is serialized on the current encounter (`[:game-state :encounters :no-action]`), **not** run-level `:no-action` (`diffs.clj` `encounters-summary`). Predicate now reads the encounter field, with run-level fallback for wire-shape tolerance.
- Suppress the wake only when the **Runner** has already passed (waiting on Corp to fire) — the pre-review code suppressed on the Corp side, which was backwards. Gated via `runner-passed-encounter?`.

## Tests
`ai-wait-test` +5: lobby no-NPE, no-active-player → `:no-game`, encounter wake, runner-passed suppression, corp-passed still-wakes. Full suite **384 tests / 894 assertions, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)