### PR TITLE
fix: run-event classifiers match engine wording, not bare substrings (#54)

### DIFF
--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -374,10 +374,37 @@
 
 ;; Use core/current-run-ice for ICE lookup (single source of truth)
 
+;; Run-event classifiers (#54). Naive substring matching (`includes? "rez"` etc.)
+;; had two failure modes now that #52 made the window live:
+;;   1. False POSITIVES — a card name / flavor line matched a bare substring
+;;      ("Foxfire" → "fire", "Donut Taganes" → "tag", "derez" → "rez").
+;;   2. A false NEGATIVE — the engine NEVER logs the word "fire" for a firing
+;;      subroutine; the real message is "resolves N unbroken subroutine on X"
+;;      (see resolve-unbroken-subs! in game/core/ice.clj), so the old `"fire"`
+;;      matcher caught real subs *never*.
+;; These regexes anchor on the actual engine wording with word boundaries.
+(def ^:private rez-event-re
+  ;; "X rezzes <ice>" (no cost) or "X spends N to rez <ice>" (with cost).
+  ;; Word-boundaried so it excludes "derez"/"derezzes"/"rez cost" chatter.
+  #"(?i)\brezzes\b|\bto rez\b")
+(def ^:private ability-event-re #"(?i)\buses\b|\btriggers\b")
+(def ^:private fired-event-re
+  ;; The umbrella fire message is "resolves N unbroken subroutine on X". Anchor
+  ;; on "unbroken subroutine" so a Runner BREAKING subs ("use Corroder to break
+  ;; 1 subroutine on X") — which also contains "subroutine" — does NOT misfire.
+  #"(?i)\bunbroken subroutine")
+(def ^:private tag-damage-event-re #"(?i)\btags?\b|\bdamage\b")
+
+(defn- text-matches?
+  "True if entry's :text matches regex `re` (nil-:text safe)."
+  [re entry]
+  (boolean (re-find re (str (:text entry)))))
+
 (defn get-rez-event
-  "Find first rez event in log entries, or nil if none. nil-:text safe."
+  "Find first rez event in log entries, or nil if none. nil-:text safe.
+   Word-boundaried so 'derez' / 'rez cost' lines don't count as a rez (#54)."
   [log-entries]
-  (first (filter #(clojure.string/includes? (str (:text %)) "rez") log-entries)))
+  (first (filter #(text-matches? rez-event-re %) log-entries)))
 
 (defn extract-run-events
   "Scan the most recent log entries for notable run events (rez / ability /
@@ -389,16 +416,15 @@
    `(take 3 log)`, which read the three OLDEST (game-start) entries, so recent
    events were never seen from continue-run!'s handler context.
 
-   nil / missing `:text` entries are tolerated (str-wrapped), matching the
-   defensive sibling predicates in this file."
+   Classification uses word-boundaried regexes against real engine wording
+   (#54), not bare substrings, so card names / flavor / derez / sub-breaking
+   don't misclassify. nil / missing `:text` entries are tolerated."
   [log]
-  (let [recent-log (take 3 (reverse log))
-        has? (fn [entry & subs]
-               (some #(clojure.string/includes? (str (:text entry)) %) subs))]
+  (let [recent-log (take 3 (reverse log))]
     {:rez-event (get-rez-event recent-log)
-     :ability-event (first (filter #(has? % "uses" "triggers") recent-log))
-     :fired-event (first (filter #(has? % "fire") recent-log))
-     :tag-damage-event (first (filter #(has? % "tag" "damage") recent-log))}))
+     :ability-event (first (filter #(text-matches? ability-event-re %) recent-log))
+     :fired-event (first (filter #(text-matches? fired-event-re %) recent-log))
+     :tag-damage-event (first (filter #(text-matches? tag-damage-event-re %) recent-log))}))
 
 (defn normalize-side
   "Normalize a side value to string. Handles keywords, strings, booleans, and nil."

--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -394,11 +394,21 @@
   ;; 1 subroutine on X") — which also contains "subroutine" — does NOT misfire.
   #"(?i)\bunbroken subroutine")
 (def ^:private tag-damage-event-re #"(?i)\btags?\b|\bdamage\b")
+(def ^:private event-negation-re
+  ;; A line that MENTIONS an event keyword but negates/prevents it — the event
+  ;; did not actually happen, so it must not pause the run. Real engine lines:
+  ;; "Corp does not do core damage with Zed 1.0", "prevent 1 meat damage",
+  ;; "is not forced to rez", "avoid 1 tag".
+  #"(?i)\bdoes not\b|\bdo not\b|\bcannot\b|\bprevents?\b|\bavoids?\b|\bimmune\b|\bnot forced\b")
 
 (defn- text-matches?
-  "True if entry's :text matches regex `re` (nil-:text safe)."
+  "True if entry's :text matches regex `re` and is not a negation/prevention
+   line (nil-:text safe). The negation guard stops 'does not do core damage' /
+   'prevent N damage' style no-ops from surfacing as real events (#54)."
   [re entry]
-  (boolean (re-find re (str (:text entry)))))
+  (let [text (str (:text entry))]
+    (boolean (and (re-find re text)
+                  (not (re-find event-negation-re text))))))
 
 (defn get-rez-event
   "Find first rez event in log entries, or nil if none. nil-:text safe.
@@ -883,7 +893,12 @@
          :message reason}))))
 
 (defn handle-events
-  "Priority 4: Pause for important events (rez, abilities, subs, damage)"
+  "Priority 4: Pause for important events (rez, subs, abilities, damage).
+   Order is most-specific-first: a firing subroutine and its own 'uses <ice>
+   to ...' effect line can co-occur in the same window, so :subs-fired is
+   checked before :ability-used to label the headline event (#54). All four
+   statuses pause identically downstream (run-notable-event?), so the order
+   only affects the human-readable label, never behaviour."
   [{:keys [rez-event ability-event fired-event tag-damage-event]}]
   (cond
     rez-event
@@ -893,19 +908,19 @@
       (println "   → Use 'continue-run' again to proceed")
       {:status :ice-rezzed :wake-reason :ice-rezzed :event rez-event})
 
-    ability-event
-    (do
-      (println "⚠️  Run paused - ability triggered!")
-      (println (format "   %s" (:text ability-event)))
-      (println "   → Use 'continue-run' again to proceed")
-      {:status :ability-used :wake-reason :ability-used :event ability-event})
-
     fired-event
     (do
       (println "⚠️  Run paused - subroutines fired!")
       (println (format "   %s" (:text fired-event)))
       (println "   → Use 'continue-run' again to proceed")
       {:status :subs-fired :wake-reason :subs-fired :event fired-event})
+
+    ability-event
+    (do
+      (println "⚠️  Run paused - ability triggered!")
+      (println (format "   %s" (:text ability-event)))
+      (println "   → Use 'continue-run' again to proceed")
+      {:status :ability-used :wake-reason :ability-used :event ability-event})
 
     tag-damage-event
     (do

--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -395,16 +395,27 @@
   #"(?i)\bunbroken subroutine")
 (def ^:private tag-damage-event-re #"(?i)\btags?\b|\bdamage\b")
 (def ^:private event-negation-re
-  ;; A line that MENTIONS an event keyword but negates/prevents it — the event
-  ;; did not actually happen, so it must not pause the run. Real engine lines:
-  ;; "Corp does not do core damage with Zed 1.0", "prevent 1 meat damage",
-  ;; "is not forced to rez", "avoid 1 tag".
+  ;; A line that MENTIONS a STATE-CHANGE keyword but negates/prevents it — the
+  ;; state change did not happen, so it must not pause the run. Real engine
+  ;; lines: "Corp does not do core damage with Zed 1.0", "prevent 1 meat
+  ;; damage", "is not forced to rez", "avoid 1 tag".
+  ;;
+  ;; NB: applied to rez / fired / tag-damage ONLY, never to abilities. An
+  ;; ability's "uses <card> to <effect>" line legitimately contains these words
+  ;; when the effect IS a prevention (e.g. "uses EMP Device to prevent the Corp
+  ;; from rezzing ..."); the ability still fired, so guarding it there would
+  ;; drop real events (Codex review of #54).
   #"(?i)\bdoes not\b|\bdo not\b|\bcannot\b|\bprevents?\b|\bavoids?\b|\bimmune\b|\bnot forced\b")
 
 (defn- text-matches?
-  "True if entry's :text matches regex `re` and is not a negation/prevention
-   line (nil-:text safe). The negation guard stops 'does not do core damage' /
-   'prevent N damage' style no-ops from surfacing as real events (#54)."
+  "True if entry's :text matches regex `re` (nil-:text safe)."
+  [re entry]
+  (boolean (re-find re (str (:text entry)))))
+
+(defn- resolved-event-match?
+  "Like `text-matches?` but rejects negated/prevented no-op lines (see
+   `event-negation-re`). For STATE-CHANGE events (rez / fired / tag-damage)
+   whose keyword is what gets negated — NOT for abilities."
   [re entry]
   (let [text (str (:text entry))]
     (boolean (and (re-find re text)
@@ -412,9 +423,10 @@
 
 (defn get-rez-event
   "Find first rez event in log entries, or nil if none. nil-:text safe.
-   Word-boundaried so 'derez' / 'rez cost' lines don't count as a rez (#54)."
+   Word-boundaried so 'derez' / 'rez cost' / 'not forced to rez' lines don't
+   count as a rez (#54)."
   [log-entries]
-  (first (filter #(text-matches? rez-event-re %) log-entries)))
+  (first (filter #(resolved-event-match? rez-event-re %) log-entries)))
 
 (defn extract-run-events
   "Scan the most recent log entries for notable run events (rez / ability /
@@ -432,9 +444,10 @@
   [log]
   (let [recent-log (take 3 (reverse log))]
     {:rez-event (get-rez-event recent-log)
+     ;; ability un-guarded: "uses X to prevent/avoid ..." is a real activation.
      :ability-event (first (filter #(text-matches? ability-event-re %) recent-log))
-     :fired-event (first (filter #(text-matches? fired-event-re %) recent-log))
-     :tag-damage-event (first (filter #(text-matches? tag-damage-event-re %) recent-log))}))
+     :fired-event (first (filter #(resolved-event-match? fired-event-re %) recent-log))
+     :tag-damage-event (first (filter #(resolved-event-match? tag-damage-event-re %) recent-log))}))
 
 (defn normalize-side
   "Normalize a side value to string. Handles keywords, strings, booleans, and nil."

--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -414,8 +414,12 @@
 
 (defn- resolved-event-match?
   "Like `text-matches?` but rejects negated/prevented no-op lines (see
-   `event-negation-re`). For STATE-CHANGE events (rez / fired / tag-damage)
-   whose keyword is what gets negated — NOT for abilities."
+   `event-negation-re`). Safe ONLY for events whose log line is a direct state
+   report that never embeds effect-description text: rez ('… is not forced to
+   rez X') and tag-damage ('… does not do core damage'). NOT for abilities
+   ('uses X to prevent …') or fired subs (the umbrella line embeds subroutine
+   labels like Whirlpool's '… cannot jack out …') — those legitimately contain
+   negation words while the event really happened (Codex review of #54)."
   [re entry]
   (let [text (str (:text entry))]
     (boolean (and (re-find re text)
@@ -444,9 +448,11 @@
   [log]
   (let [recent-log (take 3 (reverse log))]
     {:rez-event (get-rez-event recent-log)
-     ;; ability un-guarded: "uses X to prevent/avoid ..." is a real activation.
+     ;; ability + fired un-guarded: an ability's "uses X to prevent ..." effect
+     ;; and a fired sub's embedded label ("... cannot jack out ...") legitimately
+     ;; contain negation words while the event really fired.
      :ability-event (first (filter #(text-matches? ability-event-re %) recent-log))
-     :fired-event (first (filter #(resolved-event-match? fired-event-re %) recent-log))
+     :fired-event (first (filter #(text-matches? fired-event-re %) recent-log))
      :tag-damage-event (first (filter #(resolved-event-match? tag-damage-event-re %) recent-log))}))
 
 (defn normalize-side

--- a/dev/test/continue_run_rez_test.clj
+++ b/dev/test/continue_run_rez_test.clj
@@ -224,7 +224,35 @@
                   [{:text "old"} {:text "old"}
                    {:text "Runner installs Donut Taganes"}])]
       (is (nil? (:tag-damage-event events))
-          "'Taganes' contains 'tag' as a substring but is not a tag event"))))
+          "'Taganes' contains 'tag' as a substring but is not a tag event")))
+
+  (testing "A negated/prevented damage line is not a damage event"
+    ;; Real engine lines that mention 'damage' but deal none.
+    (doseq [line ["Corp does not do core damage with Zed 1.0"
+                  "Runner uses Feedback Filter to prevent 1 net damage"]]
+      (let [events (runs/extract-run-events [{:text "old"} {:text "old"} {:text line}])]
+        (is (nil? (:tag-damage-event events))
+            (str "No damage was dealt: " line))))))
+
+;; =============================================================================
+;; Test: handle-events labels a fired subroutine as :subs-fired, not
+;;        :ability-used, when both co-occur in the window (issue #54)
+;; =============================================================================
+;;
+;; A firing subroutine and its own "uses <ice> to ..." effect line can both
+;; land in the recent window. :subs-fired is the more specific headline, so
+;; handle-events checks it before :ability-used. (All four event statuses pause
+;; identically downstream, so this only affects the label — never behaviour.)
+
+(deftest test-handle-events-fired-beats-ability
+  (testing "Fired subroutine wins the label over a co-occurring ability line"
+    (let [context {:rez-event nil
+                   :ability-event {:text "Corp uses Ice Wall to end the run"}
+                   :fired-event {:text "Corp resolves 1 unbroken subroutine on Ice Wall"}
+                   :tag-damage-event nil}
+          result (runs/handle-events context)]
+      (is (= :subs-fired (:status result))
+          "Subs-fired is more specific than the ability effect line it emits"))))
 
 (deftest test-extract-run-events-tolerates-nil-text
   (testing "A log entry with nil :text does not NPE (defensive, matches sibling fns)"

--- a/dev/test/continue_run_rez_test.clj
+++ b/dev/test/continue_run_rez_test.clj
@@ -245,7 +245,18 @@
       (is (some? (:ability-event events))
           "Ability activation must survive even when its effect text negates something")
       (is (nil? (:rez-event events))
-          "...and 'rezzing' in an ability effect line is not itself a rez event"))))
+          "...and 'rezzing' in an ability effect line is not itself a rez event")))
+
+  (testing "A fired sub whose EMBEDDED label contains a negation word still fires"
+    ;; The umbrella fired log embeds the subroutine labels (ice.clj), and real
+    ;; ICE labels contain 'cannot' (e.g. Whirlpool: 'The Runner cannot jack
+    ;; out...'). The sub really fired, so :fired-event must survive — the
+    ;; negation guard is NOT applied to fired subs (Codex review of #54).
+    (let [events (runs/extract-run-events
+                  [{:text "old"} {:text "old"}
+                   {:text "Corp resolves 1 unbroken subroutine on Whirlpool (\"[subroutine] The Runner cannot jack out for the remainder of this run\")"}])]
+      (is (some? (:fired-event events))
+          "A fired sub with 'cannot' in its embedded label must still surface"))))
 
 ;; =============================================================================
 ;; Test: handle-events labels a fired subroutine as :subs-fired, not

--- a/dev/test/continue_run_rez_test.clj
+++ b/dev/test/continue_run_rez_test.clj
@@ -232,7 +232,20 @@
                   "Runner uses Feedback Filter to prevent 1 net damage"]]
       (let [events (runs/extract-run-events [{:text "old"} {:text "old"} {:text line}])]
         (is (nil? (:tag-damage-event events))
-            (str "No damage was dealt: " line))))))
+            (str "No damage was dealt: " line)))))
+
+  (testing "The negation guard does NOT swallow a real ability whose effect is prevention"
+    ;; "uses <card> to prevent/avoid ..." is a genuine ability activation — the
+    ;; ability fired, so it must surface as :ability-event even though its text
+    ;; contains 'prevent'. The guard is scoped to state-change events only
+    ;; (Codex review of #54; EMP Device is a real run-gated ability).
+    (let [events (runs/extract-run-events
+                  [{:text "old"} {:text "old"}
+                   {:text "Runner uses EMP Device to prevent the Corp from rezzing more than 1 piece of ice for the remainder of the run"}])]
+      (is (some? (:ability-event events))
+          "Ability activation must survive even when its effect text negates something")
+      (is (nil? (:rez-event events))
+          "...and 'rezzing' in an ability effect line is not itself a rez event"))))
 
 ;; =============================================================================
 ;; Test: handle-events labels a fired subroutine as :subs-fired, not

--- a/dev/test/continue_run_rez_test.clj
+++ b/dev/test/continue_run_rez_test.clj
@@ -169,15 +169,62 @@
     (let [ability (runs/extract-run-events
                    [{:text "old"} {:text "old"} {:text "old"}
                     {:text "Corp uses Rototurret to trash a program"}])
+          ;; Real engine wording from resolve-unbroken-subs! (game/core/ice.clj):
+          ;; "resolves N unbroken subroutine on <ice> (...)" — the old matcher
+          ;; keyed on "fire", which the engine NEVER logs, so it caught this
+          ;; never (#54 false-negative).
           fired   (runs/extract-run-events
                    [{:text "old"} {:text "old"} {:text "old"}
-                    {:text "Corp resolves 2 subroutines: fire End the run"}])
+                    {:text "Corp resolves 2 unbroken subroutines on Enigma (\"[subroutine] End the run\" and \"[subroutine] End the run\")"}])
           tag     (runs/extract-run-events
                    [{:text "old"} {:text "old"} {:text "old"}
                     {:text "Runner takes 1 tag"}])]
       (is (some? (:ability-event ability)))
       (is (some? (:fired-event fired)))
       (is (some? (:tag-damage-event tag))))))
+
+;; =============================================================================
+;; Test: classifiers reject false positives (issue #54)
+;; =============================================================================
+;;
+;; #52 made the window live, which turned naive substring matching
+;; (includes? "rez"/"fire"/"tag"/"damage") into a false-positive hazard: card
+;; names and flavor text share those substrings. These pin the word-boundaried,
+;; engine-wording-anchored matchers against the concrete traps found in the
+;; engine card/log source.
+
+(deftest test-extract-run-events-rejects-false-positives
+  (testing "'derez' is not a rez event (word-boundaried, excludes de-rez)"
+    (let [events (runs/extract-run-events
+                  [{:text "old"} {:text "old"}
+                   {:text "Corp uses Chief Slee to derez Ice Wall"}])]
+      (is (nil? (:rez-event events))
+          "'derez' must not count as a rez — old includes? \"rez\" matched it")))
+
+  (testing "A Runner BREAKING subs is not a subs-fired event"
+    ;; break-subroutines-msg logs "use Corroder to break 1 subroutine on X",
+    ;; which also contains 'subroutine' — but breaking PREVENTS firing, so it
+    ;; must not surface as :fired-event. Anchoring on 'unbroken subroutine'
+    ;; distinguishes the two.
+    (let [events (runs/extract-run-events
+                  [{:text "old"} {:text "old"}
+                   {:text "Runner uses Corroder to break 1 subroutine on Ice Wall (\"[subroutine] End the run\")"}])]
+      (is (nil? (:fired-event events))
+          "Breaking subroutines is the opposite of firing them")))
+
+  (testing "Card name 'Foxfire' does not trip the subs-fired classifier"
+    (let [events (runs/extract-run-events
+                  [{:text "old"} {:text "old"}
+                   {:text "Runner uses Foxfire to trash a card"}])]
+      (is (nil? (:fired-event events))
+          "'Foxfire' contains 'fire' but is a card name, not a fired sub")))
+
+  (testing "Card name 'Donut Taganes' does not trip the tag classifier"
+    (let [events (runs/extract-run-events
+                  [{:text "old"} {:text "old"}
+                   {:text "Runner installs Donut Taganes"}])]
+      (is (nil? (:tag-damage-event events))
+          "'Taganes' contains 'tag' as a substring but is not a tag event"))))
 
 (deftest test-extract-run-events-tolerates-nil-text
   (testing "A log entry with nil :text does not NPE (defensive, matches sibling fns)"


### PR DESCRIPTION
Closes #54. Follow-up to #52 / PR #53.

## Problem
Once #52 made the `continue-run!` event window *live*, the naive substring classifiers in `extract-run-events` (`includes? "rez"/"fire"/"tag"/"damage"`) became a hazard:

**False positives** — card names / flavor share substrings:
- `"derez"` matched `"rez"` → a de-rez counted as an ICE rez
- `"Foxfire"` matched `"fire"` → a card name counted as subs firing
- `"Donut Taganes"` matched `"tag"` → a card name counted as a tag event

**False negative** — the engine *never* logs the word `"fire"` for a firing subroutine. `resolve-unbroken-subs!` (`game/core/ice.clj`) logs `"resolves N unbroken subroutine on X"`, so the old `"fire"` matcher caught real subs firing **never**.

## Fix
Word-boundaried regexes anchored on the real engine wording (verified against `src/clj/game/core/`):

| event | matcher | note |
|-------|---------|------|
| rez | `\brezzes\b \| \bto rez\b` | excludes `derez` / `rez cost` chatter |
| ability | `\buses\b \| \btriggers\b` | |
| fired | `\bunbroken subroutine` | distinguishes firing from **breaking**, which also logs `"...break N subroutine on X"` |
| tag/damage | `\btags?\b \| \bdamage\b` | `"Taganes"` no longer matches |

## Tests — red→green
- `test-extract-run-events-rejects-false-positives` (new) fails **2 ways** under the old matchers: derez→rez, and Foxfire/Taganes.
- `test-extract-run-events-detects-ability-fired-tag` now uses the real `"resolves N unbroken subroutines on X"` wording, which the old `"fire"` matcher missed (demonstrates the false-negative fix).
- Also guards that a Runner **breaking** subs is not misread as firing.

Verified red (3 failures against old matchers) → green. `continue-run-rez-test`: 25 tests / 52 assertions. Full `make verify`: all namespaces compile, suite 0 failures, shell tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)