### PR TITLE
fix: --no-rez declines the pre-access upgrade window instead of looping (#57)

### DIFF
--- a/dev/src/clj/ai_run_corp_decisions.clj
+++ b/dev/src/clj/ai_run_corp_decisions.clj
@@ -203,7 +203,11 @@
     (let [title (get-in decision [:card :title] "upgrade")]
       [(format "Server upgrade decision: %s before access" title)
        (format "   rez \"%s\"  - rez it now" title)
-       "   continue      - decline for this window"])
+       ;; #57: bare `continue` re-wakes this same window (it re-hits this
+       ;; handler). `continue --no-rez` is the decline that actually passes
+       ;; priority — a standing "rez nothing" commitment, harmless here since
+       ;; every ICE has already been passed by pre-access.
+       "   continue --no-rez  - decline (pass priority for the rest of this run)"])
 
     :unsupported-prompt
     ["Unsupported Corp prompt during run"

--- a/dev/src/clj/ai_run_corp_handlers.clj
+++ b/dev/src/clj/ai_run_corp_handlers.clj
@@ -435,9 +435,19 @@
                :phase run-phase})))))))
 
 (defn handle-corp-server-upgrade-decision
-  "Wake before access when an unrezzed upgrade in the attacked server may matter."
-  [{:keys [side state]}]
-  (when (= side "corp")
+  "Wake before access when an unrezzed upgrade in the attacked server may matter.
+
+   Respects --no-rez (#57): --no-rez is a standing 'decline every rez' commitment,
+   so at a pre-access upgrade window we fall through (return nil) and let the
+   normal empty-run-window auto-pass advance the run — exactly like an
+   approach-ice rez window under --no-rez. Without it we'd re-present the same
+   'Server upgrade decision' every iteration (only a raw pass advanced it), a
+   wedge risk for an autonomous Corp seat on `monitor-run --persistent --no-rez`.
+   With no decline commitment, still wake so a meaningful pre-access rez (e.g.
+   Manegarm Skunkworks, which must be rezzed BEFORE access) is never skipped."
+  [{:keys [side state strategy]}]
+  (when (and (= side "corp")
+             (not (:no-rez strategy)))
     (let [decision (decisions/corp-run-decision state)]
       (when (= :server-upgrade (:kind decision))
         (let [card-title (get-in decision [:card :title] "upgrade")

--- a/dev/test/continue_run_rez_test.clj
+++ b/dev/test/continue_run_rez_test.clj
@@ -677,3 +677,102 @@
                   (str "a 'run'-type window must not be mistaken for a trigger decision, got: " result))
               (is (>= @calls 2)
                   "must recheck past the empty run-window wait to reach run-complete"))))))))
