### PR TITLE
fix(#76): stop a dropped socket from destroying a started game

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,16 @@ make watch-runner       # Stream runner game events (for Monitor)
 4. Test with `./dev/send_command`
 5. Repeat
 
-**Games may timeout** - server purges inactive games. If resume fails with "no active games", use `make reset`.
+**Games may timeout** - the server reaps lobbies idle longer than `:time-inactive`
+(`resources/dev.edn`, currently 2 days). If resume fails with "no active games", use `make reset`.
+
+**Note (#76):** "no active games" after a bounce used to be blamed on that purge. It wasn't.
+A websocket close unseats the player, and the *last* player leaving made the server delete the
+lobby outright - so `make resume`, which stops both clients first, destroyed the very game it
+was resuming (and then reported success anyway). `:keep-lobbies-on-disconnect?` in
+`resources/dev.edn` now keeps a *started* lobby alive across a socket drop; the seat stays
+seated, so resync works. Explicit leaves (concede, `save-replay.sh`) still close the lobby,
+so stats/replays still flush.
 
 ## Key Commands
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ check-full:
 # Run unit tests
 test:
 	@echo "Running unit tests..."
-	lein test ai-actions-test ai-actions-sad-path-test ai-basic-actions-test ai-heuristic-corp-test ai-heuristic-runner-test ai-runs-test ai-run-corp-decisions-test ai-stall-test ai-websocket-diff-test ai-websocket-error-recovery-test ai-display-test ai-state-test ai-prompts-test ai-pure-functions-test ai-turn-validation-test ai-wait-test continue-run-rez-test run-window-selfadvance-test game.ai-upgrade-rez-timing-test
+	lein test ai-actions-test ai-actions-sad-path-test ai-basic-actions-test ai-heuristic-corp-test ai-heuristic-runner-test ai-runs-test ai-run-corp-decisions-test ai-stall-test ai-websocket-diff-test ai-websocket-error-recovery-test ai-display-test ai-state-test ai-prompts-test ai-pure-functions-test ai-turn-validation-test ai-wait-test continue-run-rez-test run-window-selfadvance-test game.ai-upgrade-rez-timing-test web.lobby-disconnect-test
 
 # Run shell-level tests (fast, no REPL/server needed) — e.g. send_command output filters
 test-shell:

--- a/dev/ai-bounce.sh
+++ b/dev/ai-bounce.sh
@@ -84,18 +84,27 @@ if [ -n "$GAME_ID" ]; then
   echo "🎮 Reconnecting to game: $GAME_ID"
   echo ""
 
-  # Resync both clients
+  # Resync both clients. Do NOT swallow failures (#76): these used to be `|| true`,
+  # so a resync that timed out still printed "✅ Reconnected to game!".
+  RESYNC_FAILED=false
+
   echo "   Resyncing Runner..."
-  TIMEOUT=10 "$SCRIPT_DIR/send_command" runner resync "$GAME_ID" || true
+  TIMEOUT=10 "$SCRIPT_DIR/send_command" runner resync "$GAME_ID" || RESYNC_FAILED=true
 
   sleep 2
 
   echo "   Resyncing Corp..."
-  TIMEOUT=10 "$SCRIPT_DIR/send_command" corp resync "$GAME_ID" || true
+  TIMEOUT=10 "$SCRIPT_DIR/send_command" corp resync "$GAME_ID" || RESYNC_FAILED=true
 
   sleep 2
 
   echo ""
+  if [ "$RESYNC_FAILED" = true ]; then
+    echo "❌ Resync failed - the clients are NOT back in the game."
+    echo "   Check the game still exists: ./dev/send_command runner list-game-ids"
+    echo "   If it is gone, start fresh: ./dev/reset.sh"
+    exit 1
+  fi
   echo "✅ Reconnected to game!"
   echo ""
   echo "Check status:"

--- a/dev/resume.sh
+++ b/dev/resume.sh
@@ -182,28 +182,30 @@ echo "🔍 Verifying reconnection..." | tee -a "$LOG_FILE"
 RUNNER_CONNECTED=false
 CORP_CONNECTED=false
 
-# Check runner
-RUNNER_GID=$(TIMEOUT=5 "$SCRIPT_DIR/send_command" runner eval \
-    '(str (:gameid @ai-state/client-state))' 2>/dev/null \
-    | tail -1 | tr -d '"' | tr -d '\n' || echo "")
+# Verify each seat by asking for the gameid the SERVER sent us in :game-state, not the
+# :gameid the client set locally before any round-trip (#76: the old check compared that
+# local value and so passed even when the resync timed out and no state ever arrived).
+verify_seat() {
+    local side="$1"
+    local gid
+    gid=$(TIMEOUT=5 "$SCRIPT_DIR/send_command" "$side" eval \
+        '(str (:gameid (:game-state @ai-state/client-state)))' 2>/dev/null \
+        | tail -1 | tr -d '"' | tr -d '\n' || echo "")
+    [ "$gid" = "$GAME_ID" ]
+}
 
-if [ "$RUNNER_GID" = "$GAME_ID" ]; then
-    echo "✅ Runner reconnected" | tee -a "$LOG_FILE"
+if verify_seat runner; then
+    echo "✅ Runner reconnected (server state received)" | tee -a "$LOG_FILE"
     RUNNER_CONNECTED=true
 else
-    echo "⚠️  Runner connection uncertain (gameid: $RUNNER_GID)" | tee -a "$LOG_FILE"
+    echo "❌ Runner did NOT resync - no game state from server" | tee -a "$LOG_FILE"
 fi
 
-# Check corp
-CORP_GID=$(TIMEOUT=5 "$SCRIPT_DIR/send_command" corp eval \
-    '(str (:gameid @ai-state/client-state))' 2>/dev/null \
-    | tail -1 | tr -d '"' | tr -d '\n' || echo "")
-
-if [ "$CORP_GID" = "$GAME_ID" ]; then
-    echo "✅ Corp reconnected" | tee -a "$LOG_FILE"
+if verify_seat corp; then
+    echo "✅ Corp reconnected (server state received)" | tee -a "$LOG_FILE"
     CORP_CONNECTED=true
 else
-    echo "⚠️  Corp connection uncertain (gameid: $CORP_GID)" | tee -a "$LOG_FILE"
+    echo "❌ Corp did NOT resync - no game state from server" | tee -a "$LOG_FILE"
 fi
 
 echo "" | tee -a "$LOG_FILE"

--- a/resources/dev.edn
+++ b/resources/dev.edn
@@ -16,7 +16,12 @@
                      :max-age 5184000}}
  :web/lobby {:interval 1000
              :mongo #ig/ref :mongodb/connection
-             :time-inactive 172800}  ; 2 days (was 600s/10min)
+             :time-inactive 172800  ; 2 days (was 600s/10min)
+             ;; #76: don't let a dropped socket destroy a started game. Without this,
+             ;; bouncing both AI clients (make resume) deletes the lobby outright and
+             ;; resync can never recover it. Localhost dev only - upstream/prod default
+             ;; is false. Abandoned lobbies are still reaped by :time-inactive above.
+             :keep-lobbies-on-disconnect? true}
  :web/chat {:max-length 144
             ;; sliding window size in seconds
             :rate-window 60

--- a/src/clj/web/game.clj
+++ b/src/clj/web/game.clj
@@ -450,11 +450,17 @@
   (app-state/deregister-user! uid)
   (lobby/lobby-thread
    (let [{:keys [started state] :as lobby} (app-state/uid->lobby uid)]
-     (when (and started state)
-       ;; The game will not exist if this is the last player to leave.
-       (when-let [lobby? (lobby/leave-lobby! db user uid nil lobby)]
-         (handle-message-and-send-diffs!
-          lobby? nil nil (str (:username user) " has left the game.")))))
+     (if (lobby/retain-lobby-on-disconnect? uid lobby)
+       ;; #76: a dropped socket is not a player quitting. Keep the seat so the game
+       ;; survives both clients bouncing and the player can simply resync back in.
+       (timbre/info (str "Socket closed for " (:username user)
+                         " in started game " (:gameid lobby)
+                         " - keeping seat (keep-lobbies-on-disconnect?)"))
+       (when (and started state)
+         ;; The game will not exist if this is the last player to leave.
+         (when-let [lobby? (lobby/leave-lobby! db user uid nil lobby)]
+           (handle-message-and-send-diffs!
+            lobby? nil nil (str (:username user) " has left the game."))))))
    (lobby/broadcast-lobby-list)
    (when ?reply-fn (?reply-fn true))
    (lobby/log-delay! timestamp id)))

