### PR TITLE
fix(#75): stop Corp continue-spam at blocked checkpoints; honest choice reporting

### DIFF
--- a/dev/src/clj/ai_prompts.clj
+++ b/dev/src/clj/ai_prompts.clj
@@ -121,26 +121,33 @@
     ;; must not print before we know. Only run the auto-end hook if the prompt
     ;; actually moved (see choose-card!).
     (if (wait-for-prompt-change! old-eid)
-      (do
+      ;; Capture the revealed prompt BEFORE the auto-end hook runs (guest
+      ;; review): the hook can itself advance state, and duplicate detection
+      ;; must observe the prompt the choice immediately revealed.
+      (let [new-prompt (state/get-prompt)
+            ;; Duplicate-instance detection (#75): the engine can mint STACKED
+            ;; copies of the same prompt (marquee g2: five Manegarm 'Choose one'
+            ;; prompts from Corp continue-spam). Resolving one pops it and an
+            ;; identical-looking next instance surfaces (same msg + card, new
+            ;; eid). Without saying so, the seat reads the stack as a no-op loop
+            ;; and gives up — g2 was abandoned one answer short of draining it.
+            ;; Fingerprint requires a PRESENT msg and card cid (guest review):
+            ;; nil = nil must not identify two different card-less prompts that
+            ;; share a generic msg like "Choose one".
+            duplicate? (and new-prompt
+                            (not= (:eid new-prompt) old-eid)
+                            (some? old-msg)
+                            (= (:msg new-prompt) old-msg)
+                            (some? old-cid)
+                            (= (get-in new-prompt [:card :cid]) old-cid))]
         (maybe-auto-end-turn-after-prompt!)
         (println (str "✅ Chose: " (core/format-choice choice)))
-        ;; Duplicate-instance detection (#75): the engine can mint STACKED
-        ;; copies of the same prompt (marquee g2: five Manegarm 'Choose one'
-        ;; prompts from Corp continue-spam). Resolving one pops it and an
-        ;; identical-looking next instance surfaces (same msg + card, new eid).
-        ;; Without saying so, the seat reads the stack as a no-op loop and gives
-        ;; up — g2 was abandoned one answer short of draining it.
-        (let [new-prompt (state/get-prompt)
-              duplicate? (and new-prompt
-                              (not= (:eid new-prompt) old-eid)
-                              (= (:msg new-prompt) old-msg)
-                              (= (get-in new-prompt [:card :cid]) old-cid))]
-          (when duplicate?
-            (println (str "ℹ️  Your choice RESOLVED, but an identical duplicate prompt "
-                          "appeared (new instance of the same card prompt — the engine "
-                          "minted copies). Answer it again to drain the stack.")))
-          (core/with-cursor (cond-> {:status :success :choice choice}
-                              duplicate? (assoc :duplicate-prompt true)))))
+        (when duplicate?
+          (println (str "ℹ️  Your choice RESOLVED, but an identical duplicate prompt "
+                        "appeared (new instance of the same card prompt — the engine "
+                        "minted copies). Answer it again to drain the stack.")))
+        (core/with-cursor (cond-> {:status :success :choice choice}
+                            duplicate? (assoc :duplicate-prompt true))))
       (do
         (println (str "⚠️  Choice sent but the prompt did not change — NOT treating as "
                       "resolved: " (core/format-choice choice)))

--- a/dev/src/clj/ai_prompts.clj
+++ b/dev/src/clj/ai_prompts.clj
@@ -108,16 +108,45 @@
         side-kw (when side (keyword (clojure.string/lower-case side)))
         gameid (:gameid client-state)
         prompt (get-in client-state [:game-state side-kw :prompt-state])
-        old-eid (:eid prompt)]
-    (println (str "✅ Chose: " (core/format-choice choice)))
+        old-eid (:eid prompt)
+        old-msg (:msg prompt)
+        old-cid (get-in prompt [:card :cid])]
     (ws/send-message! :game/action
                       {:gameid gameid
                        :command "choice"
                        :args {:choice {:uuid (:uuid choice)}}})
-    ;; Only run the auto-end hook if the prompt actually moved (see choose-card!).
-    (when (wait-for-prompt-change! old-eid)
-      (maybe-auto-end-turn-after-prompt!))
-    (core/with-cursor {:status :success :choice choice})))
+    ;; Report what actually happened, not what we attempted (#75): a choice the
+    ;; engine rejects (e.g. an unpayable cost) or silently swallows leaves the
+    ;; prompt unchanged — that must NOT read as success, and the success line
+    ;; must not print before we know. Only run the auto-end hook if the prompt
+    ;; actually moved (see choose-card!).
+    (if (wait-for-prompt-change! old-eid)
+      (do
+        (maybe-auto-end-turn-after-prompt!)
+        (println (str "✅ Chose: " (core/format-choice choice)))
+        ;; Duplicate-instance detection (#75): the engine can mint STACKED
+        ;; copies of the same prompt (marquee g2: five Manegarm 'Choose one'
+        ;; prompts from Corp continue-spam). Resolving one pops it and an
+        ;; identical-looking next instance surfaces (same msg + card, new eid).
+        ;; Without saying so, the seat reads the stack as a no-op loop and gives
+        ;; up — g2 was abandoned one answer short of draining it.
+        (let [new-prompt (state/get-prompt)
+              duplicate? (and new-prompt
+                              (not= (:eid new-prompt) old-eid)
+                              (= (:msg new-prompt) old-msg)
+                              (= (get-in new-prompt [:card :cid]) old-cid))]
+          (when duplicate?
+            (println (str "ℹ️  Your choice RESOLVED, but an identical duplicate prompt "
+                          "appeared (new instance of the same card prompt — the engine "
+                          "minted copies). Answer it again to drain the stack.")))
+          (core/with-cursor (cond-> {:status :success :choice choice}
+                              duplicate? (assoc :duplicate-prompt true)))))
+      (do
+        (println (str "⚠️  Choice sent but the prompt did not change — NOT treating as "
+                      "resolved: " (core/format-choice choice)))
+        (core/with-cursor {:status :waiting-input
+                           :choice choice
+                           :reason "Prompt unchanged after choice — it may have been rejected (e.g. unpayable cost) or swallowed"})))))
 
 (defn choose-option!
   "Choose from prompt by index (side-aware).

--- a/dev/src/clj/ai_run_corp_handlers.clj
+++ b/dev/src/clj/ai_run_corp_handlers.clj
@@ -30,15 +30,28 @@
     :else (str side-value)))
 
 (defn- send-continue!
-  "Helper to send continue command and return action-taken result."
+  "Helper to send continue command and return action-taken result.
+
+   Chokepoint guard (#75): consult the LIVE state at send time — if our own
+   prompt is a 'waiting' prompt, the engine is mid-checkpoint on the OPPONENT
+   (e.g. blocked on the Runner's Manegarm Skunkworks 'Choose one' at
+   :approach-server) and a continue from us is never legitimate. The engine has
+   no in-flight guard there: each duplicate continue re-fires the checkpoint and
+   mints a duplicate opponent prompt (marquee g2 wedge — five stacked Manegarm
+   prompts). Suppress and report an opponent wait so loops idle instead of spin."
   [gameid]
-  (ws/send-message! :game/action
-                    {:gameid gameid
-                     :command "continue"
-                     :args nil})
-  (Thread/sleep 100)
-  {:status :action-taken
-   :action :sent-continue})
+  (if (state/waiting-prompt-type? (:prompt-type (state/get-prompt)))
+    {:status :waiting-for-opponent
+     :action :continue-suppressed-waiting-prompt
+     :message "Own prompt is a waiting prompt — opponent is deciding; continue suppressed (#75)"}
+    (do
+      (ws/send-message! :game/action
+                        {:gameid gameid
+                         :command "continue"
+                         :args nil})
+      (Thread/sleep 100)
+      {:status :action-taken
+       :action :sent-continue})))
 
 ;; Track last waiting status to suppress repeated output (Corp-side)
 (defonce last-waiting-status (atom nil))
