### PR TITLE
fix: monitor-run --persistent wakes on opponent ping (#50)

### DIFF
--- a/dev/src/clj/ai_core.clj
+++ b/dev/src/clj/ai_core.clj
@@ -1290,6 +1290,16 @@
     (when-let [msg-part (second (re-find #":\s*(.+)" text))]
       (= "ping" (clojure.string/lower-case (clojure.string/trim msg-part))))))
 
+(defn ping-since?
+  "True if any log entry at index `start-count` or later is an opponent `ping`
+   wake signal. Shared wake predicate so both surfaces react to an explicit chat
+   nudge: `wait-for-relevant-diff` (turn/boundary waits) and `monitor-run!`'s
+   persistent defender loop (empty run-priority windows). `start-count` is the
+   log length captured when the wait began, so only pings that arrive DURING the
+   wait wake it — a stale ping from before the wait started is ignored."
+  [log start-count]
+  (boolean (some ping-message? (drop start-count log))))
+
 (declare current-run-ice)
 
 (defn- in-active-game?

--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -1219,6 +1219,8 @@
    - :run-complete - run finished successfully
    - :no-run - no active run
    - :waiting-for-corp-rez - runner waiting for corp (corp should call their loop)
+   - :ping - opponent sent a `ping` chat nudge during a persistent wait (#50
+     recovery net; returns control so the seat can act — does NOT auto-advance)
    - stuck in same state (5 consecutive :action-taken with same [phase position ice])
    - max iterations or timeout reached
 
@@ -1406,6 +1408,28 @@
                   (assoc result
                          :status :decision-required
                          :wake-reason :agenda-trigger-decision
+                         :iterations (inc iteration)
+                         :elapsed-ms (- (System/currentTimeMillis) start-time)))
+
+                ;; #50 recovery net: an explicit opponent `ping` chat nudge wakes
+                ;; the persistent defender loop, exactly as it wakes `wait`
+                ;; (wait-for-relevant-diff). This is the mid-run analog — a seat
+                ;; parked in monitor-run --persistent at an empty priority window
+                ;; that the OTHER seat believes is ours (an unowned both-pass
+                ;; window) can be un-stalled by the opponent pinging. Return
+                ;; control (`:ping`) so the seat re-evaluates and can act; this
+                ;; does NOT auto-advance the run (no priority passed), so it is a
+                ;; control/UX wake, not a run-advance change. Checked before the
+                ;; idle-sleep so a ping that lands during the wait is not slept
+                ;; through to the timeout.
+                (and persistent
+                     (core/ping-since? (get-in cur-state [:game-state :log]) start-log-count))
+                (do
+                  (print-while-you-slept! start-log-count)
+                  (println "🏓 Woke up: opponent ping — returning control so you can act.")
+                  (assoc result
+                         :status :ping
+                         :wake-reason :ping
                          :iterations (inc iteration)
                          :elapsed-ms (- (System/currentTimeMillis) start-time)))
 

--- a/dev/test/continue_run_rez_test.clj
+++ b/dev/test/continue_run_rez_test.clj
@@ -9,6 +9,7 @@
             [ai-actions :as ai]
             [ai-runs :as runs]
             [ai-core :as core]
+            [ai-state :as state]
             [ai-basic-actions :as basic]
             [ai-run-runner-handlers :as runner-handlers]
             [ai-run-corp-handlers :as corp-handlers]
@@ -776,3 +777,60 @@
                   (str "Corp must auto-pass the empty upgrade window once it holds priority, got: " r))
               (is (some #(= "continue" (:command %)) @sent)
                   "the decline is a real priority pass — a continue must reach the engine"))))))))
