### PR TITLE
fix(peer-status): clear heartbeats on fresh game (kill false-alive at start)

### DIFF
--- a/dev/reset.sh
+++ b/dev/reset.sh
@@ -116,6 +116,13 @@ else
     echo "✅ Game ID: $GAME_ID"
 fi
 
+# Zero the peer-liveness clock: a NEW game means neither driver has acted in it
+# yet. Clearing here (after the game-id verify above, which itself touches corp's
+# heartbeat) means peer-status honestly reads "no heartbeat yet" until a real
+# driver acts in THIS game — a stale heartbeat from a prior game (or a setup
+# touch) can no longer masquerade as a live opponent. Best-effort; never fatal.
+"$SCRIPT_DIR/send_command" clear-heartbeats >> "$LOG_FILE" 2>&1 || true
+
 # Show final status
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/dev/send_command
+++ b/dev/send_command
@@ -26,7 +26,7 @@ BOT_NS="ai-heuristic-corp"
 
 # Check if first argument looks like a client name (not a command)
 FIRST_ARG="${1:-help}"
-if [[ "$FIRST_ARG" =~ ^(runner|corp|[a-z][a-z0-9-]*)$ ]] && [[ ! "$FIRST_ARG" =~ ^(help|status|snapshot|game-over\?|game-over-status|board|hand|prompt|credits|clicks|archives|heap|log|card-text|hand-text|abilities|list-playables|diagnose-blocker|start-turn|indicate-action|take-credit|draw|end-turn|smart-end-turn|remove-tag|purge|trash-resource|change|fix-credits|discard-card|draw-to-card|find-card|keep-hand|mulligan|discard|play|play-index|run|use-ability|use-runner-ability|trash|rez|fire-subs|let-subs-fire|auto-pass|advance|score|choose|choose-value|choose-card|multi-choose|continue|continue-run|monitor-run|jack-out|tank|wait|get-cursor|ping|peer-status|create-game|start-game|leave-game|list-lobbies|join|resync|chat|install|install-index|connect|eval|debug-chat|dashboard|dashboard-compact|bot|bot-turn|bot-status|bot-loop|bot-loop-status|bot-loop-stop)$ ]]; then
+if [[ "$FIRST_ARG" =~ ^(runner|corp|[a-z][a-z0-9-]*)$ ]] && [[ ! "$FIRST_ARG" =~ ^(help|status|snapshot|game-over\?|game-over-status|board|hand|prompt|credits|clicks|archives|heap|log|card-text|hand-text|abilities|list-playables|diagnose-blocker|start-turn|indicate-action|take-credit|draw|end-turn|smart-end-turn|remove-tag|purge|trash-resource|change|fix-credits|discard-card|draw-to-card|find-card|keep-hand|mulligan|discard|play|play-index|run|use-ability|use-runner-ability|trash|rez|fire-subs|let-subs-fire|auto-pass|advance|score|choose|choose-value|choose-card|multi-choose|continue|continue-run|monitor-run|jack-out|tank|wait|get-cursor|ping|peer-status|clear-heartbeats|create-game|start-game|leave-game|list-lobbies|join|resync|chat|install|install-index|connect|eval|debug-chat|dashboard|dashboard-compact|bot|bot-turn|bot-status|bot-loop|bot-loop-status|bot-loop-stop)$ ]]; then
     CLIENT_NAME="$1"
     shift
 
@@ -461,6 +461,8 @@ ${GREEN}Debug & Dev:${NC}
   find-card <name>    - Multi-turn search (Corp bot takes turns)
   eval <expr>         - Execute arbitrary Clojure expression
   nuke-state          - Clear all cached game state
+  clear-heartbeats    - Zero the peer-liveness clock (fresh game; reset.sh calls
+                        this so a stale heartbeat can't read as a live opponent)
   debug-chat [on|off] - Toggle debug chat mode
   connect             - Manually reconnect WebSocket
 
@@ -631,6 +633,7 @@ peer_liveness_line() {
 case "$COMMAND" in
     help|--help|-h)  ;;
     peer-status)     ;;   # reads local heartbeat files only — no REPL needed
+    clear-heartbeats) ;;  # removes local heartbeat files only — no REPL needed
     *)               check_client ;;
 esac
 
@@ -1301,6 +1304,16 @@ case "$COMMAND" in
             fi
             peer_liveness_line
         fi
