### PR TITLE
fix(#77): make the movement->approach-server transition idempotent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ check-full:
 # Run unit tests
 test:
 	@echo "Running unit tests..."
-	lein test ai-actions-test ai-actions-sad-path-test ai-basic-actions-test ai-heuristic-corp-test ai-heuristic-runner-test ai-runs-test ai-run-corp-decisions-test ai-stall-test ai-websocket-diff-test ai-websocket-error-recovery-test ai-display-test ai-state-test ai-prompts-test ai-pure-functions-test ai-turn-validation-test ai-wait-test continue-run-rez-test run-window-selfadvance-test game.ai-upgrade-rez-timing-test web.lobby-disconnect-test
+	lein test ai-actions-test ai-actions-sad-path-test ai-basic-actions-test ai-heuristic-corp-test ai-heuristic-runner-test ai-runs-test ai-run-corp-decisions-test ai-stall-test ai-websocket-diff-test ai-websocket-error-recovery-test ai-display-test ai-state-test ai-prompts-test ai-pure-functions-test ai-turn-validation-test ai-wait-test continue-run-rez-test run-window-selfadvance-test game.ai-upgrade-rez-timing-test game.ai-duplicate-continue-test web.lobby-disconnect-test
 
 # Run shell-level tests (fast, no REPL/server needed) — e.g. send_command output filters
 test-shell:

--- a/src/clj/game/core/runs.clj
+++ b/src/clj/game/core/runs.clj
@@ -93,6 +93,8 @@
   [state phase]
   (swap! state assoc-in [:run :phase] phase)
   (swap! state dissoc-in [:run :next-phase])
+  ;; The movement->approach-server transition (if any) has landed; let continue through.
+  (swap! state dissoc-in [:run :approaching-server])
   (swap! state assoc-in [:run :no-action] false)
   phase)
 
