### PR TITLE
fix(#68): park defers to my-turn-to-act? (kill the 2nd divergent boundary copy)

### DIFF
--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -1719,19 +1719,22 @@
   [state side]
   (let [gs (:game-state state)
         my-prompt (get-in gs [(keyword side) :prompt-state])
-        active (normalize-side (:active-player gs))
-        ;; :active-player is STALE at a turn boundary. When a player ends their
-        ;; turn the engine sets :end-turn and LEAVES :active-player pointing at
-        ;; them until the opponent actually calls start-turn (verified live:
-        ;; {:active-player "corp", :end-turn true, :corp-click 0} while
-        ;; game-over-status reads AWAITING-START next-player=runner). Reading
-        ;; :active-player raw therefore told a Corp that had *just ended its turn*
-        ;; — exactly when the brief tells it to take its post — "your move", and
-        ;; bounced it straight back out of the park it was trying to enter. So at
-        ;; a boundary the player to act is the OTHER one.
-        my-turn? (if (:end-turn gs)
-                   (= (core/other-side active) side)
-                   (= active side))]
+        ;; Turn ownership at a boundary is subtle and the engine's raw fields lie
+        ;; about it in more than one way, so DON'T re-derive it here — defer to
+        ;; core/my-turn-to-act?, the single authoritative predicate that also
+        ;; backs `wait`/`relevance-reason` and agrees with game-over-status.
+        ;; A bespoke copy of this logic bit us twice:
+        ;;   #31 — a Corp that had JUST ENDED its turn (:end-turn set, but
+        ;;         :active-player still pointing at itself) read as active and got
+        ;;         told "your move", bouncing it out of the post it was entering.
+        ;;   #68 — a boundary where :end-turn was NOT set but :active-player was
+        ;;         still "corp" with 0 clicks (live: turn=1, game-over-status
+        ;;         AWAITING-START next-player=runner) fell into the raw
+        ;;         (= active side) branch and again said "your move" ~3x, telling
+        ;;         the Corp to leave before the Runner had even started.
+        ;; my-turn-to-act? gets both right (0 clicks + not-opponent-ended => not
+        ;; my turn), so there is no second copy left to drift.
+        my-turn? (core/my-turn-to-act? state side)]
     (cond
       (state/game-over? gs) :game-over
       (some? (:run gs)) :run

--- a/dev/test/run_window_selfadvance_test.clj
+++ b/dev/test/run_window_selfadvance_test.clj
@@ -246,14 +246,18 @@
             window). Old behavior returned :no-run and abandoned the post."
     (let [st (mock-client-state
               :side "corp"
-              :game-state {:run nil :active-player "runner"})]
+              :game-state {:run nil :active-player "runner"
+                           :turn 3 :corp {:click 0} :runner {:click 2}})]
       (is (= :park (runs/park-wake-reason st "corp"))))))
 
 (deftest park-returns-on-my-turn
-  (testing "Opponent's turn ended -> hand control back to the seat"
+  (testing "It IS the Corp's live turn (active + clicks in hand) -> hand control
+            back to the seat. (The turn-boundary variants — opponent ended, or
+            AWAITING-START — are covered by the dedicated tests below.)"
     (let [st (mock-client-state
               :side "corp"
-              :game-state {:run nil :active-player "corp"})]
+              :game-state {:run nil :active-player "corp"
+                           :turn 3 :corp {:click 2} :runner {:click 0}})]
       (is (= :my-turn (runs/park-wake-reason st "corp"))))))
 
 (deftest park-wakes-on-a-corp-prompt-with-no-run
@@ -301,7 +305,7 @@
     (let [st (mock-client-state
               :side "corp"
               :game-state {:run nil :active-player "corp" :end-turn true
-                           :corp {:click 0} :runner {:click 0}})]
+                           :turn 5 :corp {:click 0} :runner {:click 0}})]
       (is (= :park (runs/park-wake-reason st "corp"))
           "Corp that just ended its turn must PARK, not be told 'your move'"))))
 