@@ -375,29 +388,39 @@
              :ice ice-title
              :position position}))
 
-        ;; Other phases with prompt but no real decision - auto-continue
-        ;; BUT NOT during success/access phases where Runner is active and Corp just waits
+        ;; Other phases with an EMPTY RUN paid-ability window - auto-continue.
+        ;; BUT NOT during success/access phases where Runner is active and Corp just waits,
+        ;; and ONLY for a "run"-type prompt (mirrors can-auto-continue?): a
+        ;; 'waiting' prompt also has empty :choices/:selectable, and continuing
+        ;; on one re-fires the checkpoint the engine is blocked on — the #75
+        ;; Manegarm duplicate-prompt wedge (this branch was the spam source at
+        ;; movement/pos-0, five continues → five stacked Runner prompts).
         (and my-prompt
+             (= "run" (:prompt-type my-prompt))
              (empty? (:choices my-prompt))
              (empty? (:selectable my-prompt))
              (not (#{"success" "access"} run-phase)))
-        (do
-          (ws/send-message! :game/action
-                           {:gameid gameid
-                            :command "continue"
-                            :args nil})
-          (Thread/sleep 100)
-          {:status :action-taken
-           :action :auto-continue-fire-if-asked})
+        ;; Route through send-continue! so the #75 waiting-prompt chokepoint
+        ;; also covers this send (belt to the prompt-type guard above).
+        (let [r (send-continue! gameid)]
+          (if (= :action-taken (:status r))
+            (assoc r :action :auto-continue-fire-if-asked)
+            r))
 
         ;; Default - don't handle, let other handlers run
         :else nil))))
 
 (defn handle-corp-all-subs-resolved
-  "Priority 1.74: Corp at encounter-ice when all subs are resolved (broken or fired)."
+  "Priority 1.74: Corp at encounter-ice when all subs are resolved (broken or fired).
+
+   Passes AT MOST ONCE per window: if :no-action already records the Corp's pass,
+   fall through instead of re-sending — the condition (all subs resolved) stays
+   true after the pass, so without the guard this handler re-continued every loop
+   iteration until the stuck-detector tripped (the frames-248-252 burst of #75)."
   [{:keys [side run-phase state gameid]}]
   (when (and (= side "corp")
-             (= run-phase "encounter-ice"))
+             (= run-phase "encounter-ice")
+             (not= side (normalize-side (get-in state [:game-state :run :no-action]))))
     (let [current-ice (core/current-run-ice state)
           subroutines (:subroutines current-ice)
           actionable-subs (filter #(and (not (:broken %)) (not (:fired %))) subroutines)]

--- a/dev/src/clj/ai_run_runner_handlers.clj
+++ b/dev/src/clj/ai_run_runner_handlers.clj
@@ -10,6 +10,7 @@
    - Returns result map {:status ... :action ...} to stop handler chain"
   (:require [ai-websocket-client-v2 :as ws]
             [ai-core :as core]
+            [ai-state :as state]
             [ai-card-actions :as actions]
             [ai-run-tactics :as tactics]))
 
@@ -30,15 +31,26 @@
     :else (str side-value)))
 
 (defn- send-continue!
-  "Helper to send continue command and return action-taken result."
+  "Helper to send continue command and return action-taken result.
+
+   Chokepoint guard (#75): never send while the LIVE state shows our own prompt
+   is a 'waiting' prompt — the engine is mid-checkpoint on the OPPONENT and a
+   continue from us re-fires that checkpoint, minting duplicate opponent
+   prompts (the marquee-g2 wedge, mirrored to the Runner seat). Same guard as
+   the ai-runs and ai-run-corp-handlers copies."
   [gameid]
-  (ws/send-message! :game/action
-                    {:gameid gameid
-                     :command "continue"
-                     :args nil})
-  (Thread/sleep 100)
-  {:status :action-taken
-   :action :sent-continue})
+  (if (state/waiting-prompt-type? (:prompt-type (state/get-prompt)))
+    {:status :waiting-for-opponent
+     :action :continue-suppressed-waiting-prompt
+     :message "Own prompt is a waiting prompt — opponent is deciding; continue suppressed (#75)"}
+    (do
+      (ws/send-message! :game/action
+                        {:gameid gameid
+                         :command "continue"
+                         :args nil})
+      (Thread/sleep 100)
+      {:status :action-taken
+       :action :sent-continue})))
 
 (defn- filter-meaningful-log-entries
   "Filter log entries to exclude 'no further action' spam."
@@ -468,7 +480,15 @@
               (send-continue! gameid))))))))
 
 (defn handle-runner-pass-fired-ice
-  "Priority 2.7: Runner at encounter-ice after subs have fired."
+  "Priority 2.7: Runner at encounter-ice after subs have fired.
+
+   Passes AT MOST ONCE per [position ice] (#75, review finding): the
+   subs-resolved? log heuristic stays true after our pass, so without the
+   pass-once guard this handler re-sent continue every loop iteration while the
+   Corp's window was still open — the same duplicate-continue spam class that
+   minted the g2 Manegarm prompt stack, mirrored to the Runner seat. Shares
+   `passed-ice-position` with handle-runner-pass-broken-ice: either path
+   passing this ICE at this position means our priority here is spent."
   [{:keys [side run-phase state gameid my-prompt]}]
   (when (and (= side "runner")
              (= run-phase "encounter-ice")
@@ -479,6 +499,8 @@
              (not (has-real-decision? my-prompt)))
     (let [current-ice (core/current-run-ice state)
           ice-title (:title current-ice "ICE")
+          position (get-in state [:game-state :run :position])
+          pass-key [position ice-title]
           log (get-in state [:game-state :log])
           meaningful-log (filter-meaningful-log-entries (reverse log))
           recent-log (take 20 meaningful-log)
@@ -486,5 +508,18 @@
                                          (str (:text %)))
                                recent-log)]
       (when (and current-ice (:rezzed current-ice) subs-resolved?)
-        (println (format "   → Subs resolved on %s, Runner passing ICE" ice-title))
-        (send-continue! gameid)))))
+        (if (= @passed-ice-position pass-key)
+          ;; Already passed our priority here - wait for Corp, don't re-send.
+          (let [status-key [:passed-fired-ice pass-key]]
+            (when-not (= @last-waiting-status status-key)
+              (reset! last-waiting-status status-key)
+              (println (format "⏸️  Passed %s (subs fired), waiting for Corp to pass priority" ice-title)))
+            {:status :waiting-for-opponent
+             :wake-reason :waiting-for-opponent
+             :message (format "Waiting for Corp to pass priority after %s" ice-title)
+             :ice ice-title
+             :position position})
+          (do
+            (reset! passed-ice-position pass-key)
+            (println (format "   → Subs resolved on %s, Runner passing ICE" ice-title))
+            (send-continue! gameid)))))))

