### PR TITLE
fix(#69): abilities/trash use normalizing side= for Corp-card lookup

### DIFF
--- a/dev/src/clj/ai_card_actions.clj
+++ b/dev/src/clj/ai_card_actions.clj
@@ -402,8 +402,11 @@
   [card-name]
   (let [client-state @state/client-state
         side (:side client-state)
-        ;; Find card in appropriate location based on side
-        card (if (= "Corp" side)
+        ;; Find card in appropriate location based on side. Use core/side= —
+        ;; client-state stores :side lowercase ("corp"), so a strict
+        ;; (= "Corp" side) is always false and would search the Runner rig,
+        ;; missing every Corp card to trash. (issue #69, same defect)
+        card (if (core/side= "Corp" side)
                (core/find-installed-corp-card card-name)
                (core/find-installed-card card-name))]
     (if card

--- a/dev/src/clj/ai_display.clj
+++ b/dev/src/clj/ai_display.clj
@@ -1518,8 +1518,10 @@
   [card-name]
   (let [state @state/client-state
         side (:side state)
-        ;; Find card in appropriate location
-        card (if (= "Corp" side)
+        ;; Find card in appropriate location. Use core/side= — client-state stores
+        ;; :side lowercase ("corp"), so a strict (= "Corp" side) is always false
+        ;; and would search the Runner rig, missing every Corp card. (issue #69)
+        card (if (core/side= "Corp" side)
                (core/find-installed-corp-card card-name)
                (core/find-installed-card card-name))]
     (if card

--- a/dev/test/ai_display_test.clj
+++ b/dev/test/ai_display_test.clj
@@ -969,3 +969,29 @@
             (str "should name the opponent we're waiting on:\n" out))
         (is (or (str/includes? out "wait") (str/includes? out "Other actions"))
             (str "should tell the player they can wait / still have actions:\n" out))))))
+
+;; ============================================================================
+;; show-card-abilities — Corp-seat card lookup (issue #69)
+;;
+;; Regression: `abilities` used a strict (= "Corp" side) check, but client-state
+;; stores :side lowercase ("corp"). So (= "Corp" "corp") was always false, the
+;; else branch searched the RUNNER rig, and every Corp card reported "Card not
+;; found installed" — even installed+rezzed assets whose abilities `use-ability`
+;; (which uses the normalizing core/side=) could fire fine. Must use side=.
+;; ============================================================================
+
+(deftest test-show-card-abilities-corp-seat-finds-corp-asset
+  (testing "abilities resolves a rezzed Corp asset for a Corp seat (:side is lowercase)"
+    (with-mock-state (mock-client-state
+                      :side "corp"
+                      :servers {:remote1 {:content [{:cid "reg-1"
+                                                     :title "Regolith Mining License"
+                                                     :type "Asset" :rezzed true
+                                                     :zone ["servers" "remote1" "content"]
+                                                     :abilities [{:label "Take 3 [Credits]"
+                                                                  :cost-label "[Click]"}]}]}})
+      (let [out (with-out-str (display/show-card-abilities "Regolith Mining License"))]
+        (is (not (str/includes? out "Card not found installed"))
+            (str "a Corp seat's own installed card must resolve:\n" out))
+        (is (str/includes? out "Take 3")
+            (str "should list the card's ability:\n" out))))))


### PR DESCRIPTION
Fixes #69.

## Root cause
`show-card-abilities` (the `abilities` command, `ai_display.clj`) and `trash-installed!` (`ai_card_actions.clj`) picked their card-lookup zone with a strict `(= "Corp" side)`. But client-state stores `:side` **lowercase** (`"corp"`) — that's exactly why `core/side=` exists. So `(= "Corp" "corp")` was **always false**, both fell through to the Runner-rig search (`find-installed-card`), and every Corp card came back *"Card not found installed"* — including installed+rezzed assets whose abilities `use-ability` (which already uses `core/side=`) could fire fine at the same moment. That mismatch is what the issue reported.

## Fix
Swap both call sites to `core/side=`, the case-insensitive helper `use-ability!` already uses for this exact purpose. No behavior change for a Runner seat. `trash-installed!` had the identical latent defect (Corp seat couldn't find its own ICE/assets/upgrades to trash) — fixed in the same pass.

## Testing
Red→green: a Corp seat asking `abilities "Regolith Mining License"` (rezzed, in a remote) now resolves the card and lists its ability instead of *"Card not found installed"*. `make verify` green (21 ns compile; full test + shell suites).

Trivial normalization fix using an existing proven helper — self-reviewed, guest panel skipped per the "generic work = noise tax" clause of the review SOP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)