--- a/src/clj/web/lobby.clj
+++ b/src/clj/web/lobby.clj
@@ -84,6 +84,13 @@
             (timbre/info "all pools are tidy!"))))))
 
 (defonce lobby-pool (cp/threadpool 1 {:name "lobbies-thread"}))
+
+;; #76: a websocket close is routed into handle-leave-lobby, which dissocs the lobby
+;; once the last *player* leaves - so both seats dropping (exactly what ai-bounce.sh
+;; does) destroys a live game, and neither :game/resync nor :lobby/join can recover it.
+;; Set from :web/lobby config; defaults to false so prod/upstream behaviour is unchanged.
+;; See retain-lobby-on-disconnect? below (defined next to player?, which it needs).
+(defonce keep-started-lobbies-on-disconnect? (atom false))
 (defmacro lobby-thread [& expr] `(cp/future lobby-pool ~@expr))
 (defmacro game-thread
   "Note: if the lobby isn't actually real, or has been nulled somehow, executing on the lobby thread is safe"
@@ -424,6 +431,27 @@
   [uid lobby]
   (or (player? uid lobby)
       (spectator? uid lobby)))
+
+(defn retain-lobby-on-disconnect?
+  "True when a dropped socket should leave lobby membership untouched (#76).
+
+  Three conditions, all required:
+  - the flag is on (dev only; prod/upstream keeps the old leave-on-close behaviour)
+  - the lobby is *started* - an unstarted lobby is a waiting room, where leaving on
+    disconnect is correct
+  - the uid is a *player* - spectators are removed as usual. Retaining a spectator
+    would buy nothing (handle-leave-lobby only counts players when deciding whether
+    to keep the lobby) while leaving stale entries in :spectators forever.
+
+  Because the sente uid is the stable username, keeping a player seated means
+  `in-lobby?` still holds on reconnect, so :game/resync works immediately without a
+  rejoin dance, and the player count can never fall to zero and delete the game.
+  Explicit leaves (:lobby/leave, concede, save-replay teardown) do not come through
+  here and still close the lobby, so stats and replays continue to flush."
+  [uid lobby]
+  (boolean (and @keep-started-lobbies-on-disconnect?
+                (:started lobby)
+                (player? uid lobby))))
 
 (defn handle-set-last-update [lobbies gameid uid]
   (let [lobby (get lobbies gameid)]

--- a/src/clj/web/system.clj
+++ b/src/clj/web/system.clj
@@ -81,8 +81,11 @@
 (defmethod ig/init-key :web/auth [_ settings]
   settings)
 
-(defmethod ig/init-key :web/lobby [_ {:keys [interval mongo time-inactive]}]
+(defmethod ig/init-key :web/lobby [_ {:keys [interval mongo time-inactive keep-lobbies-on-disconnect?]}]
   (let [db (:db mongo)]
+    ;; #76: dev-only. Keeps a started lobby alive when a socket drops, so a client
+    ;; bounce can't destroy the game. clear-inactive-lobbies still reaps it later.
+    (reset! lobby/keep-started-lobbies-on-disconnect? (boolean keep-lobbies-on-disconnect?))
     [(tick #(lobby/clear-inactive-lobbies db time-inactive) interval)
      #_(tick #(angel-arena/check-for-inactivity db) interval)]))
 

--- a/test/clj/web/lobby_disconnect_test.clj
+++ b/test/clj/web/lobby_disconnect_test.clj
@@ -1,0 +1,136 @@
+(ns web.lobby-disconnect-test
+  "Regression tests for #76: a websocket close must not destroy a started game.
+
+   Reproduced live against the dev server (game 8679a498, 2026-07-16): stopping both
+   AI clients (what `make resume` / ai-bounce.sh does first) took the lobby from
+   healthy-with-both-players to LOBBY-COUNT 0. `handle-leave-lobby` dissocs the lobby
+   once the last *player* leaves, and a socket close is routed straight into it by
+   `:chsk/uidport-close`. The game is then unrecoverable: :game/resync and :lobby/join
+   both silently no-op on a nil lobby, so the seat times out forever.
+
+   The fix is a dev-only flag (`:keep-lobbies-on-disconnect?` in resources/dev.edn):
+   for a *started* lobby, a dropped socket leaves membership untouched. Because the
+   sente uid is the stable username, the player stays `in-lobby?` and a reconnect can
+   resync immediately. Explicit leaves (:lobby/leave, concede, save-replay teardown)
+   are unaffected and still close the lobby, so stats/replays still flush."
+  (:require
+   [cljc.java-time.instant :as inst]
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [web.app-state :as app-state]
+   [web.game]
+   [web.lobby :as lobby]
+   [web.ws :as ws]))
+
+(def ^:private gameid "test-game-76")
+
+(defn- started-lobby []
+  {:gameid gameid
+   :started true
+   :players [{:uid "ai-corp" :side "Corp" :user {:username "ai-corp"}}
+             {:uid "ai-runner" :side "Runner" :user {:username "ai-runner"}}]
+   :original-players [{:uid "ai-corp" :side "Corp" :user {:username "ai-corp"}}
+                      {:uid "ai-runner" :side "Runner" :user {:username "ai-runner"}}]
+   :spectators [{:uid "umpire" :user {:username "umpire"}}]})
+
+(defn- reset-flag-fixture [f]
+  (let [original @lobby/keep-started-lobbies-on-disconnect?]
+    (try (f)
+         (finally (reset! lobby/keep-started-lobbies-on-disconnect? original)))))
+
+(use-fixtures :each reset-flag-fixture)
+
+(deftest retain-lobby-on-disconnect?-honours-flag-started-and-player
+  (testing "flag off: never retain (upstream/prod behaviour is preserved)"
+    (reset! lobby/keep-started-lobbies-on-disconnect? false)
+    (is (false? (lobby/retain-lobby-on-disconnect? "ai-runner" (started-lobby)))
+        "with the flag off a disconnect must behave exactly as upstream does")
+    (is (false? (lobby/retain-lobby-on-disconnect? "ai-runner" nil))))
+
+  (testing "flag on: retain a seated player in a started lobby"
+    (reset! lobby/keep-started-lobbies-on-disconnect? true)
+    (is (true? (lobby/retain-lobby-on-disconnect? "ai-runner" (started-lobby)))
+        "a dropped socket must not unseat a player mid-game")
+    (is (false? (lobby/retain-lobby-on-disconnect? "ai-runner" (assoc (started-lobby) :started false)))
+        "an unstarted lobby is just a waiting room - normal leave semantics apply")
+    (is (false? (lobby/retain-lobby-on-disconnect? "ai-runner" nil))
+        "no lobby, nothing to retain"))
+
+  (testing "flag on: spectators are NOT retained"
+    ;; handle-leave-lobby only counts *players* when deciding to keep the lobby, so
+    ;; retaining a spectator holds nothing open and leaks a stale :spectators entry.
+    (reset! lobby/keep-started-lobbies-on-disconnect? true)
+    (is (false? (lobby/retain-lobby-on-disconnect? "umpire" (started-lobby)))
+        "a spectator dropping must leave as usual - retaining it only leaks stale entries")
+    (is (false? (lobby/retain-lobby-on-disconnect? "nobody" (started-lobby)))
+        "an unknown uid is not a player")))
+
+(deftest last-player-disconnect-destroys-started-lobby
+  (testing "documents the #76 mechanism: last player out dissocs the whole game"
+    (let [lobbies {gameid (started-lobby)}
+          after-corp (lobby/handle-leave-lobby lobbies "ai-corp" nil)
+          after-both (lobby/handle-leave-lobby after-corp "ai-runner" nil)]
+      (is (some? (get after-corp gameid))
+          "one seat dropping is survivable - the other player holds the lobby open")
+      (is (nil? (get after-both gameid))
+          "but the second disconnect destroys the game: this is what make resume does"))))
+
+(defn- close-socket!
+  "Drives the real :chsk/uidport-close handler and waits for its lobby-thread future.
+   leave-lobby! is stubbed so we can observe whether the handler decided to unseat,
+   without needing a mongo db for the close-lobby! stats flush."
+  [uid left]
+  (with-redefs [lobby/leave-lobby! (fn [_db _user uid* _reply lobby]
+                                     (swap! left conj uid*)
+                                     (swap! app-state/app-state update :lobbies
+                                            #(lobby/handle-leave-lobby % uid* nil))
+                                     (app-state/get-lobby (:gameid lobby)))
+                web.game/handle-message-and-send-diffs! (fn [& _] nil)
+                lobby/broadcast-lobby-list (fn [& _] nil)]
+    @(ws/-msg-handler {:id :chsk/uidport-close
+                       :uid uid
+                       :timestamp (inst/now)
+                       :ring-req {:system/db nil :user {:username uid}}})))
+
+(deftest uidport-close-retains-players-when-flag-on
+  (testing "the real handler keeps both seats when both sockets drop (the make resume case)"
+    (reset! lobby/keep-started-lobbies-on-disconnect? true)
+    (reset! app-state/app-state {:lobbies {gameid (started-lobby)} :lobby-updates {} :users {}})
+    (let [left (atom #{})]
+      (close-socket! "ai-corp" left)
+      (close-socket! "ai-runner" left)
+      (is (empty? @left)
+          "the handler must not route a player's socket close into leave-lobby!")
+      (let [lobby (app-state/get-lobby gameid)]
+        (is (some? lobby)
+            "the lobby must survive both sockets closing - else resync can never recover it")
+        (is (= #{"ai-corp" "ai-runner"} (set (map :uid (:players lobby))))
+            "both seats stay seated, so a reconnect can resync immediately")
+        (is (some? (lobby/in-lobby? "ai-runner" lobby))
+            "in-lobby? is the gate :game/resync checks - it must still pass after a drop")))))
+
+(deftest uidport-close-still-leaves-when-flag-off
+  (testing "flag off: the handler behaves exactly as upstream - last player out kills it"
+    (reset! lobby/keep-started-lobbies-on-disconnect? false)
+    (reset! app-state/app-state {:lobbies {gameid (assoc (started-lobby) :state (atom {}))}
+                                 :lobby-updates {} :users {}})
+    (let [left (atom #{})]
+      (close-socket! "ai-corp" left)
+      (close-socket! "ai-runner" left)
+      (is (= #{"ai-corp" "ai-runner"} @left)
+          "with the flag off every socket close must still go through leave-lobby!")
+      (is (nil? (app-state/get-lobby gameid))
+          "and the game is still destroyed - upstream behaviour is untouched"))))
+
+(deftest uidport-close-does-not-retain-spectators
+  (testing "flag on: a spectator's socket close still leaves, so :spectators cannot go stale"
+    (reset! lobby/keep-started-lobbies-on-disconnect? true)
+    (reset! app-state/app-state {:lobbies {gameid (assoc (started-lobby) :state (atom {}))}
+                                 :lobby-updates {} :users {}})
+    (let [left (atom #{})]
+      (close-socket! "umpire" left)
+      (is (= #{"umpire"} @left)
+          "a spectator is not a seat to hold - it must be removed on disconnect")
+      (let [lobby (app-state/get-lobby gameid)]
+        (is (some? lobby) "the players still hold the lobby open")
+        (is (empty? (:spectators lobby))
+            "the disconnected spectator must not linger in :spectators")))))


### PR DESCRIPTION
Fixes #76 — but not the bug the issue describes. See the [corrected diagnosis](https://github.com/Clamatius/netrunner/issues/76#issuecomment-4999795415).

## TL;DR

A websocket close unseats you, and the **last player leaving deletes the game**. So `make resume` — which stops both clients first — has been **destroying the game it resumes**, then reporting success. Both defects as originally filed (`nuke-state` destroys the session; `resync` can't rejoin) are empirically false.

## Evidence (live server, REPL inspection of `web.app-state`)

```
connect (alone, on runner)      PLAYERS: [ai-corp, ai-runner] -> [ai-corp]   # ejected, game survives
stop-ai-both.sh (both sockets)  LOBBY-COUNT: 1 -> 0                          # GAME DESTROYED
```

After that, `:game/resync` and `:lobby/join` both **silently return without replying** (guarded on a lobby/membership that no longer exists) — hence a clean 8s client timeout that reads as a server stall. `nuke-state` is a red herring: it preserves `:gameid/:side/:socket/:uid`. `resync` itself works fine (1.4s) against a healthy game.

Likely the true cause of the g2 marquee abandonment: the Corp reported *"no state change"* at the same moment the Runner's resyncs were timing out. Both seats dead at once — an ejected Runner can't explain that; a deleted lobby can. `ensure-connected!` auto-reconnects on timeout and every reconnect unseats.

## The fix

`:keep-lobbies-on-disconnect?` in `resources/dev.edn` — **dev-only, default `false`, upstream/prod behaviour byte-identical**.

For a *started* lobby, a **player's** dropped socket leaves membership untouched. Since the sente uid is the stable username, the seat stays `in-lobby?`, so reconnect + resync works with no rejoin dance, and player count can never reach zero.

- **Spectators still leave normally** — they never hold the lobby open (`handle-leave-lobby` counts players only), so retaining them would only leak stale `:spectators`. *(Caught by GPT-5.5 review; verified red against the pre-review implementation.)*
- **Explicit leaves untouched** (`:lobby/leave`, concede, `save-replay.sh` teardown) still `close-lobby!` → **stats and replays keep flushing**.
- **No leak** — `clear-inactive-lobbies` still reaps abandoned lobbies.

## Honesty pass

- `ai-bounce.sh` no longer swallows resync failures with `|| true` (it printed "✅ Reconnected to game!" unconditionally).
- `resume.sh` now verifies against the gameid **the server sent** in `:game-state`, not the one the client sets locally before any round-trip.
- CLAUDE.md's "server purges inactive games" folklore corrected — `:time-inactive` is 2 days; the purge was never involved.

## Verification

- `make verify` green (478 tests, 0 failures).
- New `web.lobby-disconnect-test` drives the **real** `:chsk/uidport-close` handler (not a simulation): flag-on / flag-off / spectator / unstarted.
- **End-to-end**: same `stop-ai-both.sh` now leaves `LOBBY-COUNT: 1` with both seats seated, and `make resume` recovered real game state (Turn 1, both seats consistent) — as far as I can tell, for the first time.

## Reviewers

Panel per REVIEW_SOP: in-context Claude + GPT-5.5 guest (Devin). Guest's MAJOR spectator finding confirmed and fixed; its accompanying claim that this "bypasses stats/replay flushing" was rejected (`leave-lobby!` calls `close-lobby!` exactly when the dissoc happens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