--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -840,6 +840,9 @@
       (println "⚠️  WARNING: --force is for AI-vs-AI testing ONLY!")
       (println "⚠️  In HITL games, this WILL break game state by passing")
       (println "⚠️  when you should wait for opponent.")
+      (println "⚠️  At a checkpoint blocked on an opponent prompt, a forced")
+      (println "⚠️  continue can re-fire the checkpoint and mint DUPLICATE")
+      (println "⚠️  prompts (#75/#77) — the normal path suppresses this.")
       (println ""))
     (let [run (get-in state [:game-state :run])]
       (if (nil? run)

--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -787,17 +787,28 @@
 
 (defn- send-continue!
   "Helper to send continue command and return action-taken result.
-   Waits briefly for state to sync via WebSocket."
+   Waits briefly for state to sync via WebSocket.
+
+   Chokepoint guard (#75): if the LIVE state shows our own prompt is a
+   'waiting' prompt, the engine is mid-checkpoint on the OPPONENT and a
+   continue from us re-fires that checkpoint (duplicate-prompt minting — the
+   marquee-g2 Manegarm wedge). Suppress and report an opponent wait instead.
+   Same guard as the ai-run-corp-handlers copy."
   [gameid]
-  (ws/send-message! :game/action
-                   {:gameid gameid
-                    :command "continue"
-                    :args nil})
-  ;; Brief wait for WebSocket state update to arrive
-  ;; Without this, caller may see stale state on next read
-  (Thread/sleep 100)
-  {:status :action-taken
-   :action :sent-continue})
+  (if (state/waiting-prompt-type? (:prompt-type (state/get-prompt)))
+    {:status :waiting-for-opponent
+     :action :continue-suppressed-waiting-prompt
+     :message "Own prompt is a waiting prompt — opponent is deciding; continue suppressed (#75)"}
+    (do
+      (ws/send-message! :game/action
+                        {:gameid gameid
+                         :command "continue"
+                         :args nil})
+      ;; Brief wait for WebSocket state update to arrive
+      ;; Without this, caller may see stale state on next read
+      (Thread/sleep 100)
+      {:status :action-taken
+       :action :sent-continue})))
 
 (defn- send-choice!
   "Helper to send choice command and return action-taken result.

--- a/dev/test/ai_prompts_test.clj
+++ b/dev/test/ai_prompts_test.clj
@@ -535,3 +535,30 @@
           (is (not (:duplicate-prompt @result)))
           (is (str/includes? out "✅ Chose:")
               (str "normal resolution keeps the success line, got: " out)))))))
