### PR TITLE
fix: jack-out explains a run that ended out from under a stale menu (#48)

### DIFF
--- a/dev/send_command
+++ b/dev/send_command
@@ -1121,6 +1121,7 @@ case "$COMMAND" in
         execute '(do
                   (require (quote [ai-state :as state]))
                   (require (quote [ai-websocket-client-v2 :as ws]))
+                  (require (quote [ai-runs :as runs]))
                   (let [s @state/client-state
                         gameid (:gameid s)
                         run-state (get-in s [:game-state :run])]
@@ -1134,7 +1135,18 @@ case "$COMMAND" in
                            :args nil})
                         (Thread/sleep 500)
                         (println "🚪 Jacked out of run"))
-                      (println "❌ Not in a run"))))'
+                      ;; No active run. Distinguish "the run ended out from under
+                      ;; a stale encounter menu" (#48) from a plain typo: if the
+                      ;; recent log shows run-ending events, surface them so the
+                      ;; seat is not left with a stale menu + bare error.
+                      (let [ended (runs/run-ending-log-lines (get-in s [:game-state :log]))]
+                        (if (seq ended)
+                          (do
+                            (println "❌ Not in a run — it ended before your jack-out landed.")
+                            (println "   What happened:")
+                            (doseq [l ended] (println (str "   • " l)))
+                            (println "   (Any tank/jack-out menu you saw is now stale — the run is over.)"))
+                          (println "❌ Not in a run"))))))'
         ;;
 
     tank)

