### PR TITLE
fix: continue-run! reads NEWEST log entries, not oldest (#52)

### DIFF
--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -375,9 +375,30 @@
 ;; Use core/current-run-ice for ICE lookup (single source of truth)
 
 (defn get-rez-event
-  "Find first rez event in log entries, or nil if none"
+  "Find first rez event in log entries, or nil if none. nil-:text safe."
   [log-entries]
-  (first (filter #(clojure.string/includes? (:text %) "rez") log-entries)))
+  (first (filter #(clojure.string/includes? (str (:text %)) "rez") log-entries)))
+
+(defn extract-run-events
+  "Scan the most recent log entries for notable run events (rez / ability /
+   subs-fired / tag-or-damage) and return them as a context map.
+
+   `log` is chronological, so we window the NEWEST entries via
+   `(take 3 (reverse log))` — the same idiom used elsewhere in this namespace
+   (see recently-passed detection ~line 749). The pre-#52 code used
+   `(take 3 log)`, which read the three OLDEST (game-start) entries, so recent
+   events were never seen from continue-run!'s handler context.
+
+   nil / missing `:text` entries are tolerated (str-wrapped), matching the
+   defensive sibling predicates in this file."
+  [log]
+  (let [recent-log (take 3 (reverse log))
+        has? (fn [entry & subs]
+               (some #(clojure.string/includes? (str (:text entry)) %) subs))]
+    {:rez-event (get-rez-event recent-log)
+     :ability-event (first (filter #(has? % "uses" "triggers") recent-log))
+     :fired-event (first (filter #(has? % "fire") recent-log))
+     :tag-damage-event (first (filter #(has? % "tag" "damage") recent-log))}))
 
 (defn normalize-side
   "Normalize a side value to string. Handles keywords, strings, booleans, and nil."
@@ -958,16 +979,11 @@
         opp-prompt (get-in client-state [:game-state (keyword opp-side) :prompt-state])
         log (get-in client-state [:game-state :log])
 
-        ;; Check for new events in recent log (last 3 entries)
-        recent-log (take 3 log)
-        rez-event (get-rez-event recent-log)
-        ability-event (first (filter #(or (clojure.string/includes? (:text %) "uses")
-                                          (clojure.string/includes? (:text %) "triggers"))
-                                    recent-log))
-        fired-event (first (filter #(clojure.string/includes? (:text %) "fire") recent-log))
-        tag-damage-event (first (filter #(or (clojure.string/includes? (:text %) "tag")
-                                             (clojure.string/includes? (:text %) "damage"))
-                                       recent-log))
+        ;; Scan the NEWEST log entries for notable run events (#52: the window
+        ;; used to read the oldest 3, so recent rez/ability/subs/tag events
+        ;; never reached the handler context).
+        {:keys [rez-event ability-event fired-event tag-damage-event]}
+        (extract-run-events log)
 
         ;; Build context map for handlers
         context {:strategy strategy

--- a/dev/test/continue_run_rez_test.clj
+++ b/dev/test/continue_run_rez_test.clj
@@ -144,6 +144,49 @@
           "Should return nil when no rez event"))))
 
 ;; =============================================================================
+;; Test: extract-run-events reads the NEWEST log entries (issue #52)
+;; =============================================================================
+;;
+;; `log` is chronological. The old code did `(take 3 log)` — the three OLDEST
+;; (game-start) entries — so any rez/ability/subs/tag event in the *recent* log
+;; was never seen from continue-run!'s handler context. These lock down that the
+;; window is the newest entries and is nil-:text safe.
+
+(deftest test-extract-run-events-reads-newest-not-oldest
+  (testing "A rez landing in the NEWEST log entries surfaces, despite older noise (#52)"
+    (let [log [{:text "Corp starts their turn"}       ; oldest — the old (take 3) window
+               {:text "Runner draws a card"}
+               {:text "Runner spends [Click] to run HQ"}
+               {:text "Approaching Tithe"}
+               {:text "Corp rezzes Tithe"}]            ; newest — the actual event
+          events (runs/extract-run-events log)]
+      (is (some? (:rez-event events))
+          "Rez in the newest entries must be detected (was missed when window took oldest 3)")
+      (is (= "Corp rezzes Tithe" (:text (:rez-event events)))))))
+
+(deftest test-extract-run-events-detects-ability-fired-tag
+  (testing "Ability / subs-fired / tag-damage events are all read from the newest window"
+    (let [ability (runs/extract-run-events
+                   [{:text "old"} {:text "old"} {:text "old"}
+                    {:text "Corp uses Rototurret to trash a program"}])
+          fired   (runs/extract-run-events
+                   [{:text "old"} {:text "old"} {:text "old"}
+                    {:text "Corp resolves 2 subroutines: fire End the run"}])
+          tag     (runs/extract-run-events
+                   [{:text "old"} {:text "old"} {:text "old"}
+                    {:text "Runner takes 1 tag"}])]
+      (is (some? (:ability-event ability)))
+      (is (some? (:fired-event fired)))
+      (is (some? (:tag-damage-event tag))))))
+
+(deftest test-extract-run-events-tolerates-nil-text
+  (testing "A log entry with nil :text does not NPE (defensive, matches sibling fns)"
+    (let [log [{:text nil} {:foo :bar} {:text "Corp rezzes Ice Wall"}]]
+      (is (= "Corp rezzes Ice Wall"
+             (:text (:rez-event (runs/extract-run-events log))))
+          "nil / missing :text entries are skipped, not fatal"))))
+
+;; =============================================================================
 ;; Test: Integration - Full Run with Rez Decision
 ;; =============================================================================
 


### PR DESCRIPTION
Closes #52.

## The bug
`continue-run!` windowed the recent log with `(take 3 log)` to detect notable run events. But `log` is **chronological**, so this read the three *oldest* (game-start) entries, not the newest. Any rez / ability / subs-fired / tag-damage event in the recent log never reached the handler context — `handle-events` could silently never fire its `:ice-rezzed` / `:ability-used` / `:subs-fired` / `:tag-or-damage` pauses. Compare the correct idiom already in this file at ~line 749: `(take 3 (reverse log))`.

Found by a multi-model review diamond (opus-4-8 + gpt-5-5 convergent, 6/6 jury) against pre-fix state cbbfccb82.

## The fix
- Extract the inline window+match block into a pure, unit-testable helper `extract-run-events`, windowing `(take 3 (reverse log))` (newest-first, matching the recently-passed idiom).
- Harden `get-rez-event` and the helper against nil/absent `:text` (str-wrapped), matching the defensive sibling predicates (issue's I2 "adjacent hardening").

## Verification
- **Red→green**: old oldest-3 window returns no rez for a newest-entry rez; new window finds it (`test-extract-run-events-reads-newest-not-oldest`).
- `continue-run-rez-test` +3 (newest-window rez, ability/fired/tag detection, nil-:text tolerance).
- Full suite: **387 tests / 900 assertions, 0 failures**.

## Review
Decorrelated Codex (gpt-5-5) pass: no Critical/Major.
- **Minor (deferred, follow-up)**: substring matching (`"fire"`/`"tag"`/`"rez"`/`"uses"`) is broad and now operational; word-boundary / event-metadata matching is a separate hardening pass — not in scope for this direction-of-window fix.
- **Nit**: window size 3 is a magic number, but it's the established idiom and the persistent-loop logic (~line 1212) explicitly depends on events scrolling out of the 3-entry window — deliberately kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)