+
+;; Review-panel tightening of the duplicate fingerprint (#75): nil = nil must
+;; not identify two DIFFERENT prompts. Only a present msg AND present card cid
+;; that both match may flag a duplicate.
+
+(deftest choose-option-nil-fingerprint-is-not-a-duplicate
+  (testing "two card-less prompts sharing only a nil/generic identity do not false-flag as duplicates"
+    (let [old-prompt {:msg "Choose one" :prompt-type "other" :eid {:eid 200}
+                      :choices [{:uuid "a1" :value "Yes" :idx 0}
+                                {:uuid "a2" :value "No" :idx 1}]}
+          ;; different prompt, also card-less, same generic msg, new eid
+          next-prompt {:msg "Choose one" :prompt-type "other" :eid {:eid 201}
+                       :choices [{:uuid "b1" :value "Left" :idx 0}
+                                 {:uuid "b2" :value "Right" :idx 1}]}]
+      (with-mock-state (mock-client-state :side "runner" :prompt old-prompt)
+        (with-redefs [ws/send-message! (fn [_evt _data] true)
+                      prompts/wait-for-prompt-change!
+                      (fn [_eid & _]
+                        (swap! state/client-state assoc-in
+                               [:game-state :runner :prompt-state] next-prompt)
+                        true)
+                      basic/check-auto-end-turn! (fn [] nil)]
+          (let [result (atom nil)]
+            (with-out-str (reset! result (prompts/choose-option! 0)))
+            (is (= :success (:status @result)))
+            (is (not (:duplicate-prompt @result))
+                "card-less prompts must not be identified by msg alone (nil cid = nil cid is not identity)")))))))

--- a/dev/test/ai_prompts_test.clj
+++ b/dev/test/ai_prompts_test.clj
@@ -461,3 +461,77 @@
             ;; Pressed the Mulligan button (option 1).
             (is (= {:choice {:uuid "mull-uuid"}} (:args @sent)))
             (is (not (str/includes? out "No mulligan prompt active")))))))))
