### PR TITLE
fix(#70): resolve face-down cards at a multi-card remote breach

### DIFF
--- a/dev/src/clj/ai_core.clj
+++ b/dev/src/clj/ai_core.clj
@@ -840,6 +840,30 @@
                        (:title %)))
          first)))
 
+(defn find-selectable-card-by-cid
+  "Resolve a CID that came from a prompt's :selectable list to a card map.
+
+   Unlike find-card-by-cid, this does NOT require :title. At a multi-card remote
+   breach the engine lists FACE-DOWN Corp cards as selectable; in the Runner's
+   view those cards are legitimately title-less yet are real, pickable cards —
+   they carry :cid/:zone/:side/:type, which is all select-card! needs. A
+   title-less match must carry :zone AND :side — both present on a real board
+   card and among the fields select-card! consumes — so non-card maps that merely
+   carry a :cid (effects-registry entries, log refs) are still skipped. When
+   several maps share the CID, a named (:title) match is preferred so behavior for
+   ordinary visible cards is unchanged. (issue #70)
+
+   Returns nil if no card-shaped map matches."
+  [cid]
+  (let [gs (state/get-game-state)
+        matches (->> (tree-seq coll? seq gs)
+                     (filter #(and (map? %)
+                                   (= cid (:cid %))
+                                   (or (:title %) (and (:zone %) (:side %)))))
+                     seq)]
+    (or (some #(when (:title %) %) matches)
+        (first matches))))
+
 (defn resolve-selectable
   "Resolve a prompt's :selectable list, separating cards this seat can actually
    pick from PHANTOM entries — CIDs absent from the seat's visible game state
@@ -848,27 +872,34 @@
    {:pickable [{:idx <n> :card <map>} ...] :phantom [<idx> ...]}.
 
    Indices are the ORIGINAL positions in :selectable — choose-card resolves by
-   `(nth selectable index)`, so callers must never renumber the underlying list."
+   `(nth selectable index)`, so callers must never renumber the underlying list.
+
+   A CID string is resolved with find-selectable-card-by-cid, so a FACE-DOWN card
+   the seat is accessing at a breach (title-less but zone-resident) counts as
+   pickable rather than phantom. Card-shape is judged by :title OR :zone. (#70)"
   [selectable]
   (reduce
    (fn [acc [idx s]]
-     (let [card (if (string? s) (find-card-by-cid s) s)]
-       (if (and (map? card) (:title card))
+     (let [card (if (string? s) (find-selectable-card-by-cid s) s)]
+       (if (and (map? card) (or (:title card) (:zone card)))
          (update acc :pickable conj {:idx idx :card card})
          (update acc :phantom conj idx))))
    {:pickable [] :phantom []}
    (map-indexed vector selectable)))
 
 (defn format-selectable-card
-  "Format one resolved selectable card for display: title, type, zone, rez state."
+  "Format one resolved selectable card for display: title, type, zone, rez state.
+   A title-less card (e.g. a face-down Corp card being accessed at a breach) is
+   labelled 'face-down card' with its zone so the seat can still pick it. (#70)"
   [card]
-  (let [title (or (:title card) (:printed-title card) "?")
+  (let [named? (or (:title card) (:printed-title card))
+        title (or named? "face-down card")
         card-type (:type card)
         zone (:zone card)
         rezzed? (:rezzed card)]
     (str title
-         (when (seq (str card-type)) (str " [" card-type "]"))
-         (when (and (seq zone) (:title card))
+         (when (and named? (seq (str card-type))) (str " [" card-type "]"))
+         (when (seq zone)
            (str " (in " (str/join "/" (map name zone)) ")"))
          (when (some? rezzed?) (if rezzed? " (rezzed)" " (unrezzed)")))))
 

--- a/dev/src/clj/ai_prompts.clj
+++ b/dev/src/clj/ai_prompts.clj
@@ -236,11 +236,17 @@
 
       :else
       (let [cid-or-card (nth selectable index)
-            ;; Selectable can be CID strings or card maps - resolve CIDs to cards
+            ;; Selectable can be CID strings or card maps - resolve CIDs to cards.
+            ;; Use the selectable-aware resolver so a FACE-DOWN card at a breach
+            ;; (title-less in the Runner's view) still resolves — the title-gated
+            ;; find-card-by-cid dropped it and wedged multi-card remote breaches. (#70)
             card (if (string? cid-or-card)
-                   (core/find-card-by-cid cid-or-card)
+                   (core/find-selectable-card-by-cid cid-or-card)
                    cid-or-card)]
-        (if card
+        ;; Card-shape guard mirrors resolve-selectable: a real pick has :title OR
+        ;; :zone. This keeps a raw junk map that the engine might drop directly
+        ;; into :selectable from reaching select-card! by index. (#70 review)
+        (if (and (map? card) (or (:title card) (:zone card)))
           ;; Don't claim success before the prompt confirms registration: print
           ;; the confirmation only AFTER the prompt moves. A non-select prompt
           ;; that doesn't move means choose-card was the WRONG verb (the engine

--- a/dev/test/ai_pure_functions_test.clj
+++ b/dev/test/ai_pure_functions_test.clj
@@ -712,7 +712,64 @@
                                          :zone ["servers" "hq" "ices"] :rezzed false})))
     (is (= "Eli 1.0 [ICE] (in servers/rd/ices) (rezzed)"
            (core/format-selectable-card {:title "Eli 1.0" :type "ICE"
-                                         :zone ["servers" "rd" "ices"] :rezzed true})))))
+                                         :zone ["servers" "rd" "ices"] :rezzed true}))))
+  (testing "a title-less face-down card reads as 'face-down card' with its zone (#70)"
+    (is (= "face-down card (in servers/remote1/content)"
+           (core/format-selectable-card {:type "Card"
+                                         :zone ["servers" "remote1" "content"]})))))
+
+;; ============================================================================
+;; find-selectable-card-by-cid / face-down access at a remote breach (issue #70)
+;;
+;; BLOCKER regression: at a multi-card remote breach the engine sends :selectable
+;; as CID strings for FACE-DOWN Corp cards. In the Runner's view those cards carry
+;; :cid/:zone/:side/:type but NO :title. find-card-by-cid filters on :title, so it
+;; returned nil, choose-card rejected the pick as "hidden/opponent (not in your
+;; view)", and the breach — the exact game-winning access — could not be resolved
+;; except via the eval escape hatch. A title-less card genuinely present in the
+;; seat's game state (it lives in a :zone) must resolve; non-card junk that merely
+;; carries a :cid (effects-registry entries, log refs — no :zone) must not.
+;; ============================================================================
+
+(defn- facedown-breach-state
+  "Game state with a face-down Corp card (no :title) in a remote server root,
+   as the Runner sees it at a breach."
+  [cid]
+  {:corp {:servers {:remote1 {:content [{:cid cid
+                                         :zone ["servers" "remote1" "content"]
+                                         :side "Corp" :type "Card"}]}}}
+   :runner {}
+   :active-player "runner"})
+
+(deftest test-resolve-selectable-facedown-cid-pickable
+  (testing "a face-down CID at a breach is PICKABLE, not phantom (issue #70)"
+    (with-mock-state (mock-client-state :game-state (facedown-breach-state "fd-9"))
+      (let [{:keys [pickable phantom]} (core/resolve-selectable ["fd-9"])]
+        (is (empty? phantom)
+            "the face-down card must NOT be treated as a phantom/hidden CID")
+        (is (= [0] (map :idx pickable)))
+        (is (= "fd-9" (:cid (:card (first pickable)))))))))
+
+(deftest test-find-selectable-card-by-cid
+  (testing "a title-less face-down card present in state resolves by cid"
+    (with-mock-state (mock-client-state :game-state (facedown-breach-state "fd-1"))
+      (let [card (core/find-selectable-card-by-cid "fd-1")]
+        (is (some? card) "face-down card must resolve (was nil under the :title filter)")
+        (is (= "fd-1" (:cid card)))
+        (is (nil? (:title card))))))
+  (testing "find-card-by-cid (title-gated) is unchanged — still nil for the same card"
+    (with-mock-state (mock-client-state :game-state (facedown-breach-state "fd-1"))
+      (is (nil? (core/find-card-by-cid "fd-1")))))
+  (testing "a named card still resolves and is preferred over any junk sharing its cid"
+    (with-mock-state (mock-client-state
+                      :game-state {:runner {:rig {:program [{:cid "p-1" :title "Corroder"
+                                                             :zone ["rig" "program"]}]}}})
+      (is (= "Corroder" (:title (core/find-selectable-card-by-cid "p-1"))))))
+  (testing "non-card junk sharing a :cid (no :title, no :zone) does not resolve"
+    (with-mock-state (mock-client-state
+                      :game-state {:effects [{:cid "fx-1" :duration :end-of-turn}]})
+      (is (nil? (core/find-selectable-card-by-cid "fx-1"))
+          "effects-registry entries carry :cid but no :zone — must stay unresolved"))))
 
 ;; ============================================================================
 ;; new-prompt? / classify-ability-result (ai-core) -- eid-aware prompt detection


### PR DESCRIPTION
Fixes #70 (BLOCKER).

## The bug
At a multi-card remote breach the engine lists **face-down Corp cards** as `:selectable` using CID strings. In the Runner's view a face-down card carries `:cid/:zone/:side/:type` but **no `:title`**. The title-gated `find-card-by-cid` returned `nil`, so `choose-card` rejected the pick as *"hidden/opponent (not in your view)"* — while `prompt` simultaneously told the seat to use that exact command. The breach that stole the first Offworld Office (the game-winning line) could only be resolved via the `eval` escape hatch.

## The fix
- **`find-selectable-card-by-cid`** (new, `ai_core`): matches `:cid`; accepts a card that is either named (`:title`) **or** a real board card (`:zone` AND `:side` — the card-shape fields `select-card!` consumes); prefers a named match so ordinary visible cards behave exactly as before. Non-card maps that merely carry a `:cid` (effects-registry entries, log refs — no `:zone`/`:side`) are still skipped.
- Wired into **`resolve-selectable`** (so `prompt` shows the face-down card as pickable) and **`choose-card`** (so the pick registers). Added a card-shape guard in `choose-card` so a raw junk map dropped directly into `:selectable` can't reach `select-card!` by index.
- **`format-selectable-card`**: a title-less card now reads `face-down card (in servers/remote1/content)` instead of a bare `?`.

## Testing
Red→green: `test-resolve-selectable-facedown-cid-pickable` was red (face-down CID → phantom/unpickable), now green. Plus unit tests for `find-selectable-card-by-cid` (resolves face-down, still rejects `:cid`-only junk, prefers named, leaves `find-card-by-cid` untouched) and face-down formatting. `make verify` green (21 ns compile; full test + shell suites).

## Review
Guest-reviewed (GPT-5.5 via Devin): verdict **sound**, no CRITICAL/MAJOR. Both MINOR hardening notes applied — the `choose-card` card-shape guard and the stricter title-less discriminator (`:zone` AND `:side`, not `:zone` alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)