### PR TITLE
fix(#31): Corp parks at its post; Runner breaks abandoned run windows; jack-out is a smell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ check-full:
 # Run unit tests
 test:
 	@echo "Running unit tests..."
-	lein test ai-actions-test ai-actions-sad-path-test ai-basic-actions-test ai-heuristic-corp-test ai-heuristic-runner-test ai-runs-test ai-run-corp-decisions-test ai-stall-test ai-websocket-diff-test ai-websocket-error-recovery-test ai-display-test ai-state-test ai-prompts-test ai-pure-functions-test ai-turn-validation-test ai-wait-test continue-run-rez-test
+	lein test ai-actions-test ai-actions-sad-path-test ai-basic-actions-test ai-heuristic-corp-test ai-heuristic-runner-test ai-runs-test ai-run-corp-decisions-test ai-stall-test ai-websocket-diff-test ai-websocket-error-recovery-test ai-display-test ai-state-test ai-prompts-test ai-pure-functions-test ai-turn-validation-test ai-wait-test continue-run-rez-test run-window-selfadvance-test
 
 # Run shell-level tests (fast, no REPL/server needed) — e.g. send_command output filters
 test-shell:

--- a/dev/seat-corp-devin.md
+++ b/dev/seat-corp-devin.md
@@ -79,27 +79,33 @@ prior cross-model game lost a run to a **deadlock at the run-initiation window**
 because the Corp was not monitoring when the Runner started the run. Do not repeat
 it. The rule:
 
-- **The instant a `wait` wakes because a run started, issue
+- **The instant you end your turn, issue
   `./dev/send_command corp monitor-run --persistent` BEFORE doing anything else.**
-  Do not read the board first, do not deliberate first — get the persistent
-  monitor running, *then* read the decision it pauses on. A run-initiation window
-  left unattended wedges the Runner (it waits for your priority and cannot pass it
-  itself).
-- **Always `--persistent`.** One command owns the whole run; it auto-passes the
-  empty "pass priority" windows and only returns to you for a real **rez**,
-  **fire**, attacked-server **upgrade**, unsupported prompt, or run-end decision.
-  Without `--persistent` you'd exit on every symmetric window — exactly where two
-  models deadlock.
-- After a real decision, RE-ENTER the monitor (still `--persistent`) with your
-  choice: `--rez "<ICE name>"`, `--no-rez`, or `--fire-if-asked`. For an
-  attacked-server upgrade, use `rez "<upgrade>"` or `continue`, then re-enter the
-  monitor. Read any unclear decision with `./dev/send_command corp prompt` and
-  `./dev/send_command corp board`.
+  Do not wait for a run to start; do not read the board first; do not deliberate
+  first. Take your post, *then* read whatever decision it pauses on.
+- **Always `--persistent`. It PARKS.** With no run active it waits at the post, and
+  it **owns the Runner's entire turn** — every run they make — returning only for a
+  real **rez**, **fire**, attacked-server **upgrade**, unsupported prompt, the
+  Runner's turn ending (`my-turn`), or game over. **You do not re-arm it per run.**
+- **Why this is the whole ballgame.** A rez window is a *both-must-pass* window. If
+  you are not at your post when the Runner reaches your ICE, the run stalls with
+  **nobody home** — and the Runner cannot pass your priority for you. In marquee
+  `d6962df4` the Corp's monitor kept exiting with "no active run" in the gaps
+  between runs, so the Runner hit an unattended window on nearly every run: 5
+  jack-outs, 1 encounter, 1 rez in the entire game. Parking exists to close that.
+- **Pre-commit your rez policy whenever you can** (`--rez "<ICE name>"` /
+  `--no-rez` / `--fire-if-asked`). A pre-committed monitor answers the window
+  *instantly*; a window that must wait for you to think is a window the Runner
+  spends minutes staring at. After a real decision, RE-ENTER the monitor (still
+  `--persistent`) with your choice. For an attacked-server upgrade, use
+  `rez "<upgrade>"` or `continue`, then re-enter. Read unclear decisions with
+  `./dev/send_command corp prompt` and `./dev/send_command corp board`.
 - Treat raw `continue`, `continue-run`, `rez`, and `fire-subs` as low-level
   escape hatches. Most runs should be handled by `monitor-run --persistent`.
-- **TIMEOUT during an active run is normal pacing, not a stall** — just re-issue
-  `monitor-run --persistent`. Only repeated timeouts with *zero* board movement
-  across several re-issues is a possible genuine wedge (note it for your report).
+- **TIMEOUT is normal pacing, not a stall** — just re-issue `monitor-run
+  --persistent` (this re-parks you). Only repeated timeouts with *zero* board
+  movement across several re-issues is a possible genuine wedge (note it for your
+  report).
 - **Slow-but-alive vs. dead opponent — check, don't guess.** A `wait` /
   `monitor-run` return ends with a peer-liveness line; you can also run
   `./dev/send_command corp peer-status` anytime. `opponent (runner): active Ns
@@ -107,9 +113,8 @@ it. The rule:
   (runner): SILENT … likely disconnected` → their process died; confirm
   `game-over-status` and, if still IN-PROGRESS, report the dead peer and stop —
   do not loop forever.
-- When a run ends, go back to the `wait` loop. **Several runs can happen in one
-  Runner turn — after each run ends, return to `wait`, and re-arm `monitor-run
-  --persistent` the moment the next run starts.** Never leave a gap between runs.
+- When the monitor returns `my-turn`, the Runner's turn is over — take your turn,
+  then take your post again.
 
 ## DELIVERABLE — this is the point of the game
 

--- a/dev/seat-corp.md
+++ b/dev/seat-corp.md
@@ -101,7 +101,8 @@ C=$(./dev/send_command corp get-cursor)        # capture cursor first
 ./dev/send_command corp wait --since "$C"       # blocks until something relevant
 ```
 
-When `wait` returns because a **run started**, participate:
+As soon as you end your turn, **take your post** — do not wait for a run to start
+first:
 
 ```
 ./dev/send_command corp monitor-run --persistent
@@ -111,13 +112,23 @@ When `wait` returns because a **run started**, participate:
 you, when you have a real decision** — typically a **rez** opportunity as the
 Runner approaches one of your ICE, or an unbroken-subroutine **fire** decision.
 
-**Always use `--persistent`.** Without it, `monitor-run` exits every time the
-Runner has priority (every "pass priority" window), and you'd have to re-issue
-it over and over — and because that window looks symmetric to both seats, it's
-exactly the spot where two models deadlock, each thinking it's waiting on the
-other. `--persistent` keeps your defender loop alive across those empty windows:
-**one command owns the whole run**, and it only returns to you for a real
-rez/fire decision or when the run ends. Read the decision:
+**Always use `--persistent`, and issue it immediately after ending your turn.**
+`--persistent` now **parks**: with no run yet active it waits at the post, and it
+**owns the Runner's whole turn** — across every run they make — returning only for
+a real rez/fire decision, when the Runner's turn ends (`my-turn`), or on game
+over. You no longer re-arm it per run.
+
+This matters more than it looks. A rez window is a *both-must-pass* window: if you
+are not at your post when the Runner arrives at your ICE, the run **stalls with
+nobody home**, and the Runner — who cannot act for you — eventually gives up. In
+marquee `d6962df4` that happened on nearly every run (5 jack-outs, 1 rez in the
+whole game) because the Corp's monitor kept exiting with "no active run" between
+runs. Parking is what keeps you present.
+
+**Pre-commit your rez policy** (`--rez "<ICE>"` / `--no-rez`) whenever you can: a
+pre-committed monitor answers the window *instantly*, whereas a window that has to
+wait for you to think is a window the Runner spends minutes staring at. Read the
+decision:
 
 ```
 ./dev/send_command corp prompt

--- a/dev/seat-runner-devin.md
+++ b/dev/seat-runner-devin.md
@@ -40,6 +40,16 @@ already kept its hand. You take the Runner seat.
    Never conclude "the opponent is stuck / I should quit" off an empty `wait`
    alone — check `peer-status` first. An alive-but-slow Corp is the default.
 
+   **NEVER jack out to unstick a run.** A jack-out is a *netrunner smell*: the
+   only tactically legitimate reasons are (1) you misjudged what it costs to get
+   in, and (2) a Karunā jack-out subroutine (bail before the 4th net damage kills
+   you). "The window isn't advancing" is NOT one of them — jacking out throws the
+   whole run away (breakers paid, credits spent, access lost) and fixes nothing.
+   If a run window sits waiting on the Corp: `peer-status` → alive ⇒ **wait**. The
+   client now self-advances any window the Corp provably cannot act in, so a
+   window that is genuinely waiting is one the Corp really does owe you. Be
+   patient and let them answer it.
+
 3. **Isolation contract (hard rule):** ONLY ever run `./dev/send_command runner …`.
    NEVER run a `corp` command. Never try to inspect the Corp's hidden information
    (their HQ/hand, R&D order, facedown installs, pending rez). You only learn a

--- a/dev/seat-runner.md
+++ b/dev/seat-runner.md
@@ -84,6 +84,15 @@ You have 4 clicks. A turn auto-ends when clicks hit 0. A rough loop:
 - If unsure what a prompt wants, read it with `prompt` and consult
   `./dev/send_command help --full`.
 
+**Jack-out is a smell.** The only tactically legitimate reasons to jack out are
+(1) you misjudged what it costs to get in, and (2) a Karunā jack-out subroutine
+(bail before the 4th net damage kills you). **Never jack out to unstick a run
+window** — it throws the whole run away (breakers paid, credits spent, access
+lost) and fixes nothing. If a window sits waiting on the Corp, check
+`peer-status`: alive ⇒ keep waiting. The client self-advances any window the Corp
+provably cannot act in, so a window that's genuinely waiting is one the Corp
+really does owe you.
+
 ## Between turns — wait, don't busy-poll
 
 The Corp's turn is played by the bot. Block until it's your turn (or a run/prompt

--- a/dev/send_command
+++ b/dev/send_command
@@ -640,6 +640,12 @@ if [[ "$CLIENT_NAME" == "corp" || "$CLIENT_NAME" == "runner" ]]; then
     (
         while kill -0 "$_hb_parent" 2>/dev/null; do
             sleep "${HEARTBEAT_TOUCH_SECS:-60}"
+            # Only REFRESH an existing heartbeat; never resurrect a cleared one.
+            # `clear-heartbeats` (reset.sh) deletes these files precisely so a
+            # stale seat cannot read as live in a fresh game — a long-lived parked
+            # monitor from the OLD game would otherwise re-create its file and go
+            # on looking alive across the reset.
+            [[ -f "${HEARTBEAT_DIR}/${CLIENT_NAME}" ]] || break
             touch "${HEARTBEAT_DIR}/${CLIENT_NAME}" 2>/dev/null || true
         done
     ) >/dev/null 2>&1 &

--- a/dev/send_command
+++ b/dev/send_command
@@ -624,6 +624,17 @@ fi
 # "this side's process is really alive", not merely "was alive once".
 # Best-effort throughout: a heartbeat failure must never abort the real command
 # under `set -euo pipefail`.
+#
+# CRITICAL detail — the `>/dev/null 2>&1` on the subshell is load-bearing, not
+# tidiness. A background child INHERITS this script's stdout. Nearly every caller
+# reads send_command through command substitution (`OUT="$(send_command …)"`),
+# which blocks until EOF on that pipe — and EOF only arrives when the LAST writer
+# closes it. A toucher holding stdout open therefore made every single command
+# block for HEARTBEAT_TOUCH_SECS (measured: 60s for `peer-status`), which is far
+# worse than the stall this file exists to fix. Redirecting the subshell's stdio
+# detaches it from the pipe so the parent's exit is the EOF. (Caught in review;
+# the unit tests still "passed" — merely slowly — so only a timing assertion
+# guards it. See peer_status_test.sh.)
 if [[ "$CLIENT_NAME" == "corp" || "$CLIENT_NAME" == "runner" ]]; then
     _hb_parent=$$
     (
@@ -631,7 +642,7 @@ if [[ "$CLIENT_NAME" == "corp" || "$CLIENT_NAME" == "runner" ]]; then
             sleep "${HEARTBEAT_TOUCH_SECS:-60}"
             touch "${HEARTBEAT_DIR}/${CLIENT_NAME}" 2>/dev/null || true
         done
-    ) &
+    ) >/dev/null 2>&1 &
     _hb_toucher=$!
     trap 'kill "$_hb_toucher" 2>/dev/null || true' EXIT
 fi

--- a/dev/send_command
+++ b/dev/send_command
@@ -607,6 +607,35 @@ if [[ "$CLIENT_NAME" == "corp" || "$CLIENT_NAME" == "runner" ]]; then
     touch "${HEARTBEAT_DIR}/${CLIENT_NAME}" 2>/dev/null || true
 fi
 
+# KEEP the clock ticking for the life of THIS invocation.
+#
+# The touch above fires once, at invocation. That was fine while every command
+# returned quickly, but a long-blocking command (`wait`, and now especially
+# `monitor-run --persistent`, which PARKS at its post for the opponent's whole
+# turn) holds one invocation open for minutes. A correctly-parked, perfectly
+# ALIVE driver would then age past PEER_STALE_SECS and be reported to the
+# opponent as "SILENT — likely disconnected" — a false dead-peer verdict telling
+# the opponent to abandon a live game. That is precisely the failure the sensor
+# exists to prevent, so the sensor must not manufacture it.
+#
+# The toucher is bound to this process's lifetime via `kill -0`: if the driver
+# dies — including SIGKILL, where no trap runs — the toucher exits within one
+# interval and the heartbeat goes stale as it should. So "alive" still means
+# "this side's process is really alive", not merely "was alive once".
+# Best-effort throughout: a heartbeat failure must never abort the real command
+# under `set -euo pipefail`.
+if [[ "$CLIENT_NAME" == "corp" || "$CLIENT_NAME" == "runner" ]]; then
+    _hb_parent=$$
+    (
+        while kill -0 "$_hb_parent" 2>/dev/null; do
+            sleep "${HEARTBEAT_TOUCH_SECS:-60}"
+            touch "${HEARTBEAT_DIR}/${CLIENT_NAME}" 2>/dev/null || true
+        done
+    ) &
+    _hb_toucher=$!
+    trap 'kill "$_hb_toucher" 2>/dev/null || true' EXIT
+fi
+
 # peer_liveness_line — echo a one-line read of the OPPONENT's last activity, or
 # nothing if we can't tell (no side, no heartbeat yet). Used as a footer on the
 # waiting commands and by the `peer-status` command.

--- a/dev/src/clj/ai_display.clj
+++ b/dev/src/clj/ai_display.clj
@@ -1038,14 +1038,24 @@
         [(str "    ⏸️  You have already passed priority here — waiting for " opp
               " to pass before the run advances.")
          (str "      (No action needed from you; use 'wait'. Re-sending 'continue' does nothing.)")]
-        ;; Stall recovery (issue #31): a both-must-pass window only advances once
-        ;; the opponent also passes. In cross-model play the opposing seat must be
-        ;; actively monitoring the run to pass an empty window; if it isn't, the
-        ;; run stalls here and 'wait' never resolves. The Runner can break out with
-        ;; 'jack-out' (the marquee g3 escape hatch — "only jack-out cleared it").
+        ;; Stall recovery (issue #31). We used to tell the Runner that 'jack-out
+        ;; ends the run to recover' here. That advice LOST marquee d6962df4:
+        ;; GPT-5.5 followed it 5 times, once abandoning a Brân it had just broken
+        ;; for 8 credits on the run that would have contested the winning agenda.
+        ;;
+        ;; Jack-out is a NETRUNNER SMELL (Michael): the only tactically legitimate
+        ;; reasons are (1) you misjudged what it costs to get in, and (2) Karuna's
+        ;; jack-out subroutine (bail before the 4th net damage kills you). A window
+        ;; the opponent hasn't answered is NEITHER — it is the opposing seat not
+        ;; being at its post, and throwing away the run does not fix that. Patience
+        ;; is the correct play; the peer-liveness signal (#63) tells you whether
+        ;; waiting is sane.
         (when (= my-side "runner")
-          [(str "      If " opp " isn't actively monitoring the run, it can stall here — "
-                "'jack-out' ends the run to recover.")]))
+          [(str "      Waiting is CORRECT here — " opp " owes a decision. Check `peer-status`: "
+                "alive ⇒ keep waiting.")
+           (str "      Do NOT 'jack-out' to unstick a window — it throws the run away. "
+                "Jack-out is a smell: the only real reasons are a misjudged entry cost "
+                "or a Karuna jack-out sub.")]))
 
       ;; Opponent already passed — my continue advances the run now.
       (and na (not= na my-side))

--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -651,13 +651,15 @@
   [state side]
   (= (normalize-side (get-in state [:game-state :run :no-action])) side))
 
-(defn- attacked-server-content
-  "Cards in the root of the server currently being run (upgrades/assets).
-   Face-down but VISIBLE to the Runner — no hidden info is used here, only
-   whether a root card is rezzed."
+(defn- attacked-server
+  "The server map for the server currently being run, or nil if we cannot resolve
+   it. Distinguishing \"server not found\" (unknown) from \"server found, root
+   empty\" matters: the wire omits empty collections, so a missing :content on a
+   server we CAN see proves an empty root, whereas a server we cannot see at all
+   proves nothing."
   [state]
   (let [server (get-in state [:game-state :run :server])]
-    (get-in state [:game-state :corp :servers (keyword (last server)) :content])))
+    (get-in state [:game-state :corp :servers (keyword (last server))])))
 
 (defn opponent-has-run-decision?
   "Does the OPPONENT hold a REAL decision at this both-must-pass run window?
@@ -668,6 +670,19 @@
    'true' costs us nothing but a wait; answering 'false' wrongly would SKIP a
    real decision — that is the blunt `corp-auto-no-action` behaviour we rejected.
    So every case we cannot prove is conservatively `true`.
+
+   SCOPE — read this before widening the card pool. What is modelled here is
+   exactly ONE Corp decision: a REZ. That is the only run-window action the Corp
+   can take in the System Gateway pool we play. The engine permits more, and a
+   larger pool would break the equivalence: a rezzed Border Control's
+   `[trash]: End the run` is a live decision at movement even when every root card
+   is already rezzed, and this predicate would happily report 'no decision' and let
+   the Runner walk past it. That does not bite today, but it is a property of the
+   CARD POOL, not of this function, and it will not announce itself when the pool
+   changes. Widening the pool means extending this predicate (rezzed cards with
+   run-usable paid abilities) — not trusting it. The grace period in
+   `handle-stalled-window-self-advance` is what keeps the blast radius survivable
+   in the meantime: a Corp that is present still gets to take the action.
 
    Runner-side only. As Corp the opponent is the Runner, who always has live
    options at a window (jack out, break, paid abilities), so nothing is provable
@@ -686,13 +701,26 @@
     (case run-phase
       "initiation" false
 
+      ;; NOTE the nil handling in both branches. `current-run-ice` returns nil for
+      ;; "no run / position 0 / position out of bounds / no ICE on the server" —
+      ;; i.e. for every state in which we CANNOT SEE the approached ICE. Folding
+      ;; that into `false` would turn "I can't tell" into "the Corp has nothing to
+      ;; do", and we would skip a live rez window on the strength of a wire
+      ;; transient (a diff applied out of order, an ICE trashed mid-run: any
+      ;; disagreement between :position and the :ices vector). Absence of evidence
+      ;; is not evidence of absence: unknown ⇒ assume a decision ⇒ wait.
       "approach-ice"
       (let [ice (core/current-run-ice state)]
-        (boolean (and ice (not (:rezzed ice)))))
+        (if (nil? ice) true (not (:rezzed ice))))
 
       "movement"
       (if (zero? (or (get-in state [:game-state :run :position]) 0))
-        (boolean (some #(not (:rezzed %)) (attacked-server-content state)))
+        ;; Same asymmetry: if we cannot even resolve the attacked SERVER, we know
+        ;; nothing and must assume a decision. Only once the server is in hand does
+        ;; an empty/absent :content prove there is no root card to rez.
+        (if-let [server (attacked-server state)]
+          (boolean (some #(not (:rezzed %)) (:content server)))
+          true)
         true)
 
       ;; Anything else (encounter-ice, success, …): assume a real decision.
@@ -1663,11 +1691,25 @@
 (defn park-wake-reason
   "What should a PARKED persistent monitor do right now?
 
-   :game-over — stop (parking through a finished game hangs the seat forever)
-   :run       — a run is active: go own it
-   :my-turn   — the opponent's turn ended: hand control back to the seat
-   :park      — opponent's turn, no run yet: STAY AT THE POST
-   :no-run    — nothing to defend and nothing coming: don't park
+   :game-over          — stop (parking through a finished game hangs the seat forever)
+   :run                — a run is active: go own it
+   :decision-required  — I am holding a prompt only I can resolve: surface it
+   :my-turn            — the opponent's turn ended: hand control back to the seat
+   :park               — opponent's turn, no run yet: STAY AT THE POST
+   :no-run             — nothing to defend and nothing coming: don't park
+
+   :decision-required is not optional garnish — it is what keeps parking safe.
+   The flow park REPLACES was sitting in `wait`, which wakes on :has-prompt. A
+   park loop that watches only run-state is BLIND to a prompt of its own, and the
+   Corp can be prompted on the RUNNER'S turn with NO RUN ACTIVE: Wildcat Strike
+   (and ~30 other Runner cards carrying `:player :corp`) puts a two-choice prompt
+   on the Corp out of nowhere. A prompt-blind park sleeps through it while the
+   Runner is hard-blocked waiting for the answer, times out, and — per the seat
+   brief — re-parks. That is an unbreakable deadlock manufactured by the fix.
+   Checking it here also covers the re-park path: after a run ends we loop back
+   through this function, so a trigger prompt left over from the run (the #43
+   shape: a `select` with no valid targets, which `has-real-decision?` does not
+   consider real) is surfaced instead of being silently re-parked on.
 
    Only the CORP parks. Runs happen exclusively on the Runner's turn, so a Runner
    waiting for its opponent to start a run is waiting for something that cannot
@@ -1675,10 +1717,13 @@
    healthy — a wedged seat that looks fine. That is worse than the :no-run it used
    to get, so the Runner keeps the old behaviour."
   [state side]
-  (let [gs (:game-state state)]
+  (let [gs (:game-state state)
+        my-prompt (get-in gs [(keyword side) :prompt-state])]
     (cond
       (state/game-over? gs) :game-over
       (some? (:run gs)) :run
+      (or (seat-owns-trigger-decision? my-prompt)
+          (has-real-decision? my-prompt)) :decision-required
       (= (normalize-side (:active-player gs)) side) :my-turn
       (not= side "corp") :no-run
       :else :park)))
@@ -1750,9 +1795,24 @@
           (do (println "🏁 Game over — leaving the post")
               {:status :game-over :wake-reason :game-over :cursor (state/get-cursor)})
 
+          :decision-required
+          (let [my-prompt (get-in st [:game-state (keyword side) :prompt-state])]
+            (println "🛑 Decision required — you are holding a prompt only you can resolve")
+            (when-let [m (:msg my-prompt)] (println (format "   Prompt: %s" m)))
+            {:status :decision-required :wake-reason :decision-required
+             :prompt my-prompt :cursor (state/get-cursor)})
+
           :my-turn
-          (do (println "🔔 Opponent's turn ended — your move")
-              {:status :my-turn :wake-reason :my-turn :cursor (state/get-cursor)})
+          ;; DEBOUNCE. The briefs tell the seat to take its post "the instant you
+          ;; end your turn", but end-turn! returns before :active-player flips on
+          ;; the next diff — so a Corp that just ended its turn can momentarily
+          ;; still look like the active player and get told "your move" with 0
+          ;; clicks. Confirm the turn really has flipped before believing it.
+          (do (park-sleep!)
+              (if (= :my-turn (park-wake-reason @state/client-state side))
+                (do (println "🔔 Opponent's turn ended — your move")
+                    {:status :my-turn :wake-reason :my-turn :cursor (state/get-cursor)})
+                (recur)))
 
           :run
           (let [result (monitor-active-run! flags)]

--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -963,34 +963,76 @@
     (println "   → Auto-passing initiation window (no run-start decision)")
     (send-continue! gameid)))
 
+(def self-advance-grace-ms
+  "How long the opponent gets to answer a window before we treat it as ABANDONED
+   and advance it ourselves. See handle-stalled-window-self-advance."
+  5000)
+
+(defonce ^:private window-first-seen
+  ;; {[phase position no-action] first-seen-ms} — when did we first observe this
+  ;; exact stalled window? Reset per run by reset-window-grace!.
+  (atom {}))
+
+(defn reset-window-grace!
+  "Forget stalled-window timings (new run / new game)."
+  []
+  (reset! window-first-seen {}))
+
+(defn- window-stalled-for-ms
+  "Milliseconds since we FIRST saw this exact window in this exact state.
+   Records first sight on the way past, so the first call always returns 0."
+  [state]
+  (let [run (get-in state [:game-state :run])
+        k [(:phase run) (:position run) (normalize-side (:no-action run))]
+        now (System/currentTimeMillis)
+        first-seen (get (swap! window-first-seen update k #(or % now)) k now)]
+    (- now first-seen)))
+
 (defn handle-stalled-window-self-advance
-  "Issue #31 §1: advance a both-must-pass window the opponent PROVABLY cannot act
-   in — the residual stall left after #62 fixed initiation.
+  "Issue #31 §1: advance a both-must-pass window the opponent has ABANDONED —
+   the residual stall left after #62 fixed initiation.
 
-   Engine shape (verified in src/clj/game/core/runs.clj): the first `continue`
-   from EITHER side records `:run :no-action`; the SECOND `continue` advances the
-   phase, and the advance branch has NO side-check. So once I have passed, I can
-   advance the window myself. `continue-run!` normally refuses (`should-i-act?`
-   correctly says \"you already passed\") and returns :waiting-for-opponent — which
-   is right when the opponent owes a decision, and a DEADLOCK when they don't and
-   nobody is home on their seat.
+   TWO conditions, both required — this is a stall-BREAKER, not a window-skipper:
 
-   Guarded by `opponent-has-run-decision?`, which is conservative by construction:
-   we only advance when the board PROVES there is nothing to skip (approached ICE
-   already rezzed; no unrezzed upgrade in the attacked server root). An unrezzed
-   ICE is a live Corp rez choice and we keep waiting for it — the Corp's presence
-   at that window is Fix A's job (`monitor-run --persistent` park mode), not
-   something to paper over by skipping their decision.
+   1. The board proves the opponent has no REZ decision here
+      (`opponent-has-run-decision?`).
+   2. They have had `self-advance-grace-ms` to act and have not.
 
-   Runner-side only; never sends a continue on the opponent's behalf."
+   Condition 2 exists because condition 1 is not a complete proof. It shows the
+   opponent has no *rez* choice (the approached ICE is already rezzed; no unrezzed
+   card in the attacked root) — but the engine also permits paid abilities at these
+   windows, and the Runner client cannot see the Corp's prompt (fog of war), so
+   \"no rez choice\" cannot be strengthened into \"no choice at all\" from our seat.
+   Advancing on condition 1 alone would therefore risk skipping a real Corp paid
+   ability — the blunt `corp-auto-no-action` bug we rejected. (Our current Corp AI
+   only ever rezzes/fires, so it would not bite today; that is a property of our
+   bot, not of the rules, and it is not something to build on.)
+
+   Waiting out the grace removes that risk: a Corp that is present answers the
+   window in milliseconds — its monitor is a loop, not a model call — so anything
+   still unanswered after several seconds is a seat that is not at its post, and
+   the paid ability we might \"skip\" is one nobody was ever going to take. With
+   park mode (Fix A) keeping the Corp home, this should now essentially never fire;
+   it is the belt to park mode's braces.
+
+   Engine shape (verified in src/clj/game/core/runs.clj): the first `continue` from
+   EITHER side records `:run :no-action`; the SECOND advances the phase, and the
+   advance branch has NO side-check. So once I have passed, I can advance the
+   window myself. Runner-side only; never sends a continue on the opponent's
+   behalf."
   [{:keys [run-phase gameid side state my-prompt]}]
   (when (and (= side "runner")
              (contains? #{"approach-ice" "movement"} run-phase)
              (i-already-passed? state side)
              (not (opponent-has-run-decision? state side run-phase))
              (not (has-real-decision? my-prompt)))
-    (println "   → Opponent holds no decision at this window — self-advancing (#31)")
-    (send-continue! gameid)))
+    ;; Board says there's no rez decision here. Give the opponent the grace period
+    ;; anyway (see docstring) — only an ABANDONED window gets advanced.
+    (let [stalled-ms (window-stalled-for-ms state)]
+      (when (>= stalled-ms self-advance-grace-ms)
+        (println (format "   → Opponent abandoned this window (%.1fs, no rez decision available) — self-advancing (#31)"
+                         (/ stalled-ms 1000.0)))
+        (send-continue! gameid)))))
 
 (defn handle-real-decision
   "Priority 3: I have a real decision to make"
@@ -1624,13 +1666,21 @@
    :game-over — stop (parking through a finished game hangs the seat forever)
    :run       — a run is active: go own it
    :my-turn   — the opponent's turn ended: hand control back to the seat
-   :park      — opponent's turn, no run yet: STAY AT THE POST"
+   :park      — opponent's turn, no run yet: STAY AT THE POST
+   :no-run    — nothing to defend and nothing coming: don't park
+
+   Only the CORP parks. Runs happen exclusively on the Runner's turn, so a Runner
+   waiting for its opponent to start a run is waiting for something that cannot
+   happen: it would sit until timeout while the heartbeat keep-alive reported it
+   healthy — a wedged seat that looks fine. That is worse than the :no-run it used
+   to get, so the Runner keeps the old behaviour."
   [state side]
   (let [gs (:game-state state)]
     (cond
       (state/game-over? gs) :game-over
       (some? (:run gs)) :run
       (= (normalize-side (:active-player gs)) side) :my-turn
+      (not= side "corp") :no-run
       :else :park)))
 
 (defn- park-continuable?
@@ -1657,6 +1707,12 @@
   (auto-continue-loop! :return-on-runner-signal (boolean (:return-on-signal flags))
                        :persistent (boolean (:persistent flags))))
 
+(defn park-sleep!
+  "One idle tick of the park loop. A seam: `Thread/sleep` is a Java static and
+   cannot be redefined, so tests drive the loop by redefining this."
+  []
+  (Thread/sleep 1000))
+
 (defn- park-and-monitor!
   "Persistent defender that owns the OPPONENT'S WHOLE TURN, not just one run.
 
@@ -1672,36 +1728,51 @@
    Parking makes the Corp's presence at the window independent of model latency:
    combined with a pre-committed --rez/--no-rez it answers windows instantly.
    Returns only on a real decision, the opponent's turn ending, game over, or
-   timeout."
+   timeout.
+
+   `deadline` bounds total IDLE parking for the WHOLE invocation and is threaded
+   through every re-entry — it is NOT restarted each time we return to the post,
+   or a Runner making runs at intervals shorter than the timeout would keep one
+   invocation alive indefinitely (and, with the heartbeat keep-alive below,
+   looking alive to the opponent indefinitely). An ACTIVE run is owned by
+   `auto-continue-loop!`, which is bounded by its own timeout and is making
+   progress, so it does not draw down the idle budget."
+  [flags deadline]
+  (println "🅿️  Parked — waiting for the opponent to start a run (persistent; owns the whole turn)")
+  (loop []
+    (if (> (System/currentTimeMillis) deadline)
+      (do (println "⚠️  Park stopped: idle timeout reached (re-issue monitor-run --persistent)")
+          {:status :timeout :wake-reason :timeout :cursor (state/get-cursor)})
+      (let [st @state/client-state
+            side (:side st)]
+        (case (park-wake-reason st side)
+          :game-over
+          (do (println "🏁 Game over — leaving the post")
+              {:status :game-over :wake-reason :game-over :cursor (state/get-cursor)})
+
+          :my-turn
+          (do (println "🔔 Opponent's turn ended — your move")
+              {:status :my-turn :wake-reason :my-turn :cursor (state/get-cursor)})
+
+          :run
+          (let [result (monitor-active-run! flags)]
+            (if (park-continuable? (:status result))
+              (do (println "🅿️  Run ended — back to the post (opponent's turn continues)")
+                  (recur))
+              (assoc result :cursor (state/get-cursor))))
+
+          :no-run
+          (do (println "⚠️  No active run to monitor (and none can start on this turn)")
+              {:status :no-run :wake-reason :no-run :cursor (state/get-cursor)})
+
+          :park
+          (do (park-sleep!)
+              (recur)))))))
+
+(defn- park-deadline
+  "One idle-park deadline per monitor-run! invocation."
   [flags]
-  (let [timeout-ms (or (:park-timeout-ms flags) 300000)
-        deadline (+ (System/currentTimeMillis) timeout-ms)]
-    (println "🅿️  Parked — waiting for the opponent to start a run (persistent; owns the whole turn)")
-    (loop []
-      (if (> (System/currentTimeMillis) deadline)
-        (do (println (format "⚠️  Park stopped: timeout (%dms) reached" timeout-ms))
-            {:status :timeout :wake-reason :timeout :cursor (state/get-cursor)})
-        (let [st @state/client-state
-              side (:side st)]
-          (case (park-wake-reason st side)
-            :game-over
-            (do (println "🏁 Game over — leaving the post")
-                {:status :game-over :wake-reason :game-over :cursor (state/get-cursor)})
-
-            :my-turn
-            (do (println "🔔 Opponent's turn ended — your move")
-                {:status :my-turn :wake-reason :my-turn :cursor (state/get-cursor)})
-
-            :run
-            (let [result (monitor-active-run! flags)]
-              (if (park-continuable? (:status result))
-                (do (println "🅿️  Run ended — back to the post (opponent's turn continues)")
-                    (recur))
-                (assoc result :cursor (state/get-cursor))))
-
-            :park
-            (do (Thread/sleep 1000)
-                (recur))))))))
+  (+ (System/currentTimeMillis) (or (:park-timeout-ms flags) 300000)))
 
 (defn monitor-run!
   "Corp command to enter auto-continue mode during a run.
@@ -1738,7 +1809,10 @@
   (let [{:keys [flags]} (if (seq args) (parse-run-flags (vec args)) {:flags {}})
         since-cursor (:since flags)
         current-cursor (state/get-cursor)
-        run (get-in @state/client-state [:game-state :run])]
+        run (get-in @state/client-state [:game-state :run])
+        ;; ONE idle-park budget for this whole invocation, shared by every
+        ;; re-entry to the post (see park-and-monitor!).
+        deadline (park-deadline flags)]
     (cond
       ;; --since fast-return: check if state already advanced
       (and since-cursor (> current-cursor since-cursor) (nil? run))
@@ -1763,7 +1837,7 @@
       ;; Hand-driven monitor-run keeps the old immediate :no-run return.
       (nil? run)
       (if (:persistent flags)
-        (park-and-monitor! flags)
+        (park-and-monitor! flags deadline)
         (do
           (println "⚠️  No active run to monitor")
           {:status :no-run
@@ -1780,7 +1854,7 @@
           ;; opponent's turn is still running and they may start another run.
           ;; (Re-arming per-run is exactly the gap that left windows unattended.)
           (if (and (:persistent flags) (park-continuable? (:status result)))
-            (park-and-monitor! flags)
+            (park-and-monitor! flags deadline)
             (assoc result :cursor (state/get-cursor))))))))
 
 ;; ============================================================================

--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -646,6 +646,58 @@
       ;; Fresh phase (nil or false) → active player acts first
       :else (= side active-player))))
 
+(defn- i-already-passed?
+  "True if :no-action records that I am the side that already passed this window."
+  [state side]
+  (= (normalize-side (get-in state [:game-state :run :no-action])) side))
+
+(defn- attacked-server-content
+  "Cards in the root of the server currently being run (upgrades/assets).
+   Face-down but VISIBLE to the Runner — no hidden info is used here, only
+   whether a root card is rezzed."
+  [state]
+  (let [server (get-in state [:game-state :run :server])]
+    (get-in state [:game-state :corp :servers (keyword (last server)) :content])))
+
+(defn opponent-has-run-decision?
+  "Does the OPPONENT hold a REAL decision at this both-must-pass run window?
+
+   Board-derivable with NO hidden information (issue #31, §1). This is the
+   legitimacy test for self-advancing a stalled window: we may only advance past
+   the opponent when the board proves they have nothing to decide. Answering
+   'true' costs us nothing but a wait; answering 'false' wrongly would SKIP a
+   real decision — that is the blunt `corp-auto-no-action` behaviour we rejected.
+   So every case we cannot prove is conservatively `true`.
+
+   Runner-side only. As Corp the opponent is the Runner, who always has live
+   options at a window (jack out, break, paid abilities), so nothing is provable
+   and we never self-advance.
+
+   - initiation   : never a decision (no current ICE) — but that window is owned
+                    by `handle-initiation-auto-pass` (#62), not this predicate.
+   - approach-ice : a decision IFF the approached ICE is UNREZZED (Corp may rez).
+                    Rezzed ⇒ the rez choice for this ICE is already spent.
+   - movement     : at the server (position 0) a decision IFF an UNREZZED card
+                    sits in the attacked server's root (an upgrade Corp may rez).
+                    Mid-run movement (position > 0) is left conservative."
+  [state side run-phase]
+  (if-not (= side "runner")
+    true
+    (case run-phase
+      "initiation" false
+
+      "approach-ice"
+      (let [ice (core/current-run-ice state)]
+        (boolean (and ice (not (:rezzed ice)))))
+
+      "movement"
+      (if (zero? (or (get-in state [:game-state :run :position]) 0))
+        (boolean (some #(not (:rezzed %)) (attacked-server-content state)))
+        true)
+
+      ;; Anything else (encounter-ice, success, …): assume a real decision.
+      true)))
+
 (defn waiting-for-opponent?
   "True if my side is waiting for opponent to make a decision during a run.
    Uses the simple :no-action heuristic for reliability."
@@ -911,6 +963,35 @@
     (println "   → Auto-passing initiation window (no run-start decision)")
     (send-continue! gameid)))
 
+(defn handle-stalled-window-self-advance
+  "Issue #31 §1: advance a both-must-pass window the opponent PROVABLY cannot act
+   in — the residual stall left after #62 fixed initiation.
+
+   Engine shape (verified in src/clj/game/core/runs.clj): the first `continue`
+   from EITHER side records `:run :no-action`; the SECOND `continue` advances the
+   phase, and the advance branch has NO side-check. So once I have passed, I can
+   advance the window myself. `continue-run!` normally refuses (`should-i-act?`
+   correctly says \"you already passed\") and returns :waiting-for-opponent — which
+   is right when the opponent owes a decision, and a DEADLOCK when they don't and
+   nobody is home on their seat.
+
+   Guarded by `opponent-has-run-decision?`, which is conservative by construction:
+   we only advance when the board PROVES there is nothing to skip (approached ICE
+   already rezzed; no unrezzed upgrade in the attacked server root). An unrezzed
+   ICE is a live Corp rez choice and we keep waiting for it — the Corp's presence
+   at that window is Fix A's job (`monitor-run --persistent` park mode), not
+   something to paper over by skipping their decision.
+
+   Runner-side only; never sends a continue on the opponent's behalf."
+  [{:keys [run-phase gameid side state my-prompt]}]
+  (when (and (= side "runner")
+             (contains? #{"approach-ice" "movement"} run-phase)
+             (i-already-passed? state side)
+             (not (opponent-has-run-decision? state side run-phase))
+             (not (has-real-decision? my-prompt)))
+    (println "   → Opponent holds no decision at this window — self-advancing (#31)")
+    (send-continue! gameid)))
+
 (defn handle-real-decision
   "Priority 3: I have a real decision to make"
   [{:keys [my-prompt]}]
@@ -1149,6 +1230,12 @@
                   corp-handlers/handle-corp-all-subs-resolved
                   corp-handlers/handle-corp-waiting-after-subs-fired
                   corp-handlers/handle-corp-server-upgrade-decision
+                  ;; #31 §1: MUST precede handle-paid-ability-window, the general
+                  ;; "I passed, now I wait for the opponent" handler — correct when
+                  ;; the opponent owes a decision, a DEADLOCK when they don't.
+                  ;; Sits after every real-decision handler above (corp rez/fire,
+                  ;; upgrade), so it can only fire when nothing else wants to act.
+                  handle-stalled-window-self-advance
                   corp-handlers/handle-paid-ability-window
                   runner-handlers/handle-auto-select-single-card
                   runner-handlers/handle-runner-approach-ice
@@ -1531,6 +1618,91 @@
                      :iterations (inc iteration)
                      :elapsed-ms (- (System/currentTimeMillis) start-time)))))))))
 
+(defn park-wake-reason
+  "What should a PARKED persistent monitor do right now?
+
+   :game-over — stop (parking through a finished game hangs the seat forever)
+   :run       — a run is active: go own it
+   :my-turn   — the opponent's turn ended: hand control back to the seat
+   :park      — opponent's turn, no run yet: STAY AT THE POST"
+  [state side]
+  (let [gs (:game-state state)]
+    (cond
+      (state/game-over? gs) :game-over
+      (some? (:run gs)) :run
+      (= (normalize-side (:active-player gs)) side) :my-turn
+      :else :park)))
+
+(defn- park-continuable?
+  "Statuses that mean 'this run is over but the opponent's turn is not' — so a
+   parked monitor should return to its post rather than hand control back."
+  [status]
+  (contains? #{:run-complete :no-run} status))
+
+(defn- monitor-active-run!
+  "Own one active run: (re)apply the pre-committed strategy, then loop."
+  [flags]
+  (reset-strategy!)
+  (let [strategy-flags (dissoc flags :since :persistent :return-on-signal)]
+    (when (seq strategy-flags)
+      (set-strategy! strategy-flags)
+      (println (format "🎯 Strategy: %s"
+                       (clojure.string/join
+                        ", " (map (fn [[k v]]
+                                    (if (set? v)
+                                      (str (name k) " " (clojure.string/join "," v))
+                                      (name k)))
+                                  strategy-flags))))))
+  (println "👁️  Monitoring run... (auto-passing boring windows)")
+  (auto-continue-loop! :return-on-runner-signal (boolean (:return-on-signal flags))
+                       :persistent (boolean (:persistent flags))))
+
+(defn- park-and-monitor!
+  "Persistent defender that owns the OPPONENT'S WHOLE TURN, not just one run.
+
+   Issue #31, Fix A — the bug this exists to kill: `monitor-run!` used to return
+   :no-run the instant it was called with no run active, EVEN under --persistent.
+   So a Corp seat that armed its monitor a moment too early (or re-armed between
+   runs while the model was thinking) simply left the post. The Runner would then
+   start a run, arrive at a rez window with NOBODY HOME, wait, ping, and finally
+   jack out. In marquee d6962df4 that happened on every run: 5 jack-outs, 1
+   encounter, 1 rez — and the Corp seat's own report said the quiet part out loud:
+   \"the Runner jacked out before my monitor engaged ('no active run')\".
+
+   Parking makes the Corp's presence at the window independent of model latency:
+   combined with a pre-committed --rez/--no-rez it answers windows instantly.
+   Returns only on a real decision, the opponent's turn ending, game over, or
+   timeout."
+  [flags]
+  (let [timeout-ms (or (:park-timeout-ms flags) 300000)
+        deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (println "🅿️  Parked — waiting for the opponent to start a run (persistent; owns the whole turn)")
+    (loop []
+      (if (> (System/currentTimeMillis) deadline)
+        (do (println (format "⚠️  Park stopped: timeout (%dms) reached" timeout-ms))
+            {:status :timeout :wake-reason :timeout :cursor (state/get-cursor)})
+        (let [st @state/client-state
+              side (:side st)]
+          (case (park-wake-reason st side)
+            :game-over
+            (do (println "🏁 Game over — leaving the post")
+                {:status :game-over :wake-reason :game-over :cursor (state/get-cursor)})
+
+            :my-turn
+            (do (println "🔔 Opponent's turn ended — your move")
+                {:status :my-turn :wake-reason :my-turn :cursor (state/get-cursor)})
+
+            :run
+            (let [result (monitor-active-run! flags)]
+              (if (park-continuable? (:status result))
+                (do (println "🅿️  Run ended — back to the post (opponent's turn continues)")
+                    (recur))
+                (assoc result :cursor (state/get-cursor))))
+
+            :park
+            (do (Thread/sleep 1000)
+                (recur))))))))
+
 (defn monitor-run!
   "Corp command to enter auto-continue mode during a run.
 
@@ -1585,41 +1757,31 @@
          :cursor current-cursor
          :fast-return true})
 
-      ;; No active run
+      ;; No active run.
+      ;; --persistent PARKS here (owns the opponent's whole turn) instead of
+      ;; abandoning the post — see park-and-monitor! for why (#31 Fix A).
+      ;; Hand-driven monitor-run keeps the old immediate :no-run return.
       (nil? run)
-      (do
-        (println "⚠️  No active run to monitor")
-        {:status :no-run
-         :wake-reason :no-run
-         :cursor current-cursor})
+      (if (:persistent flags)
+        (park-and-monitor! flags)
+        (do
+          (println "⚠️  No active run to monitor")
+          {:status :no-run
+           :wake-reason :no-run
+           :cursor current-cursor}))
 
       ;; Normal monitoring flow
       :else
       (do
-        ;; Reset strategy at start of monitoring (Corp has separate atom from Runner)
-        ;; This prevents stale --rez sets from previous runs
-        (reset-strategy!)
-        ;; Apply new strategy flags. Exclude control flags that govern the loop
-        ;; itself (not the rez/fire strategy): :since (fast-return), :persistent
-        ;; and :return-on-signal (loop behavior) — so they don't pollute the
-        ;; 🎯 Strategy line or the run-strategy atom.
-        (let [strategy-flags (dissoc flags :since :persistent :return-on-signal)]
-          (when (seq strategy-flags)
-            (set-strategy! strategy-flags)
-            (println (format "🎯 Strategy: %s"
-                            (clojure.string/join ", "
-                                                 (map (fn [[k v]]
-                                                        (if (set? v)
-                                                          (str (name k) " " (clojure.string/join "," v))
-                                                          (name k)))
-                                                      strategy-flags))))))
-        (println "👁️  Monitoring run... (auto-passing boring windows)")
         (when (:persistent flags)
-          (println "🔁 Persistent mode — staying in the loop across empty windows (wakes for decisions / run end)"))
-        (let [result (auto-continue-loop! :return-on-runner-signal (boolean (:return-on-signal flags))
-                                          :persistent (boolean (:persistent flags)))]
-          ;; Include cursor in result for caller to track
-          (assoc result :cursor (state/get-cursor)))))))
+          (println "🔁 Persistent mode — owns the whole run (wakes for decisions / run end)"))
+        (let [result (monitor-active-run! flags)]
+          ;; A persistent monitor whose run just ENDED returns to the post: the
+          ;; opponent's turn is still running and they may start another run.
+          ;; (Re-arming per-run is exactly the gap that left windows unattended.)
+          (if (and (:persistent flags) (park-continuable? (:status result)))
+            (park-and-monitor! flags)
+            (assoc result :cursor (state/get-cursor))))))))
 
 ;; ============================================================================
 ;; Convenience Wrapper

--- a/dev/test/peer_status_test.sh
+++ b/dev/test/peer_status_test.sh
@@ -127,6 +127,27 @@ fi
 #    `kill -0`, not an EXIT trap, so it must not survive a kill -9 of the parent.
 assert_contains "toucher-bound-to-parent-liveness" "$SEND_SRC" 'kill -0 "$_hb_parent"'
 
+# 3. The toucher must NOT hold the caller's stdout pipe open.
+#    Nearly every caller reads send_command via command substitution, which blocks
+#    until EOF — and EOF needs the LAST writer to close. The first cut of the
+#    toucher inherited stdout, so `OUT="$(send_command corp peer-status)"` blocked
+#    for the full HEARTBEAT_TOUCH_SECS (measured: 60s) on EVERY command. The unit
+#    assertions above still passed — just slowly — so nothing but a TIMING check
+#    catches this. Uses the default touch interval on purpose: overriding it to
+#    something small is exactly what masked the bug.
+cs_start=$(date +%s)
+CS_OUT="$("$SEND_CMD" corp peer-status 2>&1)"
+cs_elapsed=$(( $(date +%s) - cs_start ))
+if [[ $cs_elapsed -lt 10 ]]; then
+    echo "ok   [cmd-substitution-not-blocked-by-toucher] (${cs_elapsed}s)"
+else
+    echo "FAIL [cmd-substitution-not-blocked-by-toucher]: took ${cs_elapsed}s"
+    echo "     The heartbeat toucher is holding stdout open — every send_command read"
+    echo "     via \$(...) blocks until it exits. Redirect the subshell's stdio."
+    fails=$((fails+1))
+fi
+assert_contains "cmd-substitution-still-works" "$CS_OUT" "you (corp): active"
+
 echo "---"
 if [[ $fails -eq 0 ]]; then
     echo "peer_status_test: ALL PASSED"; exit 0

--- a/dev/test/peer_status_test.sh
+++ b/dev/test/peer_status_test.sh
@@ -97,6 +97,36 @@ assert_contains "reset-wires-clear" "$(cat "$SCRIPT_DIR/../reset.sh")" "clear-he
 SEND_SRC="$(cat "$SEND_CMD")"
 assert_contains "wait-suppresses-footer-on-gameover" "$SEND_SRC" 'WAIT_OUT" != *"Game over"*'
 
+# ── Keep-alive toucher (park mode, #31 Fix A) ────────────────────────────────
+# `monitor-run --persistent` now PARKS for the opponent's whole turn, so one
+# invocation can stay open for minutes. The heartbeat is touched at invocation,
+# so without a keep-alive an ALIVE parked driver would age past PEER_STALE_SECS
+# and be reported SILENT — a false dead-peer verdict telling the opponent to
+# abandon a live game. send_command therefore runs a background toucher for the
+# life of the invocation.
+#
+# The DANGEROUS failure mode of that toucher is the mirror image: if it outlives
+# its parent, it keeps a DEAD driver's heartbeat fresh forever and the sensor can
+# never report a real disconnect. It is bound to the parent via `kill -0`, which
+# holds even under SIGKILL (where no EXIT trap runs). Both are asserted here.
+
+# 1. No orphan: once the invocation exits, the heartbeat must STOP advancing.
+HEARTBEAT_TOUCH_SECS=1 "$SEND_CMD" corp peer-status >/dev/null 2>&1 || true
+before_mt="$(stat -f %m "$HEARTBEAT_DIR/corp" 2>/dev/null || stat -c %Y "$HEARTBEAT_DIR/corp" 2>/dev/null || echo 0)"
+sleep 3
+after_mt="$(stat -f %m "$HEARTBEAT_DIR/corp" 2>/dev/null || stat -c %Y "$HEARTBEAT_DIR/corp" 2>/dev/null || echo 0)"
+if [[ "$before_mt" == "$after_mt" ]]; then
+    echo "ok   [no-orphan-toucher-after-exit]"
+else
+    echo "FAIL [no-orphan-toucher-after-exit]: heartbeat kept advancing after send_command exited"
+    echo "     (an orphaned toucher would keep a DEAD driver looking alive forever)"
+    fails=$((fails+1))
+fi
+
+# 2. A SIGKILLed driver still goes stale: the toucher's parent-liveness guard is
+#    `kill -0`, not an EXIT trap, so it must not survive a kill -9 of the parent.
+assert_contains "toucher-bound-to-parent-liveness" "$SEND_SRC" 'kill -0 "$_hb_parent"'
+
 echo "---"
 if [[ $fails -eq 0 ]]; then
     echo "peer_status_test: ALL PASSED"; exit 0

--- a/dev/test/run_window_selfadvance_test.clj
+++ b/dev/test/run_window_selfadvance_test.clj
@@ -174,15 +174,60 @@
                 "Must advance, not stall waiting on a Corp with nothing to decide")))))))
 
 (deftest continue-run-still-waits-when-corp-genuinely-must-rez
-  (testing "SAFETY: unrezzed ICE -> Corp is genuinely on the clock. Keep waiting."
-    (with-mock-state
-      (runner-state :phase "approach-ice" :position 1 :no-action "runner"
-                    :ices [{:cid 1 :title "Whitespace" :rezzed false}])
-      (let [result (runs/continue-run!)]
-        (is (contains? #{:waiting-for-corp-rez :waiting-for-opponent
-                         :waiting-for-opponent-paid-abilities}
-                       (:status result))
-            "Must still wait for a real Corp rez decision")))))
+  (testing "SAFETY: unrezzed ICE -> Corp is genuinely on the clock. Keep waiting,
+            and — the part that actually matters — send NO continue."
+    (let [sent (atom [])]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)
+                    runs/self-advance-grace-ms 0]
+        (with-mock-state
+          (runner-state :phase "approach-ice" :position 1 :no-action "runner"
+                        :ices [{:cid 1 :title "Whitespace" :rezzed false}])
+          (let [result (runs/continue-run!)]
+            (is (contains? #{:waiting-for-corp-rez :waiting-for-opponent
+                             :waiting-for-opponent-paid-abilities}
+                           (:status result))
+                "Must still wait for a real Corp rez decision")
+            (is (empty? @sent)
+                "Must NOT send a continue — that would skip the Corp's rez window")))))))
+
+;; --- F2: the predicate must fail CLOSED on "I can't see it" -------------------
+
+(deftest predicate-fails-closed-when-ice-not-visible
+  (testing "current-run-ice returns nil for out-of-bounds position / missing ices —
+            i.e. for every state where we CANNOT SEE the approached ICE. Folding
+            that into 'no decision' would skip a live rez window on a wire
+            transient. Unknown must mean WAIT."
+    ;; position 3 but only 1 ICE on the server -> current-run-ice = nil
+    (let [st (runner-state :phase "approach-ice" :position 3 :no-action "runner"
+                           :ices [{:cid 1 :title "Whitespace" :rezzed false}])]
+      (is (true? (runs/opponent-has-run-decision? st "runner" "approach-ice"))
+          "Unknown ICE must be treated as a possible Corp decision"))))
+
+(deftest predicate-fails-closed-when-server-not-resolvable
+  (testing "If we cannot even resolve the attacked server, we know nothing — a
+            lookup miss must not read as 'the root is empty, skip the Corp'."
+    (let [st (mock-client-state
+              :side "runner"
+              :game-state
+              {:run {:phase "movement" :position 0 :no-action "runner"
+                     :server [:remote99]}          ; server not in :servers
+               :runner {:prompt-state nil}
+               :corp {:prompt-state nil :servers {:remote1 {:ices [] :content []}}}})]
+      (is (true? (runs/opponent-has-run-decision? st "runner" "movement"))
+          "Unresolvable server must be treated as a possible Corp decision"))))
+
+(deftest self-advance-does-not-fire-when-ice-not-visible
+  (testing "End to end: the fail-closed predicate must stop the handler"
+    (let [sent (atom [])]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)
+                    runs/self-advance-grace-ms 0]
+        (let [st (runner-state :phase "approach-ice" :position 3 :no-action "runner"
+                               :ices [{:cid 1 :title "Whitespace" :rezzed false}])
+              result (runs/handle-stalled-window-self-advance
+                      {:run-phase "approach-ice" :gameid "g1" :side "runner"
+                       :state st :my-prompt nil})]
+          (is (nil? result))
+          (is (empty? @sent)))))))
 
 ;; =============================================================================
 ;; A. Park mode — the Corp must be able to wait for a run to START
@@ -210,6 +255,40 @@
               :side "corp"
               :game-state {:run nil :active-player "corp"})]
       (is (= :my-turn (runs/park-wake-reason st "corp"))))))
+
+(deftest park-wakes-on-a-corp-prompt-with-no-run
+  (testing "F1 (CRITICAL): the Corp can be prompted on the RUNNER'S turn with NO
+            RUN ACTIVE — Wildcat Strike and ~30 other Runner cards carry
+            :player :corp. The flow park replaced (sitting in `wait`) woke on
+            :has-prompt. A prompt-blind park sleeps through it while the Runner is
+            hard-blocked, times out, and re-parks: an unbreakable deadlock."
+    (let [st (mock-client-state
+              :side "corp"
+              :game-state
+              {:run nil
+               :active-player "runner"
+               :corp {:prompt-state {:msg "Wildcat Strike: Corp chooses"
+                                     :prompt-type "choice"
+                                     :choices [{:value "Runner draws 4"}
+                                               {:value "Runner gains 6 credits"}]}}})]
+      (is (= :decision-required (runs/park-wake-reason st "corp"))
+          "Must surface the prompt, not sleep on it"))))
+
+(deftest park-wakes-on-leftover-trigger-prompt-after-run-end
+  (testing "F3: the #43 shape — a select with NO valid targets, which
+            has-real-decision? does not consider real. After a run ends the loop
+            re-enters park-wake-reason; this must be surfaced, not re-parked on,
+            or the opponent hard-blocks on 'waiting for Corp to resolve triggers'."
+    (let [st (mock-client-state
+              :side "corp"
+              :game-state
+              {:run nil
+               :active-player "runner"
+               :corp {:prompt-state {:msg "Select a card to rez"
+                                     :prompt-type "select"
+                                     :choices []
+                                     :selectable []}}})]
+      (is (= :decision-required (runs/park-wake-reason st "corp"))))))
 
 (deftest runner-never-parks
   (testing "Runs only happen on the Runner's turn, so a Runner parking for the
@@ -319,5 +398,7 @@
           text (clojure.string/join " " lines)]
       (is (not (re-find #"(?i)jack-out ends the run to recover" text))
           "Must not recommend jack-out as the stall escape hatch")
-      (is (re-find #"(?i)peer-status|keep waiting|wait" text)
-          "Should point at the patience/liveness signal instead"))))
+      (is (re-find #"(?i)peer-status" text)
+          "Should point at the patience/liveness signal instead")
+      (is (re-find #"(?i)smell" text)
+          "Should name jack-out as the smell it is"))))

--- a/dev/test/run_window_selfadvance_test.clj
+++ b/dev/test/run_window_selfadvance_test.clj
@@ -92,24 +92,35 @@
 ;; B. The self-advance handler
 ;; =============================================================================
 
-(deftest self-advance-fires-when-opponent-has-no-decision
-  (testing "Runner already passed, ICE is rezzed -> send the 2nd continue to advance"
+(deftest self-advance-fires-only-after-the-grace-period
+  (testing "Stall-BREAKER, not window-skipper: the Corp gets self-advance-grace-ms
+            to answer. Present Corp answers in ms (its monitor is a loop); only an
+            ABANDONED window is advanced. First sight must NOT advance."
     (let [sent (atom [])]
       (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (runs/reset-window-grace!)
         (let [st (runner-state :phase "approach-ice" :position 1 :no-action "runner"
                                :ices [{:cid 1 :title "Bran 1.0" :rezzed true}])
-              result (runs/handle-stalled-window-self-advance
-                      {:run-phase "approach-ice" :gameid "g1" :side "runner"
-                       :state st :my-prompt nil})]
-          (is (= :action-taken (:status result)) "Should advance the stalled window")
-          (is (= 1 (count @sent)) "Should send exactly one continue")
-          (is (= "continue" (:command (first @sent)))))))))
+              ctx {:run-phase "approach-ice" :gameid "g1" :side "runner"
+                   :state st :my-prompt nil}
+              first-look (runs/handle-stalled-window-self-advance ctx)]
+          (is (nil? first-look)
+              "Must give the Corp its window before advancing")
+          (is (empty? @sent))
+          ;; …but a window still unanswered after the grace is abandoned.
+          (with-redefs [runs/self-advance-grace-ms 0]
+            (let [result (runs/handle-stalled-window-self-advance ctx)]
+              (is (= :action-taken (:status result)) "Should advance the abandoned window")
+              (is (= 1 (count @sent)) "Should send exactly one continue")
+              (is (= "continue" (:command (first @sent)))))))))))
 
 (deftest self-advance-NEVER-skips-a-live-rez-decision
   (testing "SAFETY: unrezzed ICE = the Corp's rez decision. Self-advancing here
-            would be the blunt corp-auto-no-action bug. Must return nil."
+            would be the blunt corp-auto-no-action bug. Must return nil EVEN when
+            the window has been stalled long past the grace period."
     (let [sent (atom [])]
-      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)
+                    runs/self-advance-grace-ms 0]
         (let [st (runner-state :phase "approach-ice" :position 1 :no-action "runner"
                                :ices [{:cid 1 :title "Whitespace" :rezzed false}])
               result (runs/handle-stalled-window-self-advance
@@ -122,7 +133,8 @@
   (testing "Fresh window (no-action nil) -> normal auto-continue owns the first
             pass; self-advance must not double-continue."
     (let [sent (atom [])]
-      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)
+                    runs/self-advance-grace-ms 0]
         (let [st (runner-state :phase "approach-ice" :position 1 :no-action nil
                                :ices [{:cid 1 :title "Bran 1.0" :rezzed true}])
               result (runs/handle-stalled-window-self-advance
@@ -137,11 +149,12 @@
                   :choices [{:value "Yes"} {:value "No"}]}
           st (runner-state :phase "approach-ice" :position 1 :no-action "runner"
                            :ices [{:cid 1 :title "Bran 1.0" :rezzed true}]
-                           :prompt prompt)
-          result (runs/handle-stalled-window-self-advance
-                  {:run-phase "approach-ice" :gameid "g1" :side "runner"
-                   :state st :my-prompt prompt})]
-      (is (nil? result)))))
+                           :prompt prompt)]
+      (with-redefs [runs/self-advance-grace-ms 0]
+        (let [result (runs/handle-stalled-window-self-advance
+                      {:run-phase "approach-ice" :gameid "g1" :side "runner"
+                       :state st :my-prompt prompt})]
+          (is (nil? result)))))))
 
 ;; =============================================================================
 ;; B. Integration through continue-run! — the actual marquee stall
@@ -151,7 +164,8 @@
   (testing "REGRESSION (marquee d6962df4): Runner passed, ICE rezzed, Corp silent.
             Old behavior: :waiting-for-opponent forever -> jack-out -> lose."
     (let [sent (atom [])]
-      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)
+                    runs/self-advance-grace-ms 0]
         (with-mock-state
           (runner-state :phase "approach-ice" :position 1 :no-action "runner"
                         :ices [{:cid 1 :title "Bran 1.0" :rezzed true}])
@@ -197,12 +211,98 @@
               :game-state {:run nil :active-player "corp"})]
       (is (= :my-turn (runs/park-wake-reason st "corp"))))))
 
+(deftest runner-never-parks
+  (testing "Runs only happen on the Runner's turn, so a Runner parking for the
+            opponent to start a run waits for something that CANNOT happen — it
+            would wedge until timeout while the heartbeat reported it healthy."
+    (let [st (mock-client-state
+              :side "runner"
+              :game-state {:run nil :active-player "corp"})]
+      (is (= :no-run (runs/park-wake-reason st "runner"))))))
+
 (deftest park-returns-on-game-over
   (testing "Game over -> never park (would hang the seat forever)"
     (let [st (mock-client-state
               :side "corp"
               :game-state {:run nil :active-player "runner" :winner "runner"})]
       (is (= :game-over (runs/park-wake-reason st "corp"))))))
+
+;; =============================================================================
+;; A. Park mode through monitor-run! — the actual command behavior
+;;
+;; park-wake-reason above is pure classification; these drive monitor-run! itself,
+;; which is where the bug lived (it returned :no-run and left the post).
+;; =============================================================================
+
+(deftest monitor-run-persistent-does-not-abandon-the-post
+  (testing "THE BUG (#31 Fix A): --persistent with no run must PARK, not return
+            :no-run. Parks until a run appears, then owns it."
+    (let [ticks (atom 0)
+          st (mock-client-state
+              :side "corp"
+              :game-state {:run nil :active-player "runner"})]
+      (with-mock-state st
+        ;; After 2 park ticks a run appears; the parked monitor must pick it up.
+        (with-redefs [runs/monitor-active-run!
+                      (fn [_flags]
+                        ;; the run we picked up ends, and so does the Runner's turn
+                        (swap! state/client-state
+                               #(-> %
+                                    (assoc-in [:game-state :run] nil)
+                                    (assoc-in [:game-state :active-player] "corp")))
+                        {:status :run-complete})
+                      state/get-cursor (fn [] 1)
+                      runs/park-sleep! (fn []
+                                         (swap! ticks inc)
+                                         ;; a run starts on the 2nd idle tick
+                                         (when (= @ticks 2)
+                                           (swap! state/client-state
+                                                  assoc-in [:game-state :run]
+                                                  {:phase "initiation" :server [:hq]})))]
+          (let [result (runs/monitor-run! "--persistent")]
+            (is (not= :no-run (:status result))
+                "Must NOT abandon the post with :no-run")
+            (is (= :my-turn (:status result))
+                "Parks through the run, returns only when the opponent's turn ends")
+            (is (pos? @ticks) "Should actually have parked")))))))
+
+(deftest monitor-run-without-persistent-keeps-old-no-run
+  (testing "Hand-driven monitor-run is unchanged: no run -> :no-run immediately"
+    (with-mock-state
+      (mock-client-state :side "corp"
+                         :game-state {:run nil :active-player "runner"})
+      (let [result (runs/monitor-run!)]
+        (is (= :no-run (:status result)))))))
+
+(deftest monitor-run-persistent-returns-immediately-on-game-over
+  (testing "Never park through a finished game — that hangs the seat forever"
+    (with-mock-state
+      (mock-client-state :side "corp"
+                         :game-state {:run nil :active-player "runner" :winner "runner"})
+      (with-redefs [state/get-cursor (fn [] 1)]
+        (let [result (runs/monitor-run! "--persistent")]
+          (is (= :game-over (:status result))))))))
+
+(deftest monitor-run-persistent-returns-immediately-on-own-turn
+  (testing "Parking on my OWN turn would deadlock the game (I owe the moves)"
+    (with-mock-state
+      (mock-client-state :side "corp"
+                         :game-state {:run nil :active-player "corp"})
+      (with-redefs [state/get-cursor (fn [] 1)]
+        (let [result (runs/monitor-run! "--persistent")]
+          (is (= :my-turn (:status result))))))))
+
+(deftest park-idle-budget-is-not-reset-by-re-entry
+  (testing "One idle-park deadline per invocation: a Runner making runs faster
+            than the timeout must not keep the command (and its liveness) alive
+            forever. An ALREADY-EXPIRED deadline must time out at once."
+    (with-mock-state
+      (mock-client-state :side "corp"
+                         :game-state {:run nil :active-player "runner"})
+      (with-redefs [state/get-cursor (fn [] 1)]
+        (let [expired (- (System/currentTimeMillis) 1000)
+              result (#'runs/park-and-monitor! {} expired)]
+          (is (= :timeout (:status result))))))))
 
 ;; =============================================================================
 ;; C. Jack-out smell — stop coaching the losing move

--- a/dev/test/run_window_selfadvance_test.clj
+++ b/dev/test/run_window_selfadvance_test.clj
@@ -1,0 +1,223 @@
+(ns run-window-selfadvance-test
+  "Tests for issue #31 residual: the both-must-pass run windows that STILL stall
+   after #62 shipped the initiation auto-pass.
+
+   Marquee game d6962df4 (2026-07-12, Opus Corp vs GPT-5.5 Runner) was decided by
+   this: 5 jack-outs, 1 encounter, 1 rez in the whole game. Every Runner run died
+   at a Corp rez window nobody was home to answer.
+
+   Three fixes under test:
+   A. PARK MODE — `monitor-run --persistent` must be able to wait for a run to
+      START (own the opponent's whole turn), not return :no-run and leave the
+      window unattended.
+   B. SELF-ADVANCE (§1) — when the opponent PROVABLY has no decision at a
+      both-pass window (board-derivable, no hidden info), the side holding the
+      window advances it rather than stalling. Critically, it must NOT fire when
+      the opponent does have a real decision (unrezzed ICE = a live rez choice).
+   C. JACK-OUT SMELL — the client must stop COACHING jack-out as the stall escape
+      hatch. Jack-out is a netrunner smell: the only legit tactical cases are
+      misjudging entry cost and Karuna's jack-out subroutine. Our own hint text
+      told GPT-5.5 to bail, and it threw away a broken Bran (8 credits) and the
+      game."
+  (:require [clojure.test :refer :all]
+            [test-helpers :refer :all]
+            [ai-runs :as runs]
+            [ai-display :as display]
+            [ai-state :as state]
+            [ai-websocket-client-v2 :as ws]))
+
+;; =============================================================================
+;; B. Board-derivable "does the OPPONENT hold a real decision at this window?"
+;; =============================================================================
+
+(defn- runner-state
+  "Runner-side client state at a run window."
+  [& {:keys [phase position no-action ices content prompt]
+      :or {phase "approach-ice" position 1 ices [] content []}}]
+  (mock-client-state
+   :side "runner"
+   :game-state
+   {:run {:phase phase
+          :position position
+          :no-action no-action
+          :server [:remote1]}
+    :runner {:prompt-state prompt}
+    :corp {:prompt-state nil
+           :servers {:remote1 {:ices ices :content content}}}}))
+
+(deftest approach-ice-unrezzed-ice-is-a-real-corp-decision
+  (testing "Corp may rez the approached ICE -> opponent HAS a decision, never skip it"
+    (let [st (runner-state :phase "approach-ice" :position 1
+                           :ices [{:cid 1 :title "Whitespace" :rezzed false}])]
+      (is (true? (runs/opponent-has-run-decision? st "runner" "approach-ice"))
+          "Unrezzed current ICE = live Corp rez choice"))))
+
+(deftest approach-ice-rezzed-ice-is-not-a-decision
+  (testing "Already-rezzed ICE -> Corp has no rez choice here -> window is skippable"
+    (let [st (runner-state :phase "approach-ice" :position 1
+                           :ices [{:cid 1 :title "Bran 1.0" :rezzed true}])]
+      (is (false? (runs/opponent-has-run-decision? st "runner" "approach-ice"))))))
+
+(deftest movement-unrezzed-upgrade-is-a-real-corp-decision
+  (testing "Unrezzed card in the attacked server root = a live upgrade rez choice"
+    (let [st (runner-state :phase "movement" :position 0
+                           :content [{:cid 9 :title "Manegarm Skunkworks" :rezzed false}])]
+      (is (true? (runs/opponent-has-run-decision? st "runner" "movement"))))))
+
+(deftest movement-empty-root-is-not-a-decision
+  (testing "No cards in the server root -> nothing for Corp to rez -> skippable"
+    (let [st (runner-state :phase "movement" :position 0 :content [])]
+      (is (false? (runs/opponent-has-run-decision? st "runner" "movement"))))))
+
+(deftest movement-all-rezzed-root-is-not-a-decision
+  (testing "Root cards already rezzed -> no pending rez choice"
+    (let [st (runner-state :phase "movement" :position 0
+                           :content [{:cid 9 :title "Manegarm Skunkworks" :rezzed true}])]
+      (is (false? (runs/opponent-has-run-decision? st "runner" "movement"))))))
+
+(deftest corp-side-never-self-advances
+  (testing "As Corp, the opponent is the RUNNER, who always has options (jack out,
+            break, abilities). Not board-derivable -> stay conservative."
+    (let [st (mock-client-state
+              :side "corp"
+              :game-state
+              {:run {:phase "approach-ice" :position 1 :no-action "corp"
+                     :server [:remote1]}
+               :corp {:prompt-state nil
+                      :servers {:remote1 {:ices [{:cid 1 :title "Bran 1.0" :rezzed true}]}}}})]
+      (is (true? (runs/opponent-has-run-decision? st "corp" "approach-ice"))
+          "Corp must never self-advance a window on the Runner's behalf"))))
+
+;; =============================================================================
+;; B. The self-advance handler
+;; =============================================================================
+
+(deftest self-advance-fires-when-opponent-has-no-decision
+  (testing "Runner already passed, ICE is rezzed -> send the 2nd continue to advance"
+    (let [sent (atom [])]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (let [st (runner-state :phase "approach-ice" :position 1 :no-action "runner"
+                               :ices [{:cid 1 :title "Bran 1.0" :rezzed true}])
+              result (runs/handle-stalled-window-self-advance
+                      {:run-phase "approach-ice" :gameid "g1" :side "runner"
+                       :state st :my-prompt nil})]
+          (is (= :action-taken (:status result)) "Should advance the stalled window")
+          (is (= 1 (count @sent)) "Should send exactly one continue")
+          (is (= "continue" (:command (first @sent)))))))))
+
+(deftest self-advance-NEVER-skips-a-live-rez-decision
+  (testing "SAFETY: unrezzed ICE = the Corp's rez decision. Self-advancing here
+            would be the blunt corp-auto-no-action bug. Must return nil."
+    (let [sent (atom [])]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (let [st (runner-state :phase "approach-ice" :position 1 :no-action "runner"
+                               :ices [{:cid 1 :title "Whitespace" :rezzed false}])
+              result (runs/handle-stalled-window-self-advance
+                      {:run-phase "approach-ice" :gameid "g1" :side "runner"
+                       :state st :my-prompt nil})]
+          (is (nil? result) "Must NOT skip the Corp's live rez decision")
+          (is (empty? @sent) "Must not send a continue"))))))
+
+(deftest self-advance-requires-that-i-already-passed
+  (testing "Fresh window (no-action nil) -> normal auto-continue owns the first
+            pass; self-advance must not double-continue."
+    (let [sent (atom [])]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (let [st (runner-state :phase "approach-ice" :position 1 :no-action nil
+                               :ices [{:cid 1 :title "Bran 1.0" :rezzed true}])
+              result (runs/handle-stalled-window-self-advance
+                      {:run-phase "approach-ice" :gameid "g1" :side "runner"
+                       :state st :my-prompt nil})]
+          (is (nil? result))
+          (is (empty? @sent)))))))
+
+(deftest self-advance-yields-to-my-own-real-decision
+  (testing "If I hold a real prompt, that must be surfaced, not auto-passed"
+    (let [prompt {:prompt-type "select" :msg "Break subroutine?"
+                  :choices [{:value "Yes"} {:value "No"}]}
+          st (runner-state :phase "approach-ice" :position 1 :no-action "runner"
+                           :ices [{:cid 1 :title "Bran 1.0" :rezzed true}]
+                           :prompt prompt)
+          result (runs/handle-stalled-window-self-advance
+                  {:run-phase "approach-ice" :gameid "g1" :side "runner"
+                   :state st :my-prompt prompt})]
+      (is (nil? result)))))
+
+;; =============================================================================
+;; B. Integration through continue-run! — the actual marquee stall
+;; =============================================================================
+
+(deftest continue-run-advances-instead-of-stalling-at-no-decision-window
+  (testing "REGRESSION (marquee d6962df4): Runner passed, ICE rezzed, Corp silent.
+            Old behavior: :waiting-for-opponent forever -> jack-out -> lose."
+    (let [sent (atom [])]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (with-mock-state
+          (runner-state :phase "approach-ice" :position 1 :no-action "runner"
+                        :ices [{:cid 1 :title "Bran 1.0" :rezzed true}])
+          (let [result (runs/continue-run!)]
+            (is (= :action-taken (:status result))
+                "Must advance, not stall waiting on a Corp with nothing to decide")))))))
+
+(deftest continue-run-still-waits-when-corp-genuinely-must-rez
+  (testing "SAFETY: unrezzed ICE -> Corp is genuinely on the clock. Keep waiting."
+    (with-mock-state
+      (runner-state :phase "approach-ice" :position 1 :no-action "runner"
+                    :ices [{:cid 1 :title "Whitespace" :rezzed false}])
+      (let [result (runs/continue-run!)]
+        (is (contains? #{:waiting-for-corp-rez :waiting-for-opponent
+                         :waiting-for-opponent-paid-abilities}
+                       (:status result))
+            "Must still wait for a real Corp rez decision")))))
+
+;; =============================================================================
+;; A. Park mode — the Corp must be able to wait for a run to START
+;; =============================================================================
+
+(deftest park-wakes-on-run-start
+  (testing "A run is active -> stop parking, go monitor it"
+    (let [st (mock-client-state
+              :side "corp"
+              :game-state {:run {:phase "initiation" :server [:hq]}
+                           :active-player "runner"})]
+      (is (= :run (runs/park-wake-reason st "corp"))))))
+
+(deftest park-keeps-waiting-when-no-run-and-opponents-turn
+  (testing "THE BUG: no run yet, still the Runner's turn -> PARK (stay home at the
+            window). Old behavior returned :no-run and abandoned the post."
+    (let [st (mock-client-state
+              :side "corp"
+              :game-state {:run nil :active-player "runner"})]
+      (is (= :park (runs/park-wake-reason st "corp"))))))
+
+(deftest park-returns-on-my-turn
+  (testing "Opponent's turn ended -> hand control back to the seat"
+    (let [st (mock-client-state
+              :side "corp"
+              :game-state {:run nil :active-player "corp"})]
+      (is (= :my-turn (runs/park-wake-reason st "corp"))))))
+
+(deftest park-returns-on-game-over
+  (testing "Game over -> never park (would hang the seat forever)"
+    (let [st (mock-client-state
+              :side "corp"
+              :game-state {:run nil :active-player "runner" :winner "runner"})]
+      (is (= :game-over (runs/park-wake-reason st "corp"))))))
+
+;; =============================================================================
+;; C. Jack-out smell — stop coaching the losing move
+;; =============================================================================
+
+(deftest hint-does-not-coach-jack-out-as-stall-recovery
+  (testing "Michael's smell heuristic: jack-out is almost never right. Our hint
+            text told the Runner to bail out of a stalled window; it did, 5x,
+            including on a run where it had already broken Bran for 8 credits."
+    (let [lines (display/run-priority-hint-lines
+                 {:phase "approach-ice" :position 1 :no-action "runner"
+                  :server [:remote1]}
+                 "runner")
+          text (clojure.string/join " " lines)]
+      (is (not (re-find #"(?i)jack-out ends the run to recover" text))
+          "Must not recommend jack-out as the stall escape hatch")
+      (is (re-find #"(?i)peer-status|keep waiting|wait" text)
+          "Should point at the patience/liveness signal instead"))))


### PR DESCRIPTION
Closes the residual half of #31 — the half that decided marquee `d6962df4`.

## The evidence
Opus Corp vs GPT-5.5 Runner, whole game: **5 jack-outs, 1 encounter, 1 rez.**
Every Runner run died at a Corp rez window with nobody home to answer it.

The two seats told opposite stories. The Corp reported a *strategy* ("I rezzed
the inner Whitespace to exploit their jack-out reflex"); the shared log shows **no
such rez ever happened**. The Runner reported the truth: "the main losing factor
was not strategic evaluation but inability to reliably resolve runs." The winning
seat had laundered a tooling stall into a confident skill narrative — which is why
these games must be judged on both seats' reports joined against the log, never one.

## The three causes

**A. The Corp left its post.** `monitor-run --persistent` returned `:no-run` the
instant it was called with no run active — even under `--persistent`. So a Corp
that armed a moment early, or re-armed between runs while the model was thinking
(minutes), simply walked away. The Corp's own report says the quiet part out loud:
*"the Runner jacked out before my monitor engaged ('no active run')."*
→ `--persistent` now **parks**: waits for a run to start and owns the opponent's
**whole turn**, returning only on a real decision / `my-turn` / game-over / timeout.
Presence no longer depends on model latency.

**B. Abandoned windows stalled forever.** A both-must-pass window nobody answers
never advances.
→ New `handle-stalled-window-self-advance` sends the second `continue` (the engine's
advance branch has no side-check) when the board proves there is no rez decision
**and** the window has gone unanswered for a grace period. A stall-**breaker**, not
a window-skipper: an unrezzed ICE is a live Corp rez choice and we still wait for it.

**C. The client coached the losing move.** On a stalled window it literally told the
Runner: *"'jack-out' ends the run to recover."* GPT-5.5 obeyed 5 times — once
throwing away a Brân it had just broken for 8 credits, on the run that would have
contested the winning agenda.
→ Jack-out is a **netrunner smell**: the only legitimate reasons are a misjudged
entry cost, or a Karunā jack-out sub. Hint text + all four seat briefs now say
waiting is the correct play, and point at `peer-status`.

## Bug this work would otherwise have shipped
The #63 heartbeat is touched once per invocation, but a parked monitor holds one
invocation open for minutes — so a **correctly-parked, perfectly alive Corp** would
age past `PEER_STALE_SECS` and be reported `SILENT — likely disconnected`, telling
the opponent to abandon a live game. The sensor would have manufactured the exact
death it exists to prevent. `send_command` now keeps the clock ticking for the life
of the invocation, bound to parent liveness via `kill -0` so a genuinely dead (even
SIGKILLed) driver still goes stale.

## Guest review (GPT-5.5) caught a real CRITICAL
The first cut of that keep-alive **held the caller's stdout pipe open**. A background
child inherits stdout; nearly every caller reads `send_command` via command
substitution, which blocks until EOF. Every command blocked for `HEARTBEAT_TOUCH_SECS`
— measured **60s** for `peer-status`. The unit tests still passed, merely *slowly*,
so only a timing assertion catches it. Also raised (and fixed): self-advance could
skip non-rez paid abilities (→ grace period), the Runner could park pointlessly
(→ can't), and the park budget reset on re-entry (→ one deadline per invocation).

## Tests
23 new Clojure tests incl. the safety case that self-advance must **not** skip a live
rez decision, and the park loop driven end-to-end; 4 new shell assertions incl. the
orphan-toucher guard (an orphan would keep a **dead** driver looking alive forever)
and the command-substitution timing guard. **Suite 441/0, shell 18/18.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)