+
+;; ============================================================================
+;; press-choice! honesty (#75, marquee g2 Manegarm wedge)
+;;
+;; press-choice! used to print "✅ Chose:" BEFORE sending and return
+;; {:status :success} unconditionally — a choice the engine rejected or
+;; swallowed still reported success (misleading-output class). And when the
+;; engine has minted DUPLICATE prompt instances (g2: five stacked Manegarm
+;; "Choose one" prompts from Corp continue-spam), resolving one pops it and
+;; reveals an identical-looking next instance; without surfacing "your choice
+;; resolved, but an identical duplicate appeared", the seat reads the stack as
+;; a no-op loop and gives up — that is exactly how g2 was abandoned one answer
+;; short of draining the stack.
+;; ============================================================================
+
+(def manegarm-prompt
+  {:msg "Choose one" :prompt-type "other" :eid {:eid 100}
+   :card {:cid "mane-1" :title "Manegarm Skunkworks" :side "Corp"}
+   :choices [{:uuid "u-pay" :value "Spend [Click][Click]" :idx 0}
+             {:uuid "u-etr" :value "End the run" :idx 1}]})
+
+(deftest choose-option-unchanged-prompt-is-not-success
+  (testing "a choice after which the prompt does NOT move must not report :success (#75)"
+    (with-mock-state (mock-client-state :side "runner" :prompt manegarm-prompt)
+      (with-redefs [ws/send-message! (fn [_evt _data] true)
+                    prompts/wait-for-prompt-change! (fn [_eid & _] false)
+                    basic/check-auto-end-turn! (fn [] nil)]
+        (let [result (atom nil)
+              out (with-out-str (reset! result (prompts/choose-option! 1)))]
+          (is (not= :success (:status @result))
+              (str "prompt unchanged ⇒ the choice may have been rejected/swallowed; got: " @result))
+          (is (not (str/includes? out "✅"))
+              (str "must not print a success checkmark for an unresolved choice, got: " out)))))))
+
+(deftest choose-option-duplicate-prompt-instance-is-surfaced
+  (testing "a choice that resolves but reveals an IDENTICAL duplicate prompt (new eid, same msg+card) says so (#75)"
+    (let [duplicate (assoc manegarm-prompt :eid {:eid 101}
+                           :choices [{:uuid "u-pay2" :value "Spend [Click][Click]" :idx 0}
+                                     {:uuid "u-etr2" :value "End the run" :idx 1}])]
+      (with-mock-state (mock-client-state :side "runner" :prompt manegarm-prompt)
+        (with-redefs [ws/send-message! (fn [_evt _data] true)
+                      prompts/wait-for-prompt-change!
+                      (fn [_eid & _]
+                        ;; the engine pops the answered instance and the next
+                        ;; stacked duplicate surfaces in its place
+                        (swap! state/client-state assoc-in
+                               [:game-state :runner :prompt-state] duplicate)
+                        true)
+                      basic/check-auto-end-turn! (fn [] nil)]
+          (let [result (atom nil)
+                out (with-out-str (reset! result (prompts/choose-option! 1)))]
+            (is (= :success (:status @result))
+                (str "the choice itself resolved — success, got: " @result))
+            (is (:duplicate-prompt @result)
+                "must flag the duplicate so a seat/bot can drain the stack instead of reading it as a no-op")
+            (is (str/includes? out "identical")
+                (str "must tell the seat an identical duplicate appeared, got: " out))))))))
+
+(deftest choose-option-normal-resolution-unchanged
+  (testing "a normally-resolving choice still reports plain :success with no duplicate flag"
+    (with-mock-state (mock-client-state :side "runner" :prompt manegarm-prompt)
+      (with-redefs [ws/send-message! (fn [_evt _data] true)
+                    prompts/wait-for-prompt-change!
+                    (fn [_eid & _]
+                      (swap! state/client-state assoc-in
+                             [:game-state :runner :prompt-state] nil)
+                      true)
+                    basic/check-auto-end-turn! (fn [] nil)]
+        (let [result (atom nil)
+              out (with-out-str (reset! result (prompts/choose-option! 1)))]
+          (is (= :success (:status @result)))
+          (is (not (:duplicate-prompt @result)))
+          (is (str/includes? out "✅ Chose:")
+              (str "normal resolution keeps the success line, got: " out)))))))

--- a/dev/test/continue_run_rez_test.clj
+++ b/dev/test/continue_run_rez_test.clj
@@ -1162,3 +1162,67 @@
                   "no continue may be sent while our own live prompt is a waiting prompt")
               (is (not= :action-taken (:status r))
                   (str "must not claim an action was taken, got: " r)))))))))