+        ;;
+
+    clear-heartbeats)
+        # Zero the peer-liveness clock for a FRESH game. Called by reset.sh so a
+        # heartbeat left over from a prior game (or a setup touch) can't read as
+        # "opponent alive" before the new opponent has actually acted — a false-
+        # alive that masks a guest driver which never connected. Invoked side-less
+        # so it does NOT re-touch a heartbeat on its way out. Best-effort; no REPL.
+        rm -f "${HEARTBEAT_DIR}/corp" "${HEARTBEAT_DIR}/runner" 2>/dev/null || true
+        echo "🧹 Peer heartbeats cleared (fresh-game liveness clock)"
         ;;
 
     # Lobby

--- a/dev/test/peer_status_test.sh
+++ b/dev/test/peer_status_test.sh
@@ -66,6 +66,29 @@ assert_contains "symmetry-opponent-is-corp" "$OUT" "opponent (corp)"
 OUT=$(PEER_STALE_SECS=3600 "$SEND_CMD" corp peer-status 2>&1)
 assert_not_contains "threshold-respected" "$OUT" "SILENT"
 
+# 6. clear-heartbeats zeroes the liveness clock (fresh-game path). Without this, a
+#    heartbeat left over from a prior game (or a setup touch) reads as "alive" and
+#    masks a guest driver that never actually connected — a FALSE-alive at exactly
+#    the moment the sensor matters. reset.sh calls this so a new game starts honest.
+"$SEND_CMD" corp peer-status >/dev/null 2>&1   # ensure both sides have heartbeats
+"$SEND_CMD" runner peer-status >/dev/null 2>&1
+[[ -f "$HEARTBEAT_DIR/corp" && -f "$HEARTBEAT_DIR/runner" ]] \
+    && echo "ok   [pre-clear-heartbeats-exist]" \
+    || { echo "FAIL [pre-clear-heartbeats-exist]: heartbeat files missing before clear"; fails=$((fails+1)); }
+CLR=$("$SEND_CMD" clear-heartbeats 2>&1)
+assert_contains "clear-reports-done" "$CLR" "cleared"
+[[ ! -f "$HEARTBEAT_DIR/corp" && ! -f "$HEARTBEAT_DIR/runner" ]] \
+    && echo "ok   [post-clear-heartbeats-gone]" \
+    || { echo "FAIL [post-clear-heartbeats-gone]: heartbeat files still present after clear"; fails=$((fails+1)); }
+# After a clear, the opponent honestly reads as "not seen acting" (not a ghost alive).
+OUT=$("$SEND_CMD" corp peer-status 2>&1)
+assert_contains "post-clear-honest" "$OUT" "opponent (runner): no heartbeat yet"
+assert_not_contains "post-clear-not-ghost-alive" "$OUT" "opponent (runner): active"
+
+# 7. Wiring: the fresh-game path (reset.sh) actually clears heartbeats, else the
+#    primitive above is dead code and the false-alive survives in real games.
+assert_contains "reset-wires-clear" "$(cat "$SCRIPT_DIR/../reset.sh")" "clear-heartbeats"
+
 echo "---"
 if [[ $fails -eq 0 ]]; then
     echo "peer_status_test: ALL PASSED"; exit 0


### PR DESCRIPTION
## What
Heartbeat files (`logs/.heartbeats/{corp,runner}`) were **never cleared between games**. A leftover heartbeat — or a setup touch like a `runner status` check during marquee launch — could read as **"opponent alive"** before the new opponent driver had ever acted in the fresh game.

That's a **false-alive at the one moment the dead-peer sensor (#63) matters most**: a Corp seat waiting on a guest Runner that crashed on startup would see `runner active 2m ago — alive, keep waiting` from the stale touch, exactly masking the "guest never connected / died" case the sensor was built to catch.

## Fix
- New REPL-free `clear-heartbeats` subcommand — invoked **side-less** so it does *not* re-touch a heartbeat on its way out.
- `reset.sh` (the fresh-game path) calls it as its last step, after the internal game-id verify, so a new game starts with an honest liveness clock.
- `resume.sh` deliberately untouched — same ongoing game, peer liveness still valid.

## Safety
Can only ever **remove a false-alive**, never create a false-dead (the dangerous direction). Worst case, `peer-status` honestly reads `no heartbeat yet`.

## Tests
6 new assertions in `peer_status_test.sh` (primitive clears both files, honest post-clear read, reset.sh wiring), red→green. Full suite **418/0** + shell green.

## Review
Codex (gpt-5.5) off-vendor: **merge**, no findings — verified `bash -n` clean, side-less path skips the touch, only `reset.sh` wires the clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)