### PR TITLE
fix: auto-pass run-initiation both-pass window when active player (#31 step 1)

### DIFF
--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -884,6 +884,33 @@
     (println "   → Auto-continuing through paid ability window")
     (send-continue! gameid)))
 
+(defn handle-initiation-auto-pass
+  "Priority 6 (before handle-auto-continue): auto-pass the run INITIATION window
+   when I am the active player (#31, step 1).
+
+   Initiation is a both-must-pass window with no run-start paid ability either
+   side uses in System Gateway. `run!` sends the Runner's first continue by
+   default, so the Runner passes (:no-action \"runner\"); the Corp then becomes
+   the active player at an EMPTY initiation window with NO prompt. Because
+   `can-auto-continue?` requires a \"run\" prompt, it never fires here — no
+   handler matches and continue-run! falls through to handle-unexpected-state,
+   returning a FALSE :waiting-for-opponent. Both seats then wait on each other:
+   the #31 initiation wedge.
+
+   Deterministic fix off `should-i-act?` (per michael-nr, forum ai-netrunner):
+   the active player passes its OWN initiation window. Symmetric — same logic
+   fires for the Runner at a fresh window and the Corp at the second pass. Never
+   sends a continue on the opponent's behalf and never advances a window I don't
+   hold priority in, so it cannot skip a real opponent decision. Scoped to
+   \"initiation\" only; the other both-pass windows (approach-ice / movement) keep
+   their board-aware guards and are a separate follow-on."
+  [{:keys [run-phase gameid side state my-prompt]}]
+  (when (and (= run-phase "initiation")
+             (should-i-act? state side)
+             (not (has-real-decision? my-prompt)))
+    (println "   → Auto-passing initiation window (no run-start decision)")
+    (send-continue! gameid)))
+
 (defn handle-real-decision
   "Priority 3: I have a real decision to make"
   [{:keys [my-prompt]}]
@@ -1136,6 +1163,7 @@
                   handle-access-display
                   handle-auto-choice
                   handle-recently-passed-in-log
+                  handle-initiation-auto-pass
                   handle-auto-continue
                   handle-run-complete
                   handle-no-run]]

--- a/dev/test/continue_run_rez_test.clj
+++ b/dev/test/continue_run_rez_test.clj
@@ -834,3 +834,67 @@
                   (str "ordinary chat must be slept through to run end, not woken on, got: " result))
               (is (>= @calls 2)
                   "must recheck past the chat message to reach run-complete"))))))))