+
+;; =============================================================================
+;; Review findings on the #75 fix (panel: Claude + GPT-5.5/Devin):
+;; the SAME duplicate-continue spam class existed mirrored on the Runner seat.
+;; handle-runner-pass-fired-ice had no pass-once guard (unlike its sibling
+;; handle-runner-pass-broken-ice), so while the Corp's window stayed open the
+;; subs-resolved log heuristic stayed true and the Runner re-sent continue every
+;; loop iteration; and the runner-handlers copy of send-continue! had no
+;; waiting-prompt chokepoint.
+;; =============================================================================
+
+(defn- pass-fired-ice-ctx
+  "Runner at encounter-ice with the ICE's subs all fired and the log recording
+   the resolution — the state handle-runner-pass-fired-ice keys on."
+  []
+  {:side "runner"
+   :run-phase "encounter-ice"
+   :strategy {}
+   :gameid (java.util.UUID/fromString "00000000-0000-0000-0000-000000000076")
+   :my-prompt {:msg "You may use paid abilities" :prompt-type "run" :choices [] :selectable []}
+   :state {:game-state
+           {:run {:phase "encounter-ice" :position 1 :server [:hq]}
+            :corp {:servers {:hq {:ices [{:cid 31 :title "Tithe" :rezzed true
+                                          :subroutines [{:label "Do 1 net damage" :fired true}
+                                                        {:label "Gain 1 credit" :fired true}]}]}}}
+            :runner {:prompt-state {:msg "You may use paid abilities"
+                                    :prompt-type "run" :choices [] :selectable []}}
+            :log [{:text "Corp resolves 2 unbroken subroutines on Tithe"}]}}})
+
+(deftest pass-fired-ice-passes-at-most-once
+  (testing "handle-runner-pass-fired-ice sends ONE continue then waits — no re-send while the Corp's window is open (#75 review finding)"
+    (let [sent (atom [])]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (runner-handlers/reset-state!)
+        (with-out-str
+          (let [r1 (runner-handlers/handle-runner-pass-fired-ice (pass-fired-ice-ctx))
+                r2 (runner-handlers/handle-runner-pass-fired-ice (pass-fired-ice-ctx))]
+            (is (= :action-taken (:status r1))
+                (str "first pass is legitimate, got: " r1))
+            (is (= :waiting-for-opponent (:status r2))
+                (str "second pass at the same [position ice] is spam; must wait, got: " r2))))
+        (is (= 1 (count (filter #(= "continue" (:command %)) @sent)))
+            "exactly one continue may reach the engine for this window")
+        (runner-handlers/reset-state!)))))
+
+(deftest runner-send-continue-chokepoint-suppresses-on-live-waiting-prompt
+  (testing "the runner-handlers copy of send-continue! suppresses while the LIVE state shows a waiting prompt (#75 review finding)"
+    (let [sent (atom [])
+          live (mock-client-state
+                :side "runner"
+                :game-state (assoc-in (get-in (pass-fired-ice-ctx) [:state :game-state])
+                                      [:runner :prompt-state]
+                                      {:msg "Waiting for Corp to make a decision"
+                                       :prompt-type "waiting" :choices [] :selectable []}))]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (runner-handlers/reset-state!)
+        (with-mock-state live
+          (with-out-str
+            (let [r (runner-handlers/handle-runner-pass-fired-ice (pass-fired-ice-ctx))]
+              (is (not-any? #(= "continue" (:command %)) @sent)
+                  "no continue may be sent while our own live prompt is a waiting prompt")
+              (is (= :waiting-for-opponent (:status r))
+                  (str "suppressed continue reports an opponent wait, got: " r)))))
+        (runner-handlers/reset-state!)))))

--- a/dev/test/continue_run_rez_test.clj
+++ b/dev/test/continue_run_rez_test.clj
@@ -1007,3 +1007,158 @@
         (let [result (corp-handlers/handle-corp-server-upgrade-decision
                       (upgrade-decision-ctx {}))]
           (is (= :decision-required (:status result))))))))