--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -455,6 +455,44 @@
      :fired-event (first (filter #(text-matches? fired-event-re %) recent-log))
      :tag-damage-event (first (filter #(resolved-event-match? tag-damage-event-re %) recent-log))}))
 
+(def ^:private run-terminal-re
+  ;; A log line that actually TERMINATES a run — the gate for #48's stale-menu
+  ;; explanation. Only two engine wordings end a run with their own log line:
+  ;;   - an end-the-run effect  "uses X to end the run" (game/cards/ice.clj)
+  ;;   - a jack out             "jacks out"             (game/core/runs.clj)
+  ;; A fired sub or a damage trash is NOT terminal on its own: a "do 1 net
+  ;; damage" sub (Neural Katana) resolves and the run continues. So those are
+  ;; used as CONTEXT (run-event-re below) only when a terminal line is present
+  ;; — otherwise a normally-completed run (access, no ETR) would be mislabeled
+  ;; "ended before your jack-out landed" (Codex review of #48).
+  #"(?i)\bto end the run\b|\bjacks out\b")
+
+(def ^:private run-event-re
+  ;; Terminal enders PLUS the context lines worth showing alongside them: the
+  ;; fired sub and the damage trash that led to the run ending. Word-boundaried
+  ;; on real engine wording (the #54 lesson): "unbroken subroutine" excludes a
+  ;; Runner BREAKING subs ("break 1 subroutine on X"); no bare "rez"/"tag".
+  #"(?i)\bunbroken subroutine\b|\bto end the run\b|\bjacks out\b|\bdue to (?:net|meat|brain|core) damage\b")
+
+(defn run-ending-log-lines
+  "When a run just ended, return the recent log lines explaining it (newest
+   window, chronological). Empty unless a TERMINAL run-ender ('to end the run'
+   / 'jacks out') appears in the last few entries — so the caller can tell
+   'the run ended out from under a stale encounter menu' (#48) from 'there was
+   never a run' (a typo) or a run that simply completed via access. nil-/
+   missing-:text safe.
+
+   Windowed to the last 5 entries (the #48 firing sequence sits at the tail,
+   sent right after the stale menu) so a *prior* run's end-the-run line, pushed
+   back by a few economy logs, is not resurfaced (Codex review of #48)."
+  [log]
+  (let [recent (take-last 5 log)]
+    (if (some #(re-find run-terminal-re (str (:text %))) recent)
+      (->> recent
+           (filter #(re-find run-event-re (str (:text %))))
+           (mapv #(str (:text %))))
+      [])))
+
 (defn normalize-side
   "Normalize a side value to string. Handles keywords, strings, booleans, and nil."
   [side-value]

--- a/dev/test/ai_runs_test.clj
+++ b/dev/test/ai_runs_test.clj
@@ -999,6 +999,87 @@
       (is (empty? lines) "the no-prompt path stays quiet (the fire line is printed by the caller)"))))
 
 ;; ============================================================================
+;; run-ending-log-lines (#48): explain a stale "not in a run" state
+;; ============================================================================
+;;
+;; #48: during an encounter the Runner client printed the tank/jack-out
+;; authorization menu, but the Corp fired the unbroken sub and ended the run
+;; before the Runner's `jack-out` landed — so jack-out replied a bare
+;; "Not in a run" with no hint that the run just ended out from under the menu.
+;; run-ending-log-lines lets jack-out surface WHAT happened instead.
+
+(deftest test-run-ending-log-lines-subs-fired-sequence
+  (testing "subs-fired + damage-trash + end-the-run are all returned, in log order"
+    (let [log [{:text "AI-runner encounters Diviner"}
+               {:text "Clamatius resolves 1 unbroken subroutine on Diviner (\"[subroutine] Do 1 net damage\")"}
+               {:text "Clamatius trashes Leech due to net damage"}
+               {:text "Clamatius uses Diviner to end the run"}]
+          lines (runs/run-ending-log-lines log)]
+      (is (= 3 (count lines)))
+      (is (= "Clamatius resolves 1 unbroken subroutine on Diviner (\"[subroutine] Do 1 net damage\")"
+             (first lines)))
+      (is (= "Clamatius uses Diviner to end the run" (last lines))))))
+
+(deftest test-run-ending-log-lines-jack-out
+  (testing "a 'jacks out' line counts as a run-ending signal"
+    (is (= ["AI-runner jacks out"]
+           (runs/run-ending-log-lines [{:text "AI-runner approaches HQ"}
+                                       {:text "AI-runner jacks out"}])))))
+
+(deftest test-run-ending-log-lines-none-when-no-run-signal
+  (testing "no run-ending signal (economy/access noise) → empty, so caller keeps the plain message"
+    (is (= [] (runs/run-ending-log-lines
+               [{:text "AI-corp uses Corp Basic Action Card to gain 1 [Credits]"}
+                {:text "AI-runner accesses an unseen card from R&D"}
+                {:text "AI-runner steals Offworld Office and gains 2 agenda points"}])))))
+
+(deftest test-run-ending-log-lines-ignores-breaking-and-derez
+  (testing "Runner BREAKING subs and derez chatter are not run-ending signals"
+    ;; 'break 1 subroutine' contains 'subroutine' but NOT 'unbroken subroutine';
+    ;; 'derez' must not read as a run end. (Same #54 substring traps.)
+    (is (= [] (runs/run-ending-log-lines
+               [{:text "AI-runner uses Corroder to break 1 subroutine on Ice Wall"}
+                {:text "AI-corp derezzes Ice Wall"}])))))
+
+(deftest test-run-ending-log-lines-nil-text-safe
+  (testing "nil / missing :text entries don't crash extraction"
+    (is (= ["Corp uses Palisade to end the run"]
+           (runs/run-ending-log-lines [{:text nil}
+                                       {}
+                                       {:text "Corp uses Palisade to end the run"}])))))
+
+(deftest test-run-ending-log-lines-windowed-to-recent
+  (testing "a run-ending line older than the recent window is not resurfaced"
+    ;; A previous run's ETR followed by a full turn of economy: jack-out now
+    ;; must NOT dredge up the stale end-the-run from the prior run.
+    (let [old-run {:text "Corp uses Ice Wall to end the run"}
+          noise (repeat 8 {:text "AI-corp uses Corp Basic Action Card to gain 1 [Credits]"})
+          log (vec (cons old-run noise))]
+      (is (= [] (runs/run-ending-log-lines log))))))
+
+(deftest test-run-ending-log-lines-non-terminal-sub-not-flagged
+  (testing "subs fired + damage trash WITHOUT a terminal ender do NOT read as run-ended (Codex #48)"
+    ;; Neural Katana's 'do 3 net damage' sub resolves and the run CONTINUES to
+    ;; access — no 'to end the run' / 'jacks out'. A later stray jack-out must
+    ;; not be told the run ended when it merely completed via access.
+    (is (= [] (runs/run-ending-log-lines
+               [{:text "Corp resolves 1 unbroken subroutine on Neural Katana (\"[subroutine] Do 3 net damage\")"}
+                {:text "Corp trashes Sure Gamble due to net damage"}
+                {:text "Runner accesses an unseen card from R&D"}])))))
+
+(deftest test-run-ending-log-lines-etr-drops-off-tightened-window
+  (testing "a prior-run ETR followed by 5 non-run logs falls out of the 5-line window (Codex #48)"
+    ;; Codex's finding-2 counterexample: the stale ETR is the 6th-from-newest
+    ;; entry, so a typo jack-out no longer gets the stale-menu explanation.
+    (is (= [] (runs/run-ending-log-lines
+               [{:text "Corp uses Ice Wall to end the run"}
+                {:text "Runner accesses an unseen card from R&D"}
+                {:text "Corp gains 1 [Credits]"}
+                {:text "Corp gains 1 [Credits]"}
+                {:text "Corp gains 1 [Credits]"}
+                {:text "Runner gains 1 [Credits]"}])))))
+
+;; ============================================================================
 
 (defn -main
   "Run continue-run! tests and report results"


### PR DESCRIPTION
## What

Fixes #48 (misleading-output class). During an ICE encounter the Runner client prints the tank/jack-out authorization menu, but the Corp can fire the unbroken sub and **end the run before the Runner's `jack-out` lands**. The old code then replied a bare `❌ Not in a run`, leaving the seat with a stale menu and no idea the run was over.

## Fix

New pure helper `run-ending-log-lines` (in `ai_runs.clj`): when a **terminal run-ender** (`uses X to end the run` / `jacks out`) appears in the last 5 log entries, it returns the run-relevant lines (fired subs, damage trashes, the ETR) as an explanation. `jack-out` surfaces them instead of the bare error when there is no active run. A genuine typo (no recent run-ender) still gets the plain `❌ Not in a run`.

Example new output:
```
❌ Not in a run — it ended before your jack-out landed.
   What happened:
   • Clamatius resolves 1 unbroken subroutine on Diviner ("[subroutine] Do 1 net damage")
   • Clamatius trashes Leech due to net damage
   • Clamatius uses Diviner to end the run
   (Any tank/jack-out menu you saw is now stale — the run is over.)
```

## Design notes (from Codex review)

- **Terminal-gated**, not "any sub fired": a `do net damage` sub (Neural Katana) resolves and the run *continues*, so subs/damage lines are shown as **context only** when a real ender is present — otherwise a normally-completed run (access, no ETR) would be mislabeled "ended before your jack-out landed".
- **5-entry window**: the #48 firing sequence sits at the tail (sent right after the stale menu), so a *prior* run's ETR pushed back by a few economy logs is not resurfaced.
- Word-boundaried on real engine wording (the #54 lesson): `unbroken subroutine` excludes a Runner *breaking* subs; no bare `rez`/`tag` substrings.

## Scope

Kept to `jack-out`, the exact reported symptom. `tank`/`continue` route through `handle-no-run` and could reuse the same helper in a follow-up; left out here to stay surgical.

## Tests

8 regression tests in `ai_runs_test.clj`, including both Codex counterexamples (Neural Katana non-terminal sub; stale ETR beyond the tightened window). `make verify` green: **397 tests, 920 assertions, 0 failures**, all 21 namespaces compile, shell tests pass.

## Review

Codex (GPT-5.5) reviewed both the initial and revised diffs. Initial pass found the two design issues above (Medium + Low); both fixed with regression tests. Confirmation pass: **merge, no findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)