+
+;; =============================================================================
+;; Test: --no-rez must DECLINE the pre-access server-upgrade window instead of
+;; re-waking every iteration (#57, cross-model marquee g1, Opus Corp).
+;;
+;; At the pre-access "Server upgrade decision" window (an unrezzed Upgrade in the
+;; attacked server, e.g. Manegarm Skunkworks), handle-corp-server-upgrade-decision
+;; used to return :decision-required UNCONDITIONALLY — it never consulted the run
+;; strategy. So an autonomous Corp seat running `monitor-run --persistent --no-rez`
+;; (a standing "decline everything" commitment) got the identical window
+;; re-presented every iteration; only a raw pass advanced the run — a wedge risk
+;; in an un-babysat game. --no-rez must now fall through (nil) so the normal
+;; empty-run-window auto-pass advances past the upgrade, exactly like an
+;; approach-ice rez window under --no-rez. The default (no strategy) wake is
+;; preserved so a meaningful pre-access rez is never silently skipped.
+;; =============================================================================
+
+(defn- server-upgrade-ctx
+  "Handler context at a pre-access server-upgrade window (an unrezzed upgrade in
+   the attacked remote), carrying the given run strategy."
+  [strategy]
+  {:side "corp"
+   :strategy strategy
+   :state {:game-state
+           {:run {:phase "movement" :position 0 :server [:remote1]}
+            :corp {:prompt-state {:msg "You may use paid abilities"
+                                  :prompt-type "run" :choices [] :selectable []}
+                   :servers {:remote1 {:content [{:cid 10 :title "Manegarm Skunkworks"
+                                                  :type "Upgrade" :rezzed false}]}}}
+            :runner {:prompt-state nil}
+            :log []}}})
+
+(deftest server-upgrade-window-wakes-by-default
+  (testing "with no rez strategy, the pre-access upgrade window still wakes the seat (unchanged)"
+    (with-out-str
+      (let [r (corp-handlers/handle-corp-server-upgrade-decision (server-upgrade-ctx {}))]
+        (is (= :decision-required (:status r))
+            (str "an unrezzed pre-access upgrade must still wake by default, got: " r))
+        (is (= "Manegarm Skunkworks" (:card r))
+            "should name the upgrade the Corp must decide on")))))
+
+(deftest server-upgrade-window-no-rez-declines-instead-of-looping
+  (testing "--no-rez falls through (nil) so the normal auto-pass advances the run, not re-waking forever (#57)"
+    (with-out-str
+      (let [r (corp-handlers/handle-corp-server-upgrade-decision
+               (server-upgrade-ctx {:no-rez true}))]
+        (is (nil? r)
+            (str "--no-rez is a standing decline; the upgrade handler must fall through "
+                 "to the empty-window auto-pass, got: " r))))))
+
+;; Chain-level lock (Codex review of #57): the handler-in-isolation tests above
+;; prove it falls through, but the point of falling through is that the REST of
+;; the continue-run! chain then does the right thing in both priority states.
+;; These drive the full chain via ai/continue-run! "--no-rez" at the pre-access
+;; upgrade window:
+;;   (a) Runner has NOT yet passed (:no-action nil) → Corp must WAIT, not
+;;       auto-pass into access ahead of the Runner's own pre-access window.
+;;   (b) Runner HAS passed (:no-action "runner") → Corp auto-passes the empty
+;;       window, advancing the run — the actual decline that was looping (#57).
+
+(defn- upgrade-window-state
+  "Runner running a remote holding an unrezzed upgrade, parked at the pre-access
+   empty run window. :no-action controls who has already passed priority."
+  [no-action]
+  (mock-client-state
+   :side "corp"
+   :game-state
+   {:run (cond-> {:phase "movement" :position 0 :server [:remote1]}
+           no-action (assoc :no-action no-action))
+    :corp {:prompt-state {:msg "You may use paid abilities"
+                          :prompt-type "run" :choices [] :selectable []}
+           :servers {:remote1 {:content [{:cid 10 :title "Manegarm Skunkworks"
+                                          :type "Upgrade" :rezzed false}]}}}
+    :runner {:prompt-state nil}
+    :log []}))
+
+(deftest no-rez-upgrade-chain-waits-before-runner-passes
+  (testing "--no-rez at the upgrade window waits for the Runner (does not race ahead into access) when Runner hasn't passed (#57)"
+    (let [sent (atom [])]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (with-mock-state (upgrade-window-state nil)   ; fresh window, nobody passed
+          (with-out-str
+            (let [r (ai/continue-run! "--no-rez")]
+              (is (not= :decision-required (:status r))
+                  (str "must not re-present the upgrade decision under --no-rez, got: " r))
+              (is (not-any? #(= "continue" (:command %)) @sent)
+                  "must NOT pass Corp priority before the Runner has passed its own pre-access window"))))))))
+
+(deftest no-rez-upgrade-chain-auto-passes-after-runner-passes
+  (testing "--no-rez at the upgrade window auto-passes once the Runner has passed, advancing the run (#57)"
+    (let [sent (atom [])]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (with-mock-state (upgrade-window-state "runner")   ; Runner already passed
+          (with-out-str
+            (let [r (ai/continue-run! "--no-rez")]
+              (is (= :action-taken (:status r))
+                  (str "Corp must auto-pass the empty upgrade window once it holds priority, got: " r))
+              (is (some #(= "continue" (:command %)) @sent)
+                  "the decline is a real priority pass — a continue must reach the engine"))))))))


### PR DESCRIPTION
## Summary
Fixes #57. At the pre-access **"Server upgrade decision"** window (an unrezzed Upgrade in the attacked server, e.g. Manegarm Skunkworks), the Corp seat could not decline — `monitor-run --persistent --no-rez`, `continue`, and re-entering `monitor-run` all **re-presented the identical prompt in a loop**. Only a raw pass advanced the run, a wedge risk in an un-babysat cross-model game.

## Root cause
`handle-corp-server-upgrade-decision` returned `:decision-required` **unconditionally**, never consulting the run strategy. The pre-access upgrade prompt is an empty run window (`prompt-type "run"`, empty choices/selectable) that `handle-auto-continue` would normally pass once it's the Corp's turn — but this handler sits **earlier** in the `continue-run!` chain and intercepted forever, even under `--no-rez`.

## Fix
`--no-rez` is a standing "decline every rez" commitment, so the upgrade handler now **falls through** (returns nil) when it's set, letting the normal empty-window auto-pass advance the run — exactly like an approach-ice rez window under `--no-rez`. Behavior preserved when no decline is committed: the seat still wakes so a meaningful pre-access rez (which must happen *before* access) is never silently skipped. Guidance text corrected: bare `continue` re-wakes; `continue --no-rez` is the decline that actually passes priority.

## Tests (`continue-run-rez-test`)
- **Handler-level**: default (no strategy) still wakes with `:decision-required`; `--no-rez` falls through to nil. *(red→green)*
- **Chain-level** (Codex review add-on): drives the full `ai/continue-run! "--no-rez"` chain and locks the real contract — Corp **waits** before the Runner passes (`:no-action nil`), and **auto-passes** (a `continue` reaches the engine) once the Runner has passed (`:no-action "runner"`).

Full suite: 401 tests, 0 failures. Reviewed by Codex (GPT-5.5): no correctness findings; the chain-level tests were its suggested residual-gap add.

Found by the Opus Corp seat during marquee G1 (2026-07-07, game `0b52266c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)