+
+;; =============================================================================
+;; Test: Corp continue-spam at a blocked checkpoint must not happen (#75).
+;;
+;; Marquee g2 (GPT-5.6-Terra Corp vs Opus Runner) wedged unrecoverably: at
+;; movement/pos-0 the Runner passed, the Corp's continue triggered the
+;; :approach-server checkpoint and the engine BLOCKED on the Runner's Manegarm
+;; Skunkworks "Choose one" prompt — run phase stays "movement", :no-action stays
+;; "runner", and the Corp's own prompt becomes prompt-type "waiting". The engine
+;; has no in-flight guard: each additional Corp `continue` re-fired approach-server
+;; and minted a FRESH duplicate Manegarm prompt (replay frames 255-259: five
+;; stacked prompts, five "approaches Server 1" log lines). The Runner paid the
+;; top one, stole, and was left draining no-op duplicates — game lost to tooling.
+;;
+;; Client-side rule: a seat holding a "waiting" prompt must NEVER send continue —
+;; the engine is mid-checkpoint on the opponent. Guarded in three layers:
+;;   (a) --fire-if-asked's empty-window auto-continue requires a "run"-type
+;;       prompt (a waiting prompt has empty :choices/:selectable and matched);
+;;   (b) handle-corp-all-subs-resolved must not RE-pass after the Corp already
+;;       passed (the earlier burst, frames 248-252);
+;;   (c) belt-and-braces: send-continue! itself suppresses when the live state
+;;       shows our own prompt is a waiting prompt.
+;; =============================================================================
+
+(defn- fire-if-asked-blocked-checkpoint-ctx
+  "Corp --fire-if-asked at movement/pos-0 where the engine is blocked on the
+   Runner's Manegarm prompt: Corp holds the mirrored 'waiting' prompt, run
+   :no-action still says 'runner'. Exactly the #75 wedge window."
+  []
+  {:side "corp"
+   :run-phase "movement"
+   :strategy {:fire-if-asked true}
+   :gameid (java.util.UUID/fromString "00000000-0000-0000-0000-000000000075")
+   :my-prompt {:msg "Waiting for Runner to make a decision"
+               :prompt-type "waiting" :choices [] :selectable []}
+   :state {:game-state
+           {:run {:phase "movement" :position 0 :server [:remote1] :no-action "runner"}
+            :corp {:prompt-state {:msg "Waiting for Runner to make a decision"
+                                  :prompt-type "waiting" :choices [] :selectable []}
+                   :servers {:remote1 {:content [{:cid 11 :title "Manegarm Skunkworks"
+                                                  :type "Upgrade" :rezzed true}]}}}
+            :runner {:prompt-state {:msg "Choose one" :prompt-type "other"
+                                    :choices [{:uuid "u0" :value "Spend [Click][Click]"}
+                                              {:uuid "u1" :value "End the run"}]}}
+            :log []}}})
+
+(deftest fire-if-asked-does-not-continue-on-waiting-prompt
+  (testing "--fire-if-asked must NOT auto-continue while holding a 'waiting' prompt — each continue re-fires the blocked approach-server checkpoint and mints a duplicate upgrade prompt (#75)"
+    (let [sent (atom [])]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (with-out-str
+          (let [r (corp-handlers/handle-corp-fire-if-asked
+                   (fire-if-asked-blocked-checkpoint-ctx))]
+            (is (not-any? #(= "continue" (:command %)) @sent)
+                "a continue here re-fires approach-server and mints a duplicate Manegarm prompt")
+            (is (not= :action-taken (:status r))
+                (str "must not claim an action was taken at a blocked checkpoint, got: " r))))))))
+
+(deftest fire-if-asked-still-continues-empty-run-window
+  (testing "--fire-if-asked still auto-continues a genuine empty 'run'-type paid-ability window (no over-blocking)"
+    (let [sent (atom [])
+          ctx (-> (fire-if-asked-blocked-checkpoint-ctx)
+                  (assoc :my-prompt {:msg "You may use paid abilities"
+                                     :prompt-type "run" :choices [] :selectable []})
+                  (assoc-in [:state :game-state :corp :prompt-state]
+                            {:msg "You may use paid abilities"
+                             :prompt-type "run" :choices [] :selectable []}))]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (with-out-str
+          (let [r (corp-handlers/handle-corp-fire-if-asked ctx)]
+            (is (some #(= "continue" (:command %)) @sent)
+                "an empty run-type window is exactly what --fire-if-asked should sleep through")
+            (is (= :action-taken (:status r)))))))))
+
+(defn- all-subs-resolved-ctx
+  "Corp at encounter-ice with every Palisade sub broken. :no-action controls
+   whether the Corp has already passed this window."
+  [no-action]
+  {:side "corp"
+   :run-phase "encounter-ice"
+   :strategy {}
+   :gameid (java.util.UUID/fromString "00000000-0000-0000-0000-000000000075")
+   :my-prompt {:msg "You may use paid abilities" :prompt-type "run" :choices [] :selectable []}
+   :state {:game-state
+           {:run (cond-> {:phase "encounter-ice" :position 1 :server [:remote1]}
+                   no-action (assoc :no-action no-action))
+            :corp {:prompt-state {:msg "You may use paid abilities"
+                                  :prompt-type "run" :choices [] :selectable []}
+                   :servers {:remote1 {:ices [{:cid 21 :title "Palisade" :rezzed true
+                                               :subroutines [{:label "End the run" :broken true}]}]}}}
+            :runner {:prompt-state nil}
+            :log []}}})
+
+(deftest all-subs-resolved-does-not-repass-after-corp-passed
+  (testing "handle-corp-all-subs-resolved must not RE-send continue after the Corp already passed (:no-action corp) — the frames-248-252 spam burst of #75"
+    (let [sent (atom [])]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (with-out-str
+          (let [r (corp-handlers/handle-corp-all-subs-resolved (all-subs-resolved-ctx "corp"))]
+            (is (not-any? #(= "continue" (:command %)) @sent)
+                "the Corp already passed this window; a second continue is spam the engine may amplify")
+            (is (not= :action-taken (:status r))
+                (str "must not claim an action, got: " r))))))))
+
+(deftest all-subs-resolved-still-passes-fresh-window
+  (testing "handle-corp-all-subs-resolved still passes a window the Corp hasn't passed yet (no over-blocking)"
+    (let [sent (atom [])]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (with-out-str
+          (let [r (corp-handlers/handle-corp-all-subs-resolved (all-subs-resolved-ctx nil))]
+            (is (some #(= "continue" (:command %)) @sent)
+                "all subs broken and Corp hasn't spoken — passing is correct")
+            (is (= :action-taken (:status r)))))))))
+
+(deftest send-continue-chokepoint-suppresses-on-live-waiting-prompt
+  (testing "belt-and-braces: even when a handler's own ctx qualifies, send-continue! consults the LIVE state and refuses to send while our prompt is a waiting prompt (#75)"
+    (let [sent (atom [])
+          ;; ctx satisfies all-subs-resolved (fresh window, subs broken), but the
+          ;; LIVE mirror — refreshed after the ctx snapshot was taken — shows the
+          ;; engine has since blocked on the Runner (Corp prompt went 'waiting').
+          ctx (all-subs-resolved-ctx nil)
+          live (mock-client-state
+                :side "corp"
+                :game-state (assoc-in (get-in ctx [:state :game-state])
+                                      [:corp :prompt-state]
+                                      {:msg "Waiting for Runner to make a decision"
+                                       :prompt-type "waiting" :choices [] :selectable []}))]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (with-mock-state live
+          (with-out-str
+            (let [r (corp-handlers/handle-corp-all-subs-resolved ctx)]
+              (is (not-any? #(= "continue" (:command %)) @sent)
+                  "the live waiting prompt is the engine saying 'opponent is deciding' — no continue may be sent")
+              (is (= :waiting-for-opponent (:status r))
+                  (str "suppressed continue should report an opponent wait so loops idle instead of spinning, got: " r)))))))))
+
+(deftest ai-runs-send-continue-chokepoint-suppresses-on-live-waiting-prompt
+  (testing "the ai-runs copy of send-continue! has the same waiting-prompt chokepoint — via handle-initiation-auto-pass with a live waiting prompt (#75)"
+    (let [sent (atom [])
+          live (mock-client-state
+                :side "corp"
+                :game-state
+                {:run {:phase "initiation" :position 1 :server [:hq] :no-action "runner"}
+                 :corp {:prompt-state {:msg "Waiting for Runner to make a decision"
+                                       :prompt-type "waiting" :choices [] :selectable []}}
+                 :runner {:prompt-state nil}
+                 :log []})]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (with-mock-state live
+          (with-out-str
+            (let [r (ai/continue-run!)]
+              (is (not-any? #(= "continue" (:command %)) @sent)
+                  "no continue may be sent while our own live prompt is a waiting prompt")
+              (is (not= :action-taken (:status r))
+                  (str "must not claim an action was taken, got: " r)))))))))


### PR DESCRIPTION
Fixes #75 (client side). Engine-side amplification filed separately as #77.

## Root cause (from replay 92c28ed5, frames 239–275)
At movement/pos-0 with the Runner passed, the Corp's `continue` triggers the `:approach-server` checkpoint and the engine **blocks** on the Runner's Manegarm Skunkworks "Choose one" — run stays `phase=movement`, `:no-action "runner"`, Corp prompt goes `"waiting"`. The engine has no in-flight guard, so each additional Corp continue re-fired approach-server and minted a **fresh duplicate prompt** (frames 255–259: five stacked prompts, five "approaches Server 1"). The Runner paid the top one, stole Orbital Superiority, then faced four stale duplicates whose "End the run" resolution is a visible no-op post-success — read it as a wedge and quit **one answer short of draining the stack**.

## Fix — Corp side (the spam)
- `--fire-if-asked`'s empty-window auto-continue now requires a `"run"`-type prompt (a `"waiting"` prompt also has empty choices/selectables and matched — this branch was the burst source; the seat was running `monitor-run --persistent --fire-if-asked`, the documented pattern)
- `handle-corp-all-subs-resolved` passes at most once per window (its condition stays true after passing; it re-continued every iteration until the stuck-detector tripped — the earlier frames-248-252 burst)
- both `send-continue!` helpers gain a chokepoint: never send while the **live** state shows our own prompt is a waiting prompt; report `:waiting-for-opponent` so loops idle instead of spinning

## Fix — Runner side (the misread)
`press-choice!` no longer prints "✅ Chose:" before sending nor returns `:success` unconditionally:
- prompt unchanged after the choice → `:waiting-input` + honest warning (choice may have been rejected/swallowed)
- choice resolved but an **identical duplicate** prompt surfaced (same msg+card, new eid) → explicit "answer it again to drain the stack" message + `:duplicate-prompt` flag

## Verification
- `make test`: 472 tests / 1126 assertions green (9 new tests, all red before the fix)
- Live (staged board, rezzed Manegarm remote): normal run produces exactly **one** approach event and the prompt clears on the first answer; corp `--persistent --fire-if-asked` monitor rides through without spamming
- Live engine-bug repro via `continue-run --force` ×3: three approach events + three stacked prompts (confirms #77); each Runner answer resolved with the duplicate warning and the stack drained to clean run-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)