+
+;; =============================================================================
+;; Test: monitor-run --persistent wakes on an explicit opponent `ping` chat
+;; nudge (#50 recovery net). `wait` (wait-for-relevant-diff) already wakes on a
+;; ping; the persistent defender loop must too, so a seat parked mid-run at an
+;; empty priority window the opponent believes is ours can be un-stalled by the
+;; opponent pinging. The ping returns control (:ping) — it does NOT auto-advance
+;; the run.
+;; =============================================================================
+
+(defn- continue-then-log
+  "continue-run! stand-in: on its FIRST call appends `chat-line` to the game log
+   (simulating an opponent chat message arriving during the wait) and reports an
+   empty opponent-priority wait; subsequent calls report run-complete so a loop
+   that does NOT wake on the message still terminates."
+  [chat-line call-count]
+  (fn [& _]
+    (let [i @call-count]
+      (swap! call-count inc)
+      (if (zero? i)
+        (do
+          (swap! state/client-state update-in [:game-state :log]
+                 (fnil conj []) {:text chat-line})
+          {:status :waiting-for-opponent :wake-reason :waiting-for-opponent})
+        {:status :run-complete :wake-reason :run-complete}))))
+
+(deftest persistent-monitor-wakes-on-opponent-ping
+  (testing "--persistent returns :ping when an opponent ping arrives during an empty priority-window wait (#50)"
+    (let [calls (atom 0)]
+      (with-mock-state (run-active-corp-state)
+        (with-redefs [runs/continue-run! (continue-then-log "AI_Runner: ping" calls)
+                      basic/check-auto-end-turn! (fn [] nil)
+                      runner-handlers/reset-state! (fn [] nil)
+                      core/quick-delay 0]
+          (with-out-str
+            (let [result (runs/auto-continue-loop! :persistent true
+                                                   :persistent-wait-delay-ms 0)]
+              (is (= :ping (:status result))
+                  (str "an opponent ping during a persistent wait must wake the loop, got: " result))
+              (is (= 1 @calls)
+                  "must return on the ping without rechecking into another continue-run! call"))))))))
+
+(deftest persistent-monitor-ignores-non-ping-chat
+  (testing "--persistent does NOT wake on ordinary opponent chit-chat — only a bare 'ping' (no #50 false positive)"
+    (let [calls (atom 0)]
+      (with-mock-state (run-active-corp-state)
+        (with-redefs [runs/continue-run! (continue-then-log "AI_Runner: good luck" calls)
+                      basic/check-auto-end-turn! (fn [] nil)
+                      runner-handlers/reset-state! (fn [] nil)
+                      core/quick-delay 0]
+          (with-out-str
+            (let [result (runs/auto-continue-loop! :persistent true
+                                                   :persistent-wait-delay-ms 0)]
+              (is (= :run-complete (:status result))
+                  (str "ordinary chat must be slept through to run end, not woken on, got: " result))
+              (is (>= @calls 2)
+                  "must recheck past the chat message to reach run-complete"))))))))


### PR DESCRIPTION
## What

Closes the last gap in the #50 chat ping/pong recovery net.

`wait` (`wait-for-relevant-diff`) already wakes on an explicit `ping` chat nudge, but the **persistent defender loop** (`monitor-run --persistent`) slept through it: its empty-priority-window idle branch just slept and rechecked until a real decision or the 300s timeout. So a seat parked *mid-run* could not be nudged out of an unowned both-pass window by the opponent.

This adds the mid-run analog: in the `:waiting-for-opponent` idle branch, before sleeping, check for an opponent ping that arrived **during** this wait and, if so, return `:ping` so the seat regains control.

## Why it's safe to ship autonomously

This is a **control/UX wake** — it passes no priority and takes no game action. It is NOT the deadlock-sensitive run-*advance* change (#31, still gated on Michael's explicit greenlight). It mirrors the ping-wake already shipped in `wait`.

## Changes
- `ai-core/ping-since?` — public shared wake predicate `(log, start-count)`, so both surfaces (`wait` and `monitor-run`) react to a ping with identical semantics. `start-count` is the log length captured when the wait began, so only pings arriving *during* the wait wake it — a stale ping from a prior run sits below the index and is ignored.
- `ai-runs` — ping clause placed **after** `seat-owns-trigger-decision?` (a real seat decision still wins) and **before** the idle-sleep (so a ping isn't slept through to timeout).

## Tests (red→green verified)
- `persistent-monitor-wakes-on-opponent-ping` — ping mid-wait → `:ping`, one `continue-run!` call. (Fails red without the fix: returns `:run-complete`.)
- `persistent-monitor-ignores-non-ping-chat` — ordinary chit-chat is slept through to run end (no false positive).

Full suite: **414 tests, 0 failures**.

## Review
Codex (GPT-5.5) review of the diff: **merge** (no correctness findings), specifically checked start-index scoping, stale-ping re-fire, and branch-ordering races.

🤖 Generated with [Claude Code](https://claude.com/claude-code)