### PR TITLE
fix: status surfaces run-window priority (whose move), not turn-level active-side

### DIFF
--- a/dev/src/clj/ai_display.clj
+++ b/dev/src/clj/ai_display.clj
@@ -183,7 +183,7 @@
               ;; runner to act'. (Michael forum [154]: surface waiting-on-X.)
               run-state
               (println "Status:" (run-status-headline
-                                  run-state (clojure.string/lower-case (or my-side "runner"))))
+                                  gs (clojure.string/lower-case (or my-side "runner"))))
 
               ;; End-turn was called, and it's my side's turn to start
               (and end-turn (not= my-side active-side))
@@ -1068,22 +1068,36 @@
       [(str "    ⏸️  " opp " (active player) has priority first here and hasn't passed yet.")
        (str "      → Your sub-step comes next: wait for the " opp " to 'continue', then you 'continue' to advance the run.")])))
 
+(defn effective-window-passer
+  "Normalized side (\"runner\"/\"corp\"/nil) that has passed the CURRENT run
+   priority window. During encounter-ice the passer lives on the current
+   encounter ([:encounters :no-action]) — the engine resets the run-level
+   :no-action on movement entry, so [:run :no-action] is stale there (engine
+   runs.clj `continue :encounter-ice`); every other window uses [:run
+   :no-action]. Mirrors the client's runner-passed-encounter? (ai-core). `gs` is
+   the [:game-state] map."
+  [gs]
+  (let [run (:run gs)
+        v   (if (= "encounter-ice" (:phase run))
+              (get-in gs [:encounters :no-action])
+              (:no-action run))]
+    (cond (keyword? v) (name v) (string? v) v :else nil)))
+
 (defn run-status-headline
   "One-line 'whose move is it now' summary for the active run's current priority
-   window, derived from public run state only: the `:no-action` passer plus the
-   rule invariant that the Runner is always the active player during a run
-   (memory run-priority-active-player-first). Pure. `run` is the [:game-state
-   :run] map; `my-side` is \"runner\"/\"corp\". Returns the string for the
-   top-level `Status:` line during a run.
+   window, derived from public run state only: the current-window passer (see
+   effective-window-passer) plus the rule invariant that the Runner is always the
+   active player during a run (memory run-priority-active-player-first). Pure.
+   `gs` is the [:game-state] map; `my-side` is \"runner\"/\"corp\". Returns the
+   string for the top-level `Status:` line during a run.
 
    Why this exists: the turn-level active-side ('it's the Runner's turn')
    misleads inside a run — the Corp still owns its rez / upgrade sub-steps — so a
    Corp seat running `status` at its own rez window used to read 'Waiting for
    runner to act'. Grounded in the SAME na/active logic as run-priority-hint-lines
    so the headline never contradicts the detailed run-window guidance below it."
-  [run my-side]
-  (let [na  (let [v (:no-action run)]
-              (cond (keyword? v) (name v) (string? v) v :else nil))
+  [gs my-side]
+  (let [na  (effective-window-passer gs)
         opp (if (= my-side "runner") "Corp" "Runner")]
     (cond
       ;; I have already passed this window — waiting on the opponent to pass.

--- a/dev/src/clj/ai_display.clj
+++ b/dev/src/clj/ai_display.clj
@@ -18,6 +18,10 @@
 ;; their definitions.
 (declare run-server-display)
 (declare print-run-phase-ladder!)
+;; Run-window priority helpers (defined near run-priority-hint-lines) — used by
+;; the status displays above their definitions.
+(declare run-status-headline)
+(declare print-run-window-priority!)
 
 ;; ============================================================================
 ;; Status & Information
@@ -172,6 +176,15 @@
 
             ;; Active player / waiting status
             (cond
+              ;; During an active run, run-window priority is authoritative. The
+              ;; turn-level active-side ('it's the Runner's turn') misleads inside
+              ;; a run — the Corp still owns its rez / upgrade sub-steps — so a
+              ;; Corp seat at its own rez window would otherwise read 'Waiting for
+              ;; runner to act'. (Michael forum [154]: surface waiting-on-X.)
+              run-state
+              (println "Status:" (run-status-headline
+                                  run-state (clojure.string/lower-case (or my-side "runner"))))
+
               ;; End-turn was called, and it's my side's turn to start
               (and end-turn (not= my-side active-side))
               (do
@@ -222,7 +235,12 @@
                           unbroken (count (filter #(not (:broken %)) subs))]
                       (println (format "  🧊 ICE: %s (str %s)" ice-title ice-str))
                       (println (format "     Type: %s" ice-subtypes))
-                      (println (format "     Subs: %d unbroken of %d" unbroken (count subs))))))))
+                      (println (format "     Subs: %d unbroken of %d" unbroken (count subs)))))))
+              ;; Whose move is it now + what 'continue' does (same guidance the
+              ;; `prompt` command shows) — status used to print only the ladder,
+              ;; leaving the seat to guess whose window it was.
+              (print-run-window-priority! run-state (:phase run-state)
+                                          (clojure.string/lower-case (or my-side "runner"))))
 
             (println "\n--- RUNNER ---")
             (let [hosted (state/runner-hosted-credits)]
@@ -1050,6 +1068,69 @@
       [(str "    ⏸️  " opp " (active player) has priority first here and hasn't passed yet.")
        (str "      → Your sub-step comes next: wait for the " opp " to 'continue', then you 'continue' to advance the run.")])))
 
