### PR TITLE
fix(wait): suppress peer-liveness footer on game-over wake

### DIFF
--- a/dev/send_command
+++ b/dev/send_command
@@ -1274,14 +1274,21 @@ case "$COMMAND" in
         done
         if [[ -n "$SINCE" ]]; then
             info "Waiting (timeout: ${TIMEOUT}s, since cursor: ${SINCE})..."
-            execute "(ai-actions/wait-for-relevant-diff {:timeout $TIMEOUT :since $SINCE})"
+            WAIT_OUT="$(execute "(ai-actions/wait-for-relevant-diff {:timeout $TIMEOUT :since $SINCE})" || true)"
         else
             info "Waiting (timeout: ${TIMEOUT}s)..."
-            execute "(ai-actions/wait-for-relevant-diff $TIMEOUT)"
+            WAIT_OUT="$(execute "(ai-actions/wait-for-relevant-diff $TIMEOUT)" || true)"
         fi
+        printf '%s\n' "$WAIT_OUT"
         # Peer-liveness footer: a wait that returns empty is where a seat must
         # decide "opponent thinking vs dead" — surface the opponent's heartbeat age.
-        PEER_LINE="$(peer_liveness_line)"; [[ -n "$PEER_LINE" ]] && echo "$PEER_LINE"
+        # But SUPPRESS it on a game-over wake: there the "alive, keep waiting if
+        # it's their move" variant flatly contradicts the "stop acting" wake line
+        # printed just above (and at real game-end the loser just moved, so their
+        # heartbeat IS fresh — the contradictory variant is the normal outcome).
+        if [[ "$WAIT_OUT" != *"Game over"* && "$WAIT_OUT" != *"game-over"* && "$WAIT_OUT" != *"🏁"* ]]; then
+            PEER_LINE="$(peer_liveness_line)"; [[ -n "$PEER_LINE" ]] && echo "$PEER_LINE"
+        fi
         ;;
 
     get-cursor)

--- a/dev/test/peer_status_test.sh
+++ b/dev/test/peer_status_test.sh
@@ -89,6 +89,14 @@ assert_not_contains "post-clear-not-ghost-alive" "$OUT" "opponent (runner): acti
 #    primitive above is dead code and the false-alive survives in real games.
 assert_contains "reset-wires-clear" "$(cat "$SCRIPT_DIR/../reset.sh")" "clear-heartbeats"
 
+# 8. Wiring: the `wait` handler suppresses the peer footer on a game-over wake, so
+#    the "alive, keep waiting" footer can't contradict the "stop acting" game-over
+#    line (verified behaviorally against a live game-over state; this guards the
+#    suppression against regression-by-deletion since the shell harness has no
+#    live in-progress game to drive a wait through).
+SEND_SRC="$(cat "$SEND_CMD")"
+assert_contains "wait-suppresses-footer-on-gameover" "$SEND_SRC" 'WAIT_OUT" != *"Game over"*'
+
 echo "---"
 if [[ $fails -eq 0 ]]; then
     echo "peer_status_test: ALL PASSED"; exit 0


### PR DESCRIPTION
## What
#63 appended a peer-liveness footer to every `wait`. On a **game-over wake** it self-contradicts. Right under:

> 🏁 Game over — Corp wins — **stop acting**; call `game-over-status` ...

the footer prints:

> ⏱  opponent (runner): active 1s ago — alive, **keep waiting if it's their move.**

And this is the **normal** outcome at real game end — the losing side just made its move, so its heartbeat is fresh, so the "keep waiting" variant is exactly what fires. A guest seat reading "stop acting" then "keep waiting" has to guess.

## Fix
Capture the wait output (`execute()` already blocks-and-echoes — there is no live streaming to lose) and skip the footer when the output carries a game-over marker (`Game over` / `game-over` / `🏁`). The footer still fires on every non-over wait — its real job is the thinking-vs-dead call on an empty/timeout wait.

## Verification
Reproduced and fixed behaviorally against a live game-over state (before: contradictory footer; after: output ends clean at the game-over line). Shell test adds a wiring guard against regression-by-deletion — the shell harness has no live in-progress game to drive a real `wait` through, so behavioral coverage here is manual.

Full suite **418/0** + shell green. Codex (gpt-5.5) off-vendor: **merge**, no findings (confirmed `set -e` safety, no `--since` regression, best-effort-only suppression, printf newline handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)