+
+;; =============================================================================
+;; Test: run-initiation both-pass window auto-advances (#31, step 1)
+;; =============================================================================
+;; The initiation window is a both-must-pass window with no run-start paid
+;; ability either side uses in System Gateway. `run!` sends the Runner's first
+;; continue by default, so the Runner passes (:no-action "runner"). The Corp
+;; then becomes the ACTIVE player at an empty initiation window with NO prompt —
+;; so `can-auto-continue?` (which requires a "run" prompt) never fires, no
+;; handler matches, and continue-run! falls through to handle-unexpected-state,
+;; returning a FALSE :waiting-for-opponent. Both seats then wait on each other:
+;; the #31 initiation wedge. The fix auto-passes the initiation window whenever
+;; the send_command seat is the active player (should-i-act?) with no real
+;; decision — it only ever passes its OWN window, never acts for the opponent.
+;; =============================================================================
+
+(defn- initiation-state
+  "A run parked at the initiation window. `no-action` controls who has already
+   passed priority. Neither side has a run prompt (initiation surfaces none)."
+  [side no-action]
+  (mock-client-state
+   :side side
+   :game-state
+   {:run (cond-> {:phase "initiation" :position 1 :server [:hq]}
+           no-action (assoc :no-action no-action))
+    :corp {:prompt-state nil}
+    :runner {:prompt-state nil}
+    :log []}))
+
+(deftest initiation-corp-active-auto-passes
+  (testing "Corp auto-passes the empty initiation window once it holds priority — the #31 wedge (Runner passed, Corp is active, no prompt)"
+    (let [sent (atom [])]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (with-mock-state (initiation-state "corp" "runner")   ; Runner already passed
+          (with-out-str
+            (let [r (ai/continue-run!)]
+              (is (= :action-taken (:status r))
+                  (str "Corp holds priority at an empty initiation window and must pass to advance, got: " r))
+              (is (some #(= "continue" (:command %)) @sent)
+                  "a real continue must reach the engine — this is the second pass that advances initiation"))))))))
+
+(deftest initiation-runner-active-auto-passes
+  (testing "Runner auto-passes a fresh initiation window (active player acts first, no prompt) — symmetric with the Corp path"
+    (let [sent (atom [])]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (with-mock-state (initiation-state "runner" nil)   ; fresh window, nobody passed
+          (with-out-str
+            (let [r (ai/continue-run!)]
+              (is (= :action-taken (:status r))
+                  (str "Runner is the active player at a fresh initiation window and passes its own window, got: " r))
+              (is (some #(= "continue" (:command %)) @sent)
+                  "the Runner's first pass must reach the engine"))))))))
+
+(deftest initiation-already-passed-does-not-double-pass
+  (testing "The seat that has ALREADY passed initiation does not pass again — guards against double-continue"
+    (let [sent (atom [])]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (with-mock-state (initiation-state "corp" "corp")   ; Corp already passed, waiting on Runner
+          (with-out-str
+            (let [r (ai/continue-run!)]
+              (is (not= :action-taken (:status r))
+                  (str "Corp already passed (no-action=corp); it must wait, not pass again, got: " r))
+              (is (not-any? #(= "continue" (:command %)) @sent)
+                  "no second continue from the side that already passed"))))))))


### PR DESCRIPTION
## What

New handler `handle-initiation-auto-pass` (in `ai_runs.clj`, placed just before `handle-auto-continue`): at the run **initiation** window, when the send_command seat is the active player (`should-i-act?`) with no real decision (`has-real-decision?` guard), it sends its own `continue`. Deterministic auto-pass off the priority state, per michael-nr's design call in forum `ai-netrunner`.

## Why (#31 initiation wedge)

Initiation is a both-must-pass priority window with no run-start paid ability either side uses in System Gateway. `run!` sends the Runner's first `continue` by default → `:no-action "runner"`. The Corp then becomes the **active player at an empty initiation window with NO prompt**. Because `can-auto-continue?` requires a `"run"` prompt, it never fires there — no handler matches, `continue-run!` falls through to `handle-unexpected-state` and returns a **false `:waiting-for-opponent`**. Both seats then wait on each other → the #31 stall. (The existing `#31 / g3` note at [ai_display.clj](../blob/ai-player/main/dev/src/clj/ai_display.clj) already flags this window.)

## Key safety properties

- **Only passes MY OWN window** — never a `continue` on the opponent's behalf, never a window I don't hold priority in. Cannot skip a real opponent decision.
- **Symmetric** — the same `should-i-act?` logic covers the Runner's first pass (fresh window) and the Corp's second pass (`:no-action "runner"`). No double-pass: the already-passed seat has `:no-action = side` → `should-i-act?` false (locked by a guard test).
- **Intrinsically AI-only** — this runs in the send_command seat only. In HITL the human's seat is the Jinteki web UI, which this code never touches (michael-nr's #2 call: no writing to the other seat's state).
- **Safe superset** of `can-auto-continue?` at initiation: same `send-continue!`, so it's identical for the with-prompt case and *adds* coverage for the no-prompt case.

## Scope / residuals

- Scoped to `"initiation"` only. approach-ice/movement keep their board-aware guards (a follow-on PR generalizes with board classification).
- Covers the **in-run-loop** stall (`monitor-run` / auto-continue-loop). A seat not in the run loop at all (plain `wait`) is the separate wake-set/persistent-monitor residual — covered by the shipped ping-wake + `monitor-run --persistent`.

## Tests

- `initiation-corp-active-auto-passes` — the #31 wedge (Runner passed, Corp active, no prompt), **red→green**.
- `initiation-runner-active-auto-passes` — symmetric fresh-window pass.
- `initiation-already-passed-does-not-double-pass` — guard against double-continue.
- Full suite **418 / 0** + shell tests (`make verify`).

## Review

Codex (gpt-5.5): **merge**, no CRITICAL/MAJOR — verified no logical double-pass, no acting-for-opponent, reasoning matches engine `continue :initiation`. Only residual it noted is the pre-existing stale-state transport race around `send-continue!`, not introduced here.

**Holding merge for @Clamatius** — this advances run state in the deadlock-sensitive area. Ideal validation is a real marquee game (does the initiation stall disappear?), which I can run on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)