@@ -509,10 +511,22 @@
 
 (defmethod continue :movement
   [state side _]
-  (if-not (get-in @state [:run :no-action])
+  (cond
+    ;; The movement->approach-server transition is already under way and is suspended
+    ;; awaiting a decision (e.g. an :approach-server upgrade prompt). approach-server
+    ;; sets no phase of its own, so without this guard the run still looks like
+    ;; {:phase :movement, :no-action <side>, :position 0} - the very state that made us
+    ;; advance - and every further continue would re-fire :approach-server, re-announce
+    ;; the approach and stack another prompt on the defender.
+    (get-in @state [:run :approaching-server])
+    nil
+
+    (not (get-in @state [:run :no-action]))
     (do (swap! state assoc-in [:run :no-action] side)
         (when (= :runner side)
           (system-msg state side "will continue the run")))
+
+    :else
     (let [eid (make-phase-eid state nil)]
       (cond (or (check-for-empty-server state)
                 (:ended (:end-run @state)))
@@ -520,7 +534,12 @@
             (pos? (get-in @state [:run :position]))
             (do (set-next-phase state :approach-ice)
                 (start-next-phase state side eid))
-            :else (approach-server state side eid)))))
+            ;; Mark the transition in-flight *synchronously*, before any awaited work,
+            ;; the way continue :approach-ice marks itself with set-next-phase. Cleared
+            ;; by set-phase when the run reaches its next phase (or discarded wholesale
+            ;; by run-cleanup if the run ends here).
+            :else (do (swap! state assoc-in [:run :approaching-server] true)
+                      (approach-server state side eid))))))
 
 (defmethod start-next-phase :success
   [state side _]
@@ -788,6 +807,10 @@
     (queue-event state :end-of-encounter {:ice (get-current-ice state)}))
   (let [marked? (is-mark? state (get-in @state [:run :server 0]))
         run (if marked? (assoc (:run @state) :marked-server true) (:run @state))
+        ;; :approaching-server is an internal in-flight marker for the movement->
+        ;; approach-server transition; it is not part of the run's public record, so
+        ;; keep it out of :last-run and the :run-ends payload.
+        run (dissoc run :approaching-server)
         run-eid (:eid run)]
     (swap! state assoc-in [:runner :register :last-run] run)
     (swap! state update-in [:runner :credit] - (get-in @state [:runner :run-credit]))

--- a/test/clj/game/ai_duplicate_continue_test.clj
+++ b/test/clj/game/ai_duplicate_continue_test.clj
@@ -1,0 +1,167 @@
+(ns game.ai-duplicate-continue-test
+  "Issue #77: duplicate Corp `continue` at movement/pos-0 re-fires :approach-server.
+
+   While the :approach-server checkpoint is blocked on a Runner decision (e.g.
+   Manegarm Skunkworks' \"Choose one\"), the run stays {:phase :movement,
+   :no-action :runner, :position 0} - which is exactly the state that made
+   `continue :movement` advance in the first place. `approach-server` sets nothing
+   synchronously (no :phase, no :next-phase, no :no-action change) and only reaches
+   `set-next-phase :success` after the prompt resolves, so every additional Corp
+   continue in that window re-dispatches and calls approach-server again: another
+   \"approaches Server 1\" log line and another duplicate prompt on the Runner's stack.
+
+   Seen live in marquee g2 (replay 92c28ed5, frames 255-259): five Corp actions, five
+   \"approaches Server 1\" lines, five distinct Manegarm prompts (eids 229824/230686/
+   231548/232410/233272). The Runner paid the top prompt, breached and stole, then
+   faced four stale duplicates whose resolution is a visible no-op post-success.
+
+   Contrast `continue :approach-ice`, which calls set-next-phase *synchronously before*
+   any awaited work - a re-entrant continue there sees the marker. approach-server is
+   the one transition that awaits without marking, which is why only this checkpoint
+   amplifies (the encounter-ice duplicate burst in the same replay was harmless)."
+  (:require [game.core :as core]
+            [game.core.diffs :as diffs]
+            [game.test-framework :refer :all]
+            [clojure.test :refer :all]))
+
+(defn- approach-log-count
+  "How many times the engine has announced approaching the remote server."
+  [state]
+  (count (re-seq #"approaches Server 1" (log-str state))))
+
+(defn- manegarm-prompt-count
+  "How many Manegarm \"Choose one\" prompts are stacked on the Runner."
+  [state]
+  (count (filter #(= "Choose one" (:msg %)) (get-in @state [:runner :prompt]))))
+
+(deftest duplicate-corp-continue-at-approach-server-is-idempotent
+  (testing "extra Corp continues while the approach-server prompt is pending are no-ops"
+    (do-game
+      (new-game {:corp {:hand ["Manegarm Skunkworks" "Ice Wall"]}})
+      (play-from-hand state :corp "Manegarm Skunkworks" "New remote")
+      (play-from-hand state :corp "Ice Wall" "Server 1")
+      (take-credits state :corp)
+      (let [mane (get-content state :remote1 0)]
+        (run-on state "Server 1")
+        (run-continue-until state :movement)
+        (is (= :movement (:phase (:run @state))))
+        (is (zero? (:position (:run @state))))
+        (rez state :corp mane)
+
+        ;; Runner passes, Corp continues -> movement transitions into approach-server,
+        ;; whose :approach-server event raises Manegarm's "Choose one" and suspends.
+        (core/continue state :runner nil)
+        (core/continue state :corp nil)
+        (is (= "Choose one" (:msg (first (get-in @state [:runner :prompt]))))
+            "Manegarm's approach ability fired and is waiting on the Runner")
+
+        (is (= 1 (approach-log-count state)) "the server was approached exactly once")
+        (is (= 1 (manegarm-prompt-count state)) "exactly one Manegarm decision is pending")
+
+        ;; The wedge: a Corp client retrying on timeout sends continue again while
+        ;; the Runner decision is still pending.
+        (dotimes [_ 4] (core/continue state :corp nil))
+
+        (is (= 1 (approach-log-count state))
+            "duplicate continues must not re-announce approaching the server")
+        (is (= 1 (manegarm-prompt-count state))
+            "duplicate continues must not mint stacked duplicate prompts")))))
+
+(deftest approach-server-still-completes-after-duplicate-continues
+  (testing "the guard must not strand the run: resolving the prompt still reaches success"
+    (do-game
+      (new-game {:corp {:hand ["Manegarm Skunkworks" "Ice Wall"]}})
+      (play-from-hand state :corp "Manegarm Skunkworks" "New remote")
+      (play-from-hand state :corp "Ice Wall" "Server 1")
+      (take-credits state :corp)
+      (let [mane (get-content state :remote1 0)]
+        (run-on state "Server 1")
+        (run-continue-until state :movement)
+        (rez state :corp mane)
+        (core/continue state :runner nil)
+        (core/continue state :corp nil)
+        (dotimes [_ 3] (core/continue state :corp nil))
+        ;; Pay the tax (Manegarm: end the run, or pay 2 clicks / 5 credits)
+        (click-prompt state :runner "Pay 5 [Credits]")
+        (is (= :success (:phase (:run @state)))
+            "the run reaches success exactly once after the Runner resolves the prompt")
+        (is (= 1 (approach-log-count state))
+            "the server was approached exactly once despite the duplicate continues")
+        (is (zero? (manegarm-prompt-count state))
+            "no stale duplicate 'Choose one' prompts survive into success (#77: the
+             Runner used to face four of them, each a visible no-op post-success)")))))
+
+(deftest duplicate-runner-continue-at-approach-server-is-idempotent
+  (testing "the guard is side-independent: Runner retries are no-ops too"
+    (do-game
+      (new-game {:corp {:hand ["Manegarm Skunkworks" "Ice Wall"]}})
+      (play-from-hand state :corp "Manegarm Skunkworks" "New remote")
+      (play-from-hand state :corp "Ice Wall" "Server 1")
+      (take-credits state :corp)
+      (let [mane (get-content state :remote1 0)]
+        (run-on state "Server 1")
+        (run-continue-until state :movement)
+        (rez state :corp mane)
+        (core/continue state :runner nil)
+        (core/continue state :corp nil)
+        (is (= 1 (manegarm-prompt-count state)))
+        (dotimes [_ 3] (core/continue state :runner nil))
+        (is (= 1 (approach-log-count state))
+            "a Runner retry must not re-announce the approach either")
+        (is (= 1 (manegarm-prompt-count state))
+            "a Runner retry must not stack prompts either")))))
+
+(deftest ending-the-run-from-the-approach-prompt-cleans-up
+  (testing "the marker must not strand the run when the approach prompt ends it"
+    (do-game
+      (new-game {:corp {:hand ["Manegarm Skunkworks" "Ice Wall"]}})
+      (play-from-hand state :corp "Manegarm Skunkworks" "New remote")
+      (play-from-hand state :corp "Ice Wall" "Server 1")
+      (take-credits state :corp)
+      (let [mane (get-content state :remote1 0)]
+        (run-on state "Server 1")
+        (run-continue-until state :movement)
+        (rez state :corp mane)
+        (core/continue state :runner nil)
+        (core/continue state :corp nil)
+        (dotimes [_ 3] (core/continue state :corp nil))
+        (click-prompt state :runner "End the run")
+        (is (nil? (:run @state)) "the run is cleaned up, not stranded")
+        (is (zero? (manegarm-prompt-count state)) "no stale prompts survive the end")
+        (is (not (contains? (get-in @state [:runner :register :last-run]) :approaching-server))
+            "the internal marker must not leak into :last-run (replay/NAN consumers)")))))
+
+(deftest approaching-server-marker-is-not-serialized-to-clients
+  (testing "the internal marker stays out of the client run summary"
+    (do-game
+      (new-game {:corp {:hand ["Manegarm Skunkworks" "Ice Wall"]}})
+      (play-from-hand state :corp "Manegarm Skunkworks" "New remote")
+      (play-from-hand state :corp "Ice Wall" "Server 1")
+      (take-credits state :corp)
+      (let [mane (get-content state :remote1 0)]
+        (run-on state "Server 1")
+        (run-continue-until state :movement)
+        (rez state :corp mane)
+        (core/continue state :runner nil)
+        (core/continue state :corp nil)
+        (is (true? (get-in @state [:run :approaching-server]))
+            "precondition: the marker is set while the approach is in flight")
+        (is (not (contains? (diffs/run-summary state) :approaching-server))
+            "the marker is engine-internal and must not reach the client")))))
+
+(deftest normal-continue-at-movement-still-advances
+  (testing "no regression: an unblocked movement continue still approaches the server"
+    (do-game
+      ;; Manegarm left UNREZZED: content keeps the server non-empty (an ice-only
+      ;; remote is an empty server and the run just ends), but nothing prompts.
+      (new-game {:corp {:hand ["Manegarm Skunkworks" "Ice Wall"]}})
+      (play-from-hand state :corp "Manegarm Skunkworks" "New remote")
+      (play-from-hand state :corp "Ice Wall" "Server 1")
+      (take-credits state :corp)
+      (run-on state "Server 1")
+      (run-continue-until state :movement)
+      (core/continue state :runner nil)
+      (core/continue state :corp nil)
+      (is (= 1 (approach-log-count state)) "the server is approached")
+      (is (= :success (:phase (:run @state)))
+          "with nothing to prompt on, approach-server runs straight through to success"))))


### PR DESCRIPTION
Fixes #77.

## The shape

`continue :movement` decides to advance and calls `approach-server`, which sets **nothing synchronously** — no `:phase`, no `:next-phase`, no `:no-action`. It queues `:approach-server` and checkpoints. When a handler prompts (Manegarm's "Choose one", `:player :runner`), that continuation **suspends** with the run still `{:phase :movement, :no-action :runner, :position 0}` — *exactly the state that made `continue` advance in the first place*. Every further continue re-dispatches and re-runs `approach-server`.

The contrast is in the same file: `continue :approach-ice` calls `set-next-phase` **synchronously before** any awaited work, so a re-entrant continue sees the marker. `approach-server` is the one transition that awaits without marking — which is why only this checkpoint amplifies, and why the encounter-ice duplicate burst in the same replay was harmless.

## Fix

Mark `[:run :approaching-server]` synchronously before calling `approach-server`; no-op `continue :movement` while set; clear it in `set-phase` (which already clears `:no-action`/`:next-phase`). Deliberately **not** reusing `:next-phase` as the marker — `approach-server`'s own `:cancel-fn` and branch logic read it as "phase changed" and would misroute the transition.

Can it get stuck? No: `approach-server` has exactly one caller, and every exit clears it — `start-next-phase`→`set-phase`, redirect-with-phase→`set-phase`, `handle-end-run`→`run-cleanup` (drops `:run` wholesale). Also dissoc'd in `run-cleanup` so the marker never reaches `:last-run` / `:run-ends`.

## Not just a Corp bug

The issue describes Corp spam, but `continue :movement` **never compares `side` against `:no-action`** (only `:encounter-ice` does) — so a **Runner** retry amplifies identically. Verified red at **1 vs 4**. This matters: the client-side #75 guards only suppress *Corp* continues while holding a waiting prompt, so this was still reachable from the other seat.

## Verification

- Repro pins the live g2 evidence (replay `92c28ed5`, frames 255–259): **red at 5 approaches / 5 stacked prompts → green at 1/1** — same numbers as the eids in the issue.
- Tests: both sides, end-run-from-the-prompt cleanup, `:last-run` hygiene, `run-summary` serialization, no-regression case. **Each verified red against the unguarded engine** (not just green against the fixed one).
- **Full engine suite: 3746 tests, 123,900 assertions, 0 failures.** `make verify` green. New ns registered in the Makefile's hand-maintained list.

## Review

Panel per REVIEW_SOP (Claude + GPT-5.5 guest).
- **Rejected** — *"`start-next-phase` bypasses the guard"*: during the window `:next-phase` is nil, so it dispatches to `:default`, which only logs. Verified. (Client exposure of an internal primitive is a real pre-existing design hazard, but not introduced here — worth a separate issue.)
- **Rejected** — *"marker stuck on redirect"*: the guest walked this back itself; every exit clears the marker, and redirect-without-phase still lands on `:success`→`set-phase`.
- **Confirmed & fixed** — marker leaking into `:last-run`/`:run-ends`; missing Runner-side and end-run tests.

## Upstream

Minimized and engine-idiomatic, so it can be filed at mtgred/netrunner with the repro. Per the issue's note, human clients probably can't emit duplicate continues fast enough to hit this — which is likely why it's unreported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