+(defn run-status-headline
+  "One-line 'whose move is it now' summary for the active run's current priority
+   window, derived from public run state only: the `:no-action` passer plus the
+   rule invariant that the Runner is always the active player during a run
+   (memory run-priority-active-player-first). Pure. `run` is the [:game-state
+   :run] map; `my-side` is \"runner\"/\"corp\". Returns the string for the
+   top-level `Status:` line during a run.
+
+   Why this exists: the turn-level active-side ('it's the Runner's turn')
+   misleads inside a run — the Corp still owns its rez / upgrade sub-steps — so a
+   Corp seat running `status` at its own rez window used to read 'Waiting for
+   runner to act'. Grounded in the SAME na/active logic as run-priority-hint-lines
+   so the headline never contradicts the detailed run-window guidance below it."
+  [run my-side]
+  (let [na  (let [v (:no-action run)]
+              (cond (keyword? v) (name v) (string? v) v :else nil))
+        opp (if (= my-side "runner") "Corp" "Runner")]
+    (cond
+      ;; I have already passed this window — waiting on the opponent to pass.
+      (= na my-side)
+      (str "⏳ Waiting on " opp " — you've passed this run window ('wait').")
+
+      ;; Opponent already passed — my move advances / decides the window.
+      (and na (not= na my-side))
+      (str "✅ Your move — " opp " has passed; act on the run window below.")
+
+      ;; Fresh window, I'm the Runner (active player acts first).
+      (= my-side "runner")
+      "✅ Your move (active player) — act on the run window below."
+
+      ;; Fresh window, I'm the Corp: my sub-step is second, Runner acts first.
+      :else
+      "⏳ Waiting on Runner — active player acts first; your sub-step is next.")))
+
+(defn print-run-window-priority!
+  "Print the 'whose move is it now + what continue does' guidance for the current
+   run window. Shared by the `prompt` and `status` commands so both surface the
+   same run-priority read (status previously printed only the timing ladder,
+   leaving the seat to guess whose window it was). Assumes the caller already
+   printed the phase ladder. `run` is [:game-state :run]; `run-phase` is
+   (:phase run); `my-side` is \"runner\"/\"corp\". Returns nil.
+
+   The both-must-pass windows (initiation for the Runner, movement/approach-server
+   for both) route through run-priority-hint-lines, which disambiguates the two
+   sub-steps and warns about the #31 stall. Other windows get the terse
+   decline/continue guidance — spelled out for the Corp (continue here DECLINES an
+   action, e.g. an ICE rez, rather than being forced)."
+  [run run-phase my-side]
+  (if (contains? (if (= my-side "runner")
+                   #{"initiation" "movement" "approach-server"}
+                   #{"movement" "approach-server"})
+                 run-phase)
+    (doseq [line (run-priority-hint-lines run my-side)]
+      (println line))
+    (if (= my-side "corp")
+      (do
+        (println "    → 'continue' passes priority here (you DECLINE to act this window).")
+        (println "    → Other options: rez a card / fire a paid ability if useful.")
+        (when (= run-phase "approach-ice")
+          (println "    → This is the ICE rez window: continue --rez <ice> to rez, or --no-rez to decline.")))
+      (println "    → Use 'continue' to pass priority (advance the run).")))
+  nil)
+
 (def ^:private run-ladder-rungs
   "Conceptual run-timing ladder (jinteki run structure), in order. Steps #2–#4
    repeat per piece of ICE; the live :phase + :position pick the current rung."
@@ -1210,34 +1291,9 @@
                 ;; During encounter-ice, show ICE and breaker info
                 (when (= run-phase "encounter-ice")
                   (show-encounter-ice-info state run my-side))
-                ;; Movement / approach-server are both-must-pass priority windows;
-                ;; spell out whose move it is and what continuing does, so neither
-                ;; seat assumes the run advances on its own (the symmetric
-                ;; 'pass priority' text deadlocked cross-model play).
-                ;; `initiation` is a both-must-pass window too (issue #31): the
-                ;; Runner routes through the already-passed-aware hint so a passed
-                ;; Runner is told to wait / jack-out rather than re-`continue` (a
-                ;; no-op loop). The Corp keeps its rich rez/decline guidance below.
-                (if (contains? (if (= my-side "runner")
-                                 #{"initiation" "movement" "approach-server"}
-                                 #{"movement" "approach-server"})
-                               run-phase)
-                  (doseq [line (run-priority-hint-lines run my-side)]
-                    (println line))
-                  ;; Other run windows (initiation / approach-ice / encounter).
-                  ;; "Use continue to pass priority" alone reads to the Corp as
-                  ;; "that's the only thing" — but continuing here is a CHOICE to
-                  ;; decline action. Spell out the rez / paid-ability options so a
-                  ;; passing Corp knows it passed up something, not that it was
-                  ;; forced. (re forum [093] — Corp told it can continue, not that
-                  ;; it has other options when nothing looks interesting.)
-                  (if (= my-side "corp")
-                    (do
-                      (println "    → 'continue' passes priority here (you DECLINE to act this window).")
-                      (println "    → Other options: rez a card / fire a paid ability if useful.")
-                      (when (= run-phase "approach-ice")
-                        (println "    → This is the ICE rez window: continue --rez <ice> to rez, or --no-rez to decline.")))
-                    (println "    → Use 'continue' to pass priority (advance the run)."))))
+                ;; Whose move is it now + what 'continue' does — shared with the
+                ;; `status` command so both surface the same run-priority read.
+                (print-run-window-priority! run run-phase my-side))
               ;; Not in a run. `continue` is RUN-ONLY (errors "No active run to
               ;; monitor") — never advertise it here. A "waiting" prompt means the
               ;; opponent is deciding (e.g. Wildcat Strike); the player takes no

--- a/dev/test/ai_display_test.clj
+++ b/dev/test/ai_display_test.clj
@@ -564,6 +564,109 @@
       (is (str/includes? out "Your sub-step comes next")))))
 
 ;; ============================================================================
