### PR TITLE
fix: ping-wake matches any chat containing 'ping' (#50 gap-1)

### DIFF
--- a/dev/src/clj/ai_core.clj
+++ b/dev/src/clj/ai_core.clj
@@ -1281,14 +1281,21 @@
 
 (defn- ping-message?
   "Check if a log entry is a 'ping' wake signal.
-   Returns true for exact match 'ping' (case-insensitive, trimmed).
-   Used by AIs to wake each other without game state changes."
+   Returns true if the chat message body CONTAINS 'ping' (case-insensitive).
+   Loosened from exact-match per michael-nr (forum ai-netrunner [162]): a human
+   won't reliably send a bare 'ping' (he typed English and slept the seat in the
+   HITL game-5 wedge), so any chat mentioning 'ping' — 'ping', 'ping your turn',
+   'PING!' — now wakes. Still narrow enough that ordinary AI-vs-AI banter with no
+   'ping' token is ignored, and a false wake is cheap (loop re-checks, finds no
+   decision, sleeps again) while a MISSED wake is a silent wedge — so we bias
+   toward waking. Used by AIs to wake each other without game state changes."
   [entry]
   (let [text (or (:text entry) "")]
-    ;; Match chat messages that are just "ping" (with optional username prefix)
-    ;; Chat format is "Username: message" for player messages
+    ;; Match chat messages (format "Username: message") whose body mentions "ping".
+    ;; Capture only the body after the first colon so a 'ping' in the USERNAME
+    ;; (e.g. "Pingu: hello") does not spuriously wake.
     (when-let [msg-part (second (re-find #":\s*(.+)" text))]
-      (= "ping" (clojure.string/lower-case (clojure.string/trim msg-part))))))
+      (clojure.string/includes? (clojure.string/lower-case msg-part) "ping"))))
 
 (defn ping-since?
   "True if any log entry at index `start-count` or later is an opponent `ping`
@@ -1296,7 +1303,8 @@
    nudge: `wait-for-relevant-diff` (turn/boundary waits) and `monitor-run!`'s
    persistent defender loop (empty run-priority windows). `start-count` is the
    log length captured when the wait began, so only pings that arrive DURING the
-   wait wake it — a stale ping from before the wait started is ignored."
+   wait wake it — a stale ping from before the wait started is ignored. A `ping`
+   is any opponent chat mentioning the word (see `ping-message?`)."
   [log start-count]
   (boolean (some ping-message? (drop start-count log))))
 

--- a/dev/test/ai_pure_functions_test.clj
+++ b/dev/test/ai_pure_functions_test.clj
@@ -343,10 +343,18 @@
     (is (not (ping-message? {:text "Player: nice play!"})))))
 
 (deftest test-ping-message-contains-ping
-  (testing "messages containing 'ping' but not exact match don't trigger"
-    (is (not (ping-message? {:text "Player: ping pong"})))
-    (is (not (ping-message? {:text "Player: I'll ping you later"})))
-    (is (not (ping-message? {:text "Player: pinging..."})))))
+  (testing "messages CONTAINING 'ping' now wake (loosened per michael-nr [162])"
+    ;; A goldfish human types English around the word rather than a bare "ping".
+    (is (ping-message? {:text "Player: ping pong"}))
+    (is (ping-message? {:text "Player: I'll ping you later"}))
+    (is (ping-message? {:text "Player: pinging..."}))
+    (is (ping-message? {:text "Player: ping your turn"}))
+    (is (ping-message? {:text "Player: PING!"}))))
+
+(deftest test-ping-message-username-not-body
+  (testing "'ping' in the username alone does not wake — only the body counts"
+    (is (not (ping-message? {:text "Pingu: your turn"})))
+    (is (not (ping-message? {:text "PingBot: hello"})))))
 
 (deftest test-ping-message-nil-entry
   (testing "nil or missing text handled gracefully"

--- a/dev/test/continue_run_rez_test.clj
+++ b/dev/test/continue_run_rez_test.clj
@@ -820,7 +820,7 @@
                   "must return on the ping without rechecking into another continue-run! call"))))))))
 
 (deftest persistent-monitor-ignores-non-ping-chat
-  (testing "--persistent does NOT wake on ordinary opponent chit-chat — only a bare 'ping' (no #50 false positive)"
+  (testing "--persistent does NOT wake on ordinary opponent chit-chat with no 'ping' token (no #50 false positive)"
     (let [calls (atom 0)]
       (with-mock-state (run-active-corp-state)
         (with-redefs [runs/continue-run! (continue-then-log "AI_Runner: good luck" calls)


### PR DESCRIPTION
## What

Loosen the ping-wake predicate (`ai-core/ping-message?`) from **exact-match** `"ping"` to a **case-insensitive substring** match: any opponent chat whose body mentions "ping" now wakes a waiting/persistent-monitoring seat.

## Why

Per michael-nr (forum `ai-netrunner` [162]), responding to the #50 gap-1 write-up. The game-5 HITL wedge was Michael typing English at a waiting Corp seat that only woke on the *exact* word "ping" (he's "being a goldfish" and forgot the magic word). His call: **not** a dedicated HITL mode yet — "the only tweak would be checking for `string.contains_insensitive("ping")`."

Cost asymmetry backs the direction: a false wake is cheap (loop re-checks, finds no decision, sleeps again); a **missed** wake is a silent wedge. So bias toward waking.

## Scope / safety

- Body-only capture (after the first colon) preserved → a "ping" in the *username* (`Pingu: hi`) does **not** wake.
- Ordinary AI-vs-AI banter with no "ping" token is still slept through — `persistent-monitor-ignores-non-ping-chat` ("good luck") stays green, so the marquee AI-vs-AI loop keeps its banter-suppression.
- Known loosening: words like "shipping"/"hoping" contain the substring "ping" and would now wake. Judged acceptable given the cost asymmetry and that seats rarely emit such banter; flagged for the record.

## Tests

- `test-ping-message-contains-ping` flipped: contains-ping messages now wake (red→green vs the old `=` predicate).
- Added `test-ping-message-username-not-body`.
- Full suite **415 tests / 0 failures** + shell tests (`make verify`).

Does **not** touch #50 gap-2 (human-side ntfy notification), which stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)