### PR TITLE
Marquee robustness: dead-peer detection + ICE-first Corp mulligan heuristic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ test-shell:
 	@echo "Running shell tests..."
 	@./dev/test/send_command_filter_test.sh
 	@./dev/test/ai_eval_charset_test.sh
+	@./dev/test/peer_status_test.sh
 
 # Run behavioral tests (slow, requires game server)
 test-behavioral:

--- a/dev/seat-corp-devin.md
+++ b/dev/seat-corp-devin.md
@@ -100,6 +100,13 @@ it. The rule:
 - **TIMEOUT during an active run is normal pacing, not a stall** — just re-issue
   `monitor-run --persistent`. Only repeated timeouts with *zero* board movement
   across several re-issues is a possible genuine wedge (note it for your report).
+- **Slow-but-alive vs. dead opponent — check, don't guess.** A `wait` /
+  `monitor-run` return ends with a peer-liveness line; you can also run
+  `./dev/send_command corp peer-status` anytime. `opponent (runner): active Ns
+  ago` → still thinking, keep re-issuing (patience is correct). `opponent
+  (runner): SILENT … likely disconnected` → their process died; confirm
+  `game-over-status` and, if still IN-PROGRESS, report the dead peer and stop —
+  do not loop forever.
 - When a run ends, go back to the `wait` loop. **Several runs can happen in one
   Runner turn — after each run ends, return to `wait`, and re-arm `monitor-run
   --persistent` the moment the next run starts.** Never leave a gap between runs.

--- a/dev/seat-corp-devin.md
+++ b/dev/seat-corp-devin.md
@@ -9,6 +9,17 @@ the shell command `./dev/send_command corp <...>`. The local game server is
 already running and the game is set up at the mulligan phase. You take the Corp
 seat. **The Corp mulligans and starts FIRST.**
 
+**Mulligan heuristic — ICE first, economy second.** The single most important
+property of an opening hand is ICE. A hand with **zero ICE should almost always
+be mulliganed**, even if rich in economy — you cannot protect your servers, and
+you must top-deck several ICE *before* agendas arrive or you just lose (a naked
+server = free agenda access). Do NOT keep a 0-ICE hand on "money is threat" /
+"low agenda-flood" reasoning; a great economy you can't defend behind still
+loses. Rough guide: **0 ICE → mulligan**; **1 ICE → lean mulligan** unless the
+rest is strong with draw to find more; **2+ ICE + some economy → keep.** Agendas
+in the opener are fine (hold in HQ, install behind ICE later) — it's the absence
+of ICE, not the presence of an agenda, that makes a hand a throw.
+
 ## CRITICAL operating rules — read these first
 
 1. **Play the ENTIRE game to GAME-OVER. Do NOT stop after one turn.** This is a

--- a/dev/seat-corp.md
+++ b/dev/seat-corp.md
@@ -44,6 +44,20 @@ Corp mulligans before the Runner. Make your call, then the Runner will mulligan:
 ./dev/send_command corp keep-hand    # or:  ./dev/send_command corp mulligan
 ```
 
+**Mulligan heuristic — ICE first, economy second.** The single most important
+property of an opening hand is **ICE**. A hand with **zero ICE should almost
+always be mulliganed**, even if it is rich in economy: you cannot protect your
+servers, and you have to top-deck several ICE *before* agendas start arriving or
+you simply lose (a naked server = free agenda access for the Runner). Do **not**
+talk yourself into keeping a 0-ICE hand on "money is threat" / "low agenda-flood"
+reasoning — a great economy you can't defend behind still loses. Rough guide:
+- **0 ICE → mulligan** (unless the hand is otherwise so degenerate that keeping is
+  a specific known line — rare; default to mulligan).
+- **1 ICE → lean mulligan** unless the rest is strong and you have draw to find more.
+- **2+ ICE + some economy → keep.**
+Agendas in the opener are fine to keep (hold them in HQ, install behind ICE later);
+it's the *absence of ICE*, not the presence of an agenda, that makes a hand a throw.
+
 ## Each of your turns
 
 You have 3 clicks. A rough loop (use `snapshot` to pull status + prompt + board +

--- a/dev/seat-corp.md
+++ b/dev/seat-corp.md
@@ -152,6 +152,13 @@ return is normal pacing, NOT a stall and NOT a decision. Re-entering simply
 re-arms the defender loop where it left off. (Only treat repeated timeouts with
 *zero* board movement across several re-issues as a possible genuine wedge.)
 
+To tell a slow-but-alive opponent from a dead one, don't guess — a `wait` /
+`monitor-run` return ends with a peer-liveness line, and you can check anytime
+with `./dev/send_command corp peer-status`. `opponent (runner): active Ns ago`
+→ still thinking, keep re-issuing. `opponent (runner): SILENT … likely
+disconnected` → their process has died; confirm `game-over-status` and, if still
+IN-PROGRESS, report the dead peer and stop rather than looping forever.
+
 **Rez judgement:** rez when the ICE actually stops or taxes a run you care about
 (protecting an agenda/centrals you can't afford to lose), not reflexively — rezzing
 burns credits and reveals the card. A cheap ICE on a server with nothing worth

--- a/dev/seat-runner-devin.md
+++ b/dev/seat-runner-devin.md
@@ -28,6 +28,18 @@ already kept its hand. You take the Runner seat.
    A `wait` that wakes with reason `my-turn-start` means **start your turn** (run
    `start-turn`); it is NOT a stall. Reason `my-turn` (with clicks) means act now.
 
+   **Do NOT give up just because a `wait` times out empty.** A `wait` return now
+   ends with a peer-liveness line — and you can check any time with
+   `./dev/send_command runner peer-status`:
+   - `opponent (corp): active Ns ago — alive` → the Corp is **still thinking**.
+     Re-issue `wait` and keep going. This is the normal case; a slow model can
+     think for many minutes. Patience is correct play, not a stall.
+   - `opponent (corp): SILENT … — likely disconnected` → only THEN is the Corp
+     genuinely gone. Confirm with `game-over-status`; if still IN-PROGRESS, the
+     opponent's process has died and the game can't continue — report that and stop.
+   Never conclude "the opponent is stuck / I should quit" off an empty `wait`
+   alone — check `peer-status` first. An alive-but-slow Corp is the default.
+
 3. **Isolation contract (hard rule):** ONLY ever run `./dev/send_command runner …`.
    NEVER run a `corp` command. Never try to inspect the Corp's hidden information
    (their HQ/hand, R&D order, facedown installs, pending rez). You only learn a

--- a/dev/send_command
+++ b/dev/send_command
@@ -26,7 +26,7 @@ BOT_NS="ai-heuristic-corp"
 
 # Check if first argument looks like a client name (not a command)
 FIRST_ARG="${1:-help}"
-if [[ "$FIRST_ARG" =~ ^(runner|corp|[a-z][a-z0-9-]*)$ ]] && [[ ! "$FIRST_ARG" =~ ^(help|status|snapshot|game-over\?|game-over-status|board|hand|prompt|credits|clicks|archives|heap|log|card-text|hand-text|abilities|list-playables|diagnose-blocker|start-turn|indicate-action|take-credit|draw|end-turn|smart-end-turn|remove-tag|purge|trash-resource|change|fix-credits|discard-card|draw-to-card|find-card|keep-hand|mulligan|discard|play|play-index|run|use-ability|use-runner-ability|trash|rez|fire-subs|let-subs-fire|auto-pass|advance|score|choose|choose-value|choose-card|multi-choose|continue|continue-run|monitor-run|jack-out|tank|wait|get-cursor|ping|create-game|start-game|leave-game|list-lobbies|join|resync|chat|install|install-index|connect|eval|debug-chat|dashboard|dashboard-compact|bot|bot-turn|bot-status|bot-loop|bot-loop-status|bot-loop-stop)$ ]]; then
+if [[ "$FIRST_ARG" =~ ^(runner|corp|[a-z][a-z0-9-]*)$ ]] && [[ ! "$FIRST_ARG" =~ ^(help|status|snapshot|game-over\?|game-over-status|board|hand|prompt|credits|clicks|archives|heap|log|card-text|hand-text|abilities|list-playables|diagnose-blocker|start-turn|indicate-action|take-credit|draw|end-turn|smart-end-turn|remove-tag|purge|trash-resource|change|fix-credits|discard-card|draw-to-card|find-card|keep-hand|mulligan|discard|play|play-index|run|use-ability|use-runner-ability|trash|rez|fire-subs|let-subs-fire|auto-pass|advance|score|choose|choose-value|choose-card|multi-choose|continue|continue-run|monitor-run|jack-out|tank|wait|get-cursor|ping|peer-status|create-game|start-game|leave-game|list-lobbies|join|resync|chat|install|install-index|connect|eval|debug-chat|dashboard|dashboard-compact|bot|bot-turn|bot-status|bot-loop|bot-loop-status|bot-loop-stop)$ ]]; then
     CLIENT_NAME="$1"
     shift
 
@@ -84,7 +84,7 @@ did_you_mean() {
             echo -e "${YELLOW}💡 Did you mean: continue  (pass priority in a run; or monitor-run to participate)${NC}" >&2; return;;
     esac
     # Fallback: substring match against the player-facing commands.
-    local known="status board hand prompt credits clicks archives heap log card-text abilities list-playables diagnose-blocker start-turn end-turn smart-end-turn draw take-credit play install advance score rez run continue jack-out tank choose choose-card choose-value multi-choose wait get-cursor ping keep-hand mulligan discard remove-tag game-over-status"
+    local known="status board hand prompt credits clicks archives heap log card-text abilities list-playables diagnose-blocker start-turn end-turn smart-end-turn draw take-credit play install advance score rez run continue jack-out tank choose choose-card choose-value multi-choose wait get-cursor ping peer-status keep-hand mulligan discard remove-tag game-over-status"
     local hits
     # `|| true`: grep exits non-zero on no match, which under `set -euo pipefail`
     # would abort the whole script *here* — silently swallowing both this hint and
@@ -275,6 +275,10 @@ ${GREEN}Waiting:${NC}
                               Default 300s timeout. Always pass --since
                               with the cursor you captured before acting.
   ping             Send 'ping' chat to wake opponent's wait
+  peer-status      Is my opponent alive? Shows how long since their driver last
+                   acted. Use when a wait keeps timing out empty: 'active Ns ago'
+                   = still thinking (keep waiting); 'SILENT / likely disconnected'
+                   = their process died — conclude, don't wait forever.
 
 ${GREEN}Lobby:${NC}
   create-game <title>   Create new game
@@ -564,11 +568,68 @@ else
     echo "[$(date +'%Y-%m-%d %H:%M:%S')] default: $COMMAND $*" >> "$LOG_FILE" 2>/dev/null || true
 fi
 
+# ── Peer liveness / dead-peer detection ──────────────────────────────────────
+# Every send_command invocation from a side is a heartbeat: that side's DRIVER
+# (Claude / devin / any guest) is alive and acting. We touch a per-side file so
+# the OTHER side can tell "opponent still thinking" from "opponent process died"
+# — the gap that silently kills un-babysat cross-model games (a dead guest looks
+# identical to a slow one). Chokepoint design: instrumenting send_command means
+# every harness is covered without per-harness hooks. Because the 120s Bash tool
+# ceiling forces even a blocking `wait` to return every ~2min, an alive-but-
+# waiting driver re-touches within ~2min; only a genuinely dead driver goes
+# stale past the ~5min threshold. Best-effort — a heartbeat failure must never
+# abort the real command under `set -euo pipefail`.
+HEARTBEAT_DIR="${HEARTBEAT_DIR:-${NETRUNNER_ROOT}/logs/.heartbeats}"
+PEER_STALE_SECS="${PEER_STALE_SECS:-300}"   # opponent silent this long ⇒ likely disconnected
+
+opponent_of() {   # echo the other seat, or empty for non-corp/runner callers
+    case "$1" in
+        corp)   echo "runner" ;;
+        runner) echo "corp" ;;
+        *)      echo "" ;;
+    esac
+}
+
+file_mtime() {    # portable mtime epoch (darwin -f, linux -c)
+    stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null
+}
+
+fmt_age() {       # seconds → "8s" / "6m 12s"
+    local s="$1"
+    if (( s < 60 )); then echo "${s}s"; else echo "$(( s / 60 ))m $(( s % 60 ))s"; fi
+}
+
+# Touch THIS side's heartbeat (driver is alive right now).
+if [[ "$CLIENT_NAME" == "corp" || "$CLIENT_NAME" == "runner" ]]; then
+    mkdir -p "$HEARTBEAT_DIR" 2>/dev/null || true
+    touch "${HEARTBEAT_DIR}/${CLIENT_NAME}" 2>/dev/null || true
+fi
+
+# peer_liveness_line — echo a one-line read of the OPPONENT's last activity, or
+# nothing if we can't tell (no side, no heartbeat yet). Used as a footer on the
+# waiting commands and by the `peer-status` command.
+peer_liveness_line() {
+    local opp; opp="$(opponent_of "$CLIENT_NAME")"
+    [[ -z "$opp" ]] && return 0
+    local hb="${HEARTBEAT_DIR}/${opp}"
+    [[ -f "$hb" ]] || { echo "⏱  opponent (${opp}): no heartbeat yet (not seen acting this session)"; return 0; }
+    local mt; mt="$(file_mtime "$hb")"
+    [[ -z "$mt" ]] && return 0
+    local now age; now="$(date +%s)"; age=$(( now - mt ))
+    (( age < 0 )) && age=0
+    if (( age >= PEER_STALE_SECS )); then
+        echo "⚠️  opponent (${opp}): SILENT $(fmt_age "$age") — likely disconnected (threshold ${PEER_STALE_SECS}s). Don't wait forever; verify game-over-status / conclude."
+    else
+        echo "⏱  opponent (${opp}): active $(fmt_age "$age") ago — alive, keep waiting if it's their move."
+    fi
+}
+
 # Help is pure text — it must work even when no REPL is running (e.g. after a
 # game times out and the REPLs get bounced). Everything else needs a live client.
 case "$COMMAND" in
-    help|--help|-h) ;;
-    *)              check_client ;;
+    help|--help|-h)  ;;
+    peer-status)     ;;   # reads local heartbeat files only — no REPL needed
+    *)               check_client ;;
 esac
 
 case "$COMMAND" in
@@ -1114,6 +1175,9 @@ case "$COMMAND" in
         info "Loop mode (monitor-run is alias for 'continue')..."
         execute "(ai-actions/monitor-run!$FLAGS_ARGS)"
         show_last_log_if_enabled
+        # Peer-liveness footer: on a monitor-run timeout the seat must judge
+        # whether the opponent is thinking or gone before re-issuing.
+        PEER_LINE="$(peer_liveness_line)"; [[ -n "$PEER_LINE" ]] && echo "$PEER_LINE"
         ;;
 
     jack-out)
@@ -1210,11 +1274,30 @@ case "$COMMAND" in
             info "Waiting (timeout: ${TIMEOUT}s)..."
             execute "(ai-actions/wait-for-relevant-diff $TIMEOUT)"
         fi
+        # Peer-liveness footer: a wait that returns empty is where a seat must
+        # decide "opponent thinking vs dead" — surface the opponent's heartbeat age.
+        PEER_LINE="$(peer_liveness_line)"; [[ -n "$PEER_LINE" ]] && echo "$PEER_LINE"
         ;;
 
     get-cursor)
         ensure_connection
         execute "(ai-actions/get-cursor)"
+        ;;
+
+    peer-status)
+        # Dead-peer check: how long since the OPPONENT's driver last acted (issued
+        # any send_command). No REPL needed — reads local heartbeat files only.
+        OPP="$(opponent_of "$CLIENT_NAME")"
+        if [[ -z "$OPP" ]]; then
+            echo "peer-status needs a side: ./dev/send_command <corp|runner> peer-status"
+        else
+            SELF_HB="${HEARTBEAT_DIR}/${CLIENT_NAME}"
+            if [[ -f "$SELF_HB" ]]; then
+                SELF_MT="$(file_mtime "$SELF_HB")"; SELF_AGE=$(( $(date +%s) - ${SELF_MT:-0} ))
+                echo "you (${CLIENT_NAME}): active $(fmt_age "$SELF_AGE") ago"
+            fi
+            peer_liveness_line
+        fi
         ;;
 
     # Lobby

--- a/dev/send_command
+++ b/dev/send_command
@@ -613,7 +613,9 @@ peer_liveness_line() {
     [[ -z "$opp" ]] && return 0
     local hb="${HEARTBEAT_DIR}/${opp}"
     [[ -f "$hb" ]] || { echo "⏱  opponent (${opp}): no heartbeat yet (not seen acting this session)"; return 0; }
-    local mt; mt="$(file_mtime "$hb")"
+    # Guard: a failed stat (TOCTOU delete, perms, unsupported stat) must NOT abort
+    # the real command under set -e — peer liveness is strictly best-effort.
+    local mt; mt="$(file_mtime "$hb" 2>/dev/null || true)"
     [[ -z "$mt" ]] && return 0
     local now age; now="$(date +%s)"; age=$(( now - mt ))
     (( age < 0 )) && age=0
@@ -1293,7 +1295,8 @@ case "$COMMAND" in
         else
             SELF_HB="${HEARTBEAT_DIR}/${CLIENT_NAME}"
             if [[ -f "$SELF_HB" ]]; then
-                SELF_MT="$(file_mtime "$SELF_HB")"; SELF_AGE=$(( $(date +%s) - ${SELF_MT:-0} ))
+                SELF_MT="$(file_mtime "$SELF_HB" 2>/dev/null || true)"
+                SELF_AGE=$(( $(date +%s) - ${SELF_MT:-0} ))
                 echo "you (${CLIENT_NAME}): active $(fmt_age "$SELF_AGE") ago"
             fi
             peer_liveness_line

--- a/dev/test/peer_status_test.sh
+++ b/dev/test/peer_status_test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# peer_status_test.sh — regression guard for dead-peer detection (heartbeat).
+#
+# Why this exists: an un-babysat cross-model game silently wedges when a guest
+# seat's DRIVER dies (e.g. devin one-shot exit) while its REPL stays alive — from
+# the other seat, an empty `wait` is indistinguishable from "opponent thinking".
+# send_command now touches a per-side heartbeat on every invocation and reports
+# the opponent's last-active age (`peer-status`, and a footer on wait/monitor-run).
+# This test locks that logic. `peer-status` needs NO live REPL (reads local files
+# only), so the whole flow is testable in isolation.
+#
+# Heartbeats are isolated to a temp dir via HEARTBEAT_DIR so the test never
+# touches the real logs/.heartbeats.
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SEND_CMD="$SCRIPT_DIR/../send_command"
+
+export HEARTBEAT_DIR
+HEARTBEAT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/nr-heartbeat-test.XXXXXX")"
+trap 'rm -rf "$HEARTBEAT_DIR"' EXIT
+
+fails=0
+assert_contains() {  # NAME  HAYSTACK  NEEDLE
+    local name="$1" hay="$2" needle="$3"
+    if [[ "$hay" == *"$needle"* ]]; then
+        echo "ok   [$name]"
+    else
+        echo "FAIL [$name]: expected to contain '$needle', got:"; printf '%s\n' "$hay" | sed 's/^/    /'
+        fails=$((fails+1))
+    fi
+}
+assert_not_contains() {  # NAME  HAYSTACK  NEEDLE
+    local name="$1" hay="$2" needle="$3"
+    if [[ "$hay" != *"$needle"* ]]; then
+        echo "ok   [$name]"
+    else
+        echo "FAIL [$name]: expected NOT to contain '$needle', got:"; printf '%s\n' "$hay" | sed 's/^/    /'
+        fails=$((fails+1))
+    fi
+}
+
+# 1. Cold start: runner has never acted → corp sees "no heartbeat yet".
+OUT=$("$SEND_CMD" corp peer-status 2>&1)
+assert_contains "cold-start-no-heartbeat" "$OUT" "opponent (runner): no heartbeat yet"
+assert_contains "self-heartbeat-touched"  "$OUT" "you (corp): active"
+
+# 2. Runner acts (peer-status touches its own side) → corp now sees runner alive.
+"$SEND_CMD" runner peer-status >/dev/null 2>&1
+OUT=$("$SEND_CMD" corp peer-status 2>&1)
+assert_contains "fresh-peer-alive" "$OUT" "opponent (runner): active"
+assert_not_contains "fresh-peer-not-silent" "$OUT" "SILENT"
+
+# 3. Dead peer: backdate runner heartbeat past the threshold → "SILENT / disconnected".
+BACKDATE="$(date -v-6M +%Y%m%d%H%M 2>/dev/null || date -d '6 min ago' +%Y%m%d%H%M)"
+touch -t "$BACKDATE" "$HEARTBEAT_DIR/runner"
+OUT=$(PEER_STALE_SECS=300 "$SEND_CMD" corp peer-status 2>&1)
+assert_contains "stale-peer-flagged"      "$OUT" "SILENT"
+assert_contains "stale-peer-disconnected" "$OUT" "likely disconnected"
+
+# 4. Symmetry: from the runner's seat the opponent is the corp.
+OUT=$("$SEND_CMD" runner peer-status 2>&1)
+assert_contains "symmetry-opponent-is-corp" "$OUT" "opponent (corp)"
+
+# 5. Threshold is honoured: a 6-min-old heartbeat is NOT stale under a 3600s bar.
+OUT=$(PEER_STALE_SECS=3600 "$SEND_CMD" corp peer-status 2>&1)
+assert_not_contains "threshold-respected" "$OUT" "SILENT"
+
+echo "---"
+if [[ $fails -eq 0 ]]; then
+    echo "peer_status_test: ALL PASSED"; exit 0
+else
+    echo "peer_status_test: $fails FAILED"; exit 1
+fi


### PR DESCRIPTION
Two fixes from the G1 marquee post-mortem (forum `ai-netrunner` [164]). Neither is the #31 fix (that's merged + validated) — these are what actually made G1 die.

## 1. Dead-peer detection (`feat(send_command)`)

**Problem:** un-babysat cross-model games silently wedge when a guest seat's *driver* dies (e.g. devin's one-shot exit) while its REPL stays alive. From the other seat, an empty `wait` is **indistinguishable** from "opponent still thinking." G1 died exactly this way — the GPT-5.5 Runner quit during the Corp's legit deliberation, and no seat could tell a dead peer from a slow one.

**Fix (send_command chokepoint — covers every harness, no per-harness hooks, per @Clamatius):**
- Every `send_command <side> …` touches a per-side heartbeat file (driver is alive + acting).
- New **`peer-status`** command (REPL-free — reads local files only) + a **peer-liveness footer on `wait`/`monitor-run`** returns: `opponent (runner): active 8s ago — alive` vs `SILENT 6m — likely disconnected`.
- The 120s Bash tool ceiling forces even a blocking `wait` to return every ~2min, so an alive-but-waiting driver re-touches within ~2min while a dead driver goes stale past the ~5min `PEER_STALE_SECS` threshold — cleanly separating the two. (That annoying ceiling becomes the liveness clock.)
- **Parse-safe:** footer only on wait/monitor-run; machine-parsed outputs (`get-cursor`, `eval`) untouched. Best-effort touch/stat (never aborts the real command). `HEARTBEAT_DIR`/`PEER_STALE_SECS` env-overridable.

**Seat briefs** (runner-devin, corp, corp-devin): on an empty wait, check `peer-status` — alive → keep waiting (patience is correct play), SILENT → confirm `game-over-status` and stop. Directly fixes the "gave up too early" failure that killed G1.

## 2. ICE-first Corp mulligan heuristic (`docs(seat-corp)`)

The Opus Corp kept a 0-ICE, economy-rich opener (reasoning "money is threat"). @Clamatius: that's a losing keep — you must top-deck several ICE before agendas arrive or a naked server hands over free agenda access. Root cause was a **doc gap**: both Corp briefs' mulligan sections said only "make your call." Added the heuristic (0 ICE → mulligan; 1 → lean mulligan; 2+ + econ → keep; agendas in the opener are fine). A documentation-error finding, not a model error.

## Tests / review
- `dev/test/peer_status_test.sh` — 8 REPL-free assertions (cold-start, fresh-alive, stale-flagged, symmetry, threshold), wired into `make test-shell`.
- Full suite **418/0** + all shell tests (`make verify`).
- Codex (gpt-5.5) review: found one MAJOR (unguarded `file_mtime` could abort send_command under `set -e`) — **fixed** (`2>/dev/null || true`); otherwise confirmed footer parse-safety, `peer-status` REPL-exemption, and stat/date portability. Re-verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)