+;; run-status-headline — the top-level `Status:` line during a run. The
+;; turn-level active-side ('it's the Runner's turn') misleads inside a run: the
+;; Corp still owns its rez / upgrade sub-steps, so a Corp seat running `status`
+;; at its own rez window used to read 'Waiting for runner to act' (Michael forum
+;; [154]: surface waiting-on-X). Grounded purely in :no-action + the
+;; Runner-is-active invariant, so it never contradicts run-priority-hint-lines.
+;; ============================================================================
+
+(deftest test-run-status-headline-corp-fresh-waits-on-runner
+  (testing "Corp, fresh window (nobody passed): active-player Runner acts first,
+            so the Corp is waiting — NOT told it's its move"
+    (let [line (display/run-status-headline
+                {:server ["rd"] :phase "approach-ice" :position 1 :no-action false}
+                "corp")]
+      (is (str/includes? line "Waiting on Runner"))
+      (is (str/includes? line "active player acts first"))
+      (is (not (str/includes? line "Your move"))))))
+
+(deftest test-run-status-headline-runner-fresh-is-its-move
+  (testing "Runner, fresh window: active player acts first -> it's the Runner's move"
+    (let [line (display/run-status-headline
+                {:server ["rd"] :phase "movement" :position 0 :no-action nil}
+                "runner")]
+      (is (str/includes? line "Your move"))
+      (is (str/includes? line "active player")))))
+
+(deftest test-run-status-headline-i-passed-waits-on-opponent
+  (testing "Side that already passed is told it's waiting on the opponent, not that
+            it's its move (mirrors run-priority-hint-lines' already-passed branch)"
+    (let [line (display/run-status-headline
+                {:server ["hq"] :phase "movement" :position 0 :no-action "runner"}
+                "runner")]
+      (is (str/includes? line "Waiting on Corp"))
+      (is (str/includes? line "you've passed"))
+      (is (not (str/includes? line "Your move"))))))
+
+(deftest test-run-status-headline-opponent-passed-is-my-move
+  (testing "When the opponent has already passed, it's my move"
+    (let [line (display/run-status-headline
+                {:server ["rd"] :phase "approach-server" :position 0 :no-action :runner}
+                "corp")]
+      (is (str/includes? line "Your move"))
+      (is (str/includes? line "Runner has passed")))))
+
+;; ============================================================================
+;; print-run-window-priority! — shared 'whose move + what continue does' block,
+;; now used by BOTH `prompt` and `status` (status previously showed only the
+;; ladder). Both-must-pass windows route through run-priority-hint-lines; other
+;; windows get the terse decline/continue guidance (spelled out for the Corp).
+;; ============================================================================
+
+(deftest test-run-window-priority-corp-approach-ice-is-rez-window
+  (testing "Corp at approach-ice: continue DECLINES (a rez), and the rez options
+            are spelled out — not routed through the movement hint lines"
+    (let [out (with-out-str
+                (display/print-run-window-priority!
+                 {:server ["rd"] :phase "approach-ice" :position 1 :no-action false}
+                 "approach-ice" "corp"))]
+      (is (str/includes? out "DECLINE"))
+      (is (str/includes? out "ICE rez window"))
+      (is (str/includes? out "--no-rez")))))
+
+(deftest test-run-window-priority-movement-routes-through-hint-lines
+  (testing "Both-must-pass movement window routes through run-priority-hint-lines
+            (Runner told continuing yields its access)"
+    (let [out (with-out-str
+                (display/print-run-window-priority!
+                 {:server ["hq"] :phase "movement" :position 0 :no-action false}
+                 "movement" "runner"))]
+      (is (str/includes? out "active player goes first"))
+      (is (str/includes? out "breach HQ and access cards")))))
+
+(deftest test-run-window-priority-runner-approach-ice-passes-priority
+  (testing "Runner at approach-ice (not a both-pass window for the Runner) gets the
+            terse pass-priority line, no Corp rez phrasing"
+    (let [out (with-out-str
+                (display/print-run-window-priority!
+                 {:server ["rd"] :phase "approach-ice" :position 1 :no-action false}
+                 "approach-ice" "runner"))]
+      (is (str/includes? out "pass priority"))
+      (is (not (str/includes? out "ICE rez window"))))))
+
+;; Integration: show-status must surface the run-window read in its headline,
+;; overriding the misleading turn-level line for the Corp mid-run.
+(deftest test-show-status-run-headline-overrides-turn-level
+  (testing "Corp seat during a run: headline reflects run-window priority, not the
+            turn-level 'Waiting for runner to act'"
+    (with-mock-state (mock-client-state
+                      :side "Corp"
+                      :game-state {:active-player "runner" :turn 5
+                                   :run {:server ["rd"] :phase "approach-ice"
+                                         :position 1 :no-action false}
+                                   :runner {:user {:username "ai-runner"}
+                                            :click 2 :credit 5 :hand [] :agenda-point 0 :rig {}}
+                                   :corp {:user {:username "ai-corp"}
+                                          :click 0 :credit 9 :hand [] :agenda-point 0 :servers {}}})
+      (let [out (with-out-str (display/show-status))]
+        (is (not (str/includes? out "Status: ⏳ Waiting for runner to act"))
+            (str "run must override turn-level status headline, got:\n" out))
+        (is (str/includes? out "Waiting on Runner")
+            (str "expected run-window priority headline, got:\n" out))))))
+
+;; ============================================================================
 ;; show-prompt-detailed with no prompt — turn-aware "what now?"
 ;; "No active prompt" alone misled at a turn boundary (reader concludes the game
 ;; isn't waiting on them when it's their turn to start). The no-prompt path now