@@ -311,8 +315,26 @@
     (let [st (mock-client-state
               :side "corp"
               :game-state {:run nil :active-player "runner" :end-turn true
-                           :corp {:click 0} :runner {:click 0}})]
+                           :turn 5 :corp {:click 0} :runner {:click 0}})]
       (is (= :my-turn (runs/park-wake-reason st "corp"))))))
+
+(deftest park-does-not-say-your-move-at-awaiting-start-boundary
+  (testing "#68 (LIVE-CAUGHT, marquee 14bb5405): the OTHER turn-boundary residual.
+            A parked Corp saw '🔔 Opponent's turn ended — your move' ~3x while
+            game-over-status authoritatively read AWAITING-START next-player=runner.
+            Repro'd live: {:active-player \"corp\" :end-turn FALSE :turn 1
+            :corp-click 0}. Unlike #31 the engine had NOT set :end-turn, so the old
+            bespoke my-turn? fell into its (= active side) branch and said 'your
+            move' — telling the Corp to leave the post while the Runner had not yet
+            started. next-player=runner means the Corp must stay at its post. Fixed
+            by deferring to core/my-turn-to-act? (the same predicate game-over-status
+            agrees with) instead of a second, divergent copy of boundary logic."
+    (let [st (mock-client-state
+              :side "corp"
+              :game-state {:run nil :active-player "corp" :end-turn false
+                           :turn 1 :corp {:click 0} :runner {:click 0}})]
+      (is (= :park (runs/park-wake-reason st "corp"))
+          "AWAITING-START next-player=runner: Corp parks, not 'your move'"))))
 
 (deftest runner-never-parks
   (testing "Runs only happen on the Runner's turn, so a Runner parking for the


### PR DESCRIPTION
Closes #68.

## What
A parked persistent Corp monitor printed `🔔 Opponent's turn ended — your move` ~3× while `game-over-status` authoritatively read `AWAITING-START next-player=runner` (marquee `14bb5405`, Corp seat). It's self-correcting (`start-turn` refused, the seat retried), but it's the "message lies about what happened" class and wastes a round-trip + erodes trust in the monitor's return reasons.

## Root cause (live-repro'd this session)
`park-wake-reason` kept its **own copy** of "is it my turn", derived from raw `:active-player`/`:end-turn`. On the stuck game I eval'd the exact state:

```
{:active-player "corp", :end-turn false, :turn 1, :corp-click 0}   ; game-over-status: AWAITING-START next-player=runner
```

Here `:end-turn` was **not** set, so the bespoke `my-turn?` fell into its `(= active side)` branch → `true` → `:my-turn`, telling the Corp to leave the post before the Runner had even started. The authoritative `core/my-turn-to-act?` returns `false` on the same state (confirmed live).

This is the **same bug class as #31** — a second divergent copy of turn-boundary logic that drifts from the truth. #31 patched the copy; #68 is the residual it left behind.

## Fix
Remove the copy. `park-wake-reason` now defers to `core/my-turn-to-act?`, the single authoritative predicate that also backs `wait`/`relevance-reason` and agrees with `game-over-status`. It gets **both** directions right:
- #31 direction: a Corp that just ended its turn (0 clicks, not opponent-ended) → `:park`
- #68 direction: mid-game boundary, 0 clicks, `:end-turn` unset → `:park`

## Tests
- New regression test with the exact live-caught state (red→green).
- Three existing park tests had mocks that omitted `:turn` (defaulting to 0), which masked the consolidated predicate's post-mulligan clause and let assertions pass for the wrong reason. Pinned them to realistic mid-game turns so they test the boundary they describe. No assertion weakened.
- `make verify` green (450 tests). `lein test run-window-selfadvance-test`: 31 tests, 0 failures.

## Review
Guest review (GPT-5.5 via codex, read-only): **no findings** across all three dimensions (missed hand-back / wrong `:my-turn` / weakened mocks). It independently validated the runner→corp both-zero-clicks transient is safe — `:run` is checked before `:my-turn`, the debounce re-checks, and a real boundary stabilizes to `:end-turn true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)