--- a/dev/test/ai_display_test.clj
+++ b/dev/test/ai_display_test.clj
@@ -576,7 +576,7 @@
   (testing "Corp, fresh window (nobody passed): active-player Runner acts first,
             so the Corp is waiting — NOT told it's its move"
     (let [line (display/run-status-headline
-                {:server ["rd"] :phase "approach-ice" :position 1 :no-action false}
+                {:run {:server ["rd"] :phase "approach-ice" :position 1 :no-action false}}
                 "corp")]
       (is (str/includes? line "Waiting on Runner"))
       (is (str/includes? line "active player acts first"))
@@ -585,7 +585,7 @@
 (deftest test-run-status-headline-runner-fresh-is-its-move
   (testing "Runner, fresh window: active player acts first -> it's the Runner's move"
     (let [line (display/run-status-headline
-                {:server ["rd"] :phase "movement" :position 0 :no-action nil}
+                {:run {:server ["rd"] :phase "movement" :position 0 :no-action nil}}
                 "runner")]
       (is (str/includes? line "Your move"))
       (is (str/includes? line "active player")))))
@@ -594,7 +594,7 @@
   (testing "Side that already passed is told it's waiting on the opponent, not that
             it's its move (mirrors run-priority-hint-lines' already-passed branch)"
     (let [line (display/run-status-headline
-                {:server ["hq"] :phase "movement" :position 0 :no-action "runner"}
+                {:run {:server ["hq"] :phase "movement" :position 0 :no-action "runner"}}
                 "runner")]
       (is (str/includes? line "Waiting on Corp"))
       (is (str/includes? line "you've passed"))
@@ -603,10 +603,49 @@
 (deftest test-run-status-headline-opponent-passed-is-my-move
   (testing "When the opponent has already passed, it's my move"
     (let [line (display/run-status-headline
-                {:server ["rd"] :phase "approach-server" :position 0 :no-action :runner}
+                {:run {:server ["rd"] :phase "approach-server" :position 0 :no-action :runner}}
                 "corp")]
       (is (str/includes? line "Your move"))
       (is (str/includes? line "Runner has passed")))))
+
+;; Encounter-ice regression (Codex/GPT-5.5 review of this change): during an
+;; encounter the passer is recorded on the CURRENT ENCOUNTER
+;; ([:encounters :no-action]), NOT [:run :no-action] — the engine resets the
+;; run-level field on movement entry (runs.clj `continue :encounter-ice`). Using
+;; the run-level field would tell the Corp 'Waiting on Runner' after the Runner
+;; has already passed the encounter and it is the Corp's window to fire subs / end
+;; the encounter.
+(deftest test-run-status-headline-encounter-runner-passed-is-corp-move
+  (testing "Encounter-ice, Runner passed the encounter -> it's the Corp's move,
+            read from [:encounters :no-action] not the stale run-level field"
+    (let [gs {:run {:server ["rd"] :phase "encounter-ice" :position 1 :no-action false}
+              :encounters {:no-action "runner"}}]
+      (is (str/includes? (display/run-status-headline gs "corp") "Your move")
+          "Corp: Runner has passed the encounter, Corp acts")
+      (let [runner-line (display/run-status-headline gs "runner")]
+        (is (str/includes? runner-line "Waiting on Corp"))
+        (is (str/includes? runner-line "you've passed"))))))
+
+(deftest test-run-status-headline-encounter-fresh-runner-acts
+  (testing "Encounter-ice, nobody passed yet: Runner (active) resolves the
+            encounter first; the Corp waits"
+    (let [gs {:run {:server ["rd"] :phase "encounter-ice" :position 1 :no-action false}
+              :encounters {:no-action nil}}]
+      (is (str/includes? (display/run-status-headline gs "runner") "Your move"))
+      (is (str/includes? (display/run-status-headline gs "corp") "Waiting on Runner")))))
+
+(deftest test-effective-window-passer-prefers-encounter-in-encounter-phase
+  (testing "effective-window-passer reads the encounter field during encounter-ice
+            and the run field otherwise"
+    ;; encounter-ice: encounter field wins over the stale run field
+    (is (= "runner" (display/effective-window-passer
+                     {:run {:phase "encounter-ice" :no-action false}
+                      :encounters {:no-action "runner"}})))
+    ;; non-encounter: run field is used (encounters ignored / absent)
+    (is (= "corp" (display/effective-window-passer
+                   {:run {:phase "movement" :no-action :corp}})))
+    (is (nil? (display/effective-window-passer
+               {:run {:phase "approach-ice" :no-action false}})))))
 
 ;; ============================================================================
 ;; print-run-window-priority! — shared 'whose move + what continue does' block,


### PR DESCRIPTION
## Summary
During a run, the `status` command's headline used **turn-level** active-side ("it's the Runner's turn"), which misleads inside a run: the Corp still owns its rez / upgrade sub-steps, so a Corp seat running `status` at its own rez window read **"Waiting for runner to act"**. The ACTIVE RUN block also printed only the timing ladder (where am I) with no *whose-move* read. (Michael forum [154]: surface waiting-on-X in `status`.)

Both fixes are **display-only**, grounded in the deterministic `:no-action` passer + the Runner-is-active invariant (memory `run-priority-active-player-first`) — **no change to run-advance behavior**.

## Changes
- **`run-status-headline`** (pure): during a run the `Status:` line reports whose move it is / who we're waiting on, consistent with `run-priority-hint-lines`.
- **`print-run-window-priority!`**: the "whose move + what continue does" guidance, **extracted** from `show-prompt` and now **shared** with `status` (DRY — `status` gains the same read `prompt` already had; `show-prompt` behavior unchanged).
- **`effective-window-passer`**: reads the passer from `[:encounters :no-action]` during `encounter-ice` and `[:run :no-action]` elsewhere (the engine resets the run-level field on movement entry — mirrors the client's `runner-passed-encounter?`).

## Review (multi-model, per REVIEW_SOP)
- **Codex (GPT-5.5)** reviewed commit 1 and caught a real correctness bug: `run-status-headline` runs for *every* run phase (unlike `run-priority-hint-lines`, gated to movement/approach-server), so during `encounter-ice` it read the stale `[:run :no-action]`. Confirmed against engine `runs.clj` (`continue :encounter-ice` records the passer on the current encounter). Fixed in commit 2 with `effective-window-passer` + 3 regression tests.
- Codex final review of the full diff: **merge** (no parity regression in the `show-prompt` refactor; display-only).

## Tests
+11 (`run-status-headline` across all `:no-action`/active cases incl. encounter-ice; `print-run-window-priority!` for corp-approach-ice / movement / runner-approach; `effective-window-passer` phase selection; `show-status` integration overriding the turn-level headline). Full suite **412 tests / 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)