### PR TITLE
fix(#31): stop handle-events latching on an already-reported event

### DIFF
--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -256,6 +256,8 @@
 
 (declare continue-run!)
 (declare auto-continue-loop!)
+(declare reset-window-grace!)
+(declare reset-reported-events!)
 
 ;; ============================================================================
 ;; Run Initiation
@@ -304,6 +306,14 @@
 
       ;; Reset and set strategy for this run
       (reset-strategy!)
+      ;; Per-run scratch state. reset-window-grace! had NO production caller at
+      ;; all — window-first-seen persisted across runs, so a repeat window
+      ;; ([phase position no-action] collides readily) could look instantly
+      ;; stale and self-advance without ever granting the grace period.
+      ;; NB reported-events is deliberately NOT reset here: it is game-scoped,
+      ;; and a per-run reset would re-report a previous run's tail event if it
+      ;; were still inside the newest-3 window (a duplicate stale pause).
+      (reset-window-grace!)
       (set-strategy! (dissoc flags :no-continue))  ; Store all except :no-continue
 
       ;; Provide feedback if we normalized the input
@@ -446,7 +456,16 @@
    (#54), not bare substrings, so card names / flavor / derez / sub-breaking
    don't misclassify. nil / missing `:text` entries are tolerated."
   [log]
-  (let [recent-log (take 3 (reverse log))]
+  (let [n (count log)
+        ;; Tag each entry with its INDEX in the append-only log. This is the
+        ;; event's real identity: `handle-events` dedupes on it, and text +
+        ;; timestamp alone cannot distinguish a genuine repeat (same card used
+        ;; twice) from a re-read of the same entry. Index is stable across a
+        ;; resync (the server log is authoritative), and if the log were ever
+        ;; truncated the shifted key fails toward re-reporting — i.e. toward
+        ;; pausing, never toward going blind. (Guest review of the #31 fix.)
+        recent-log (map-indexed (fn [i e] (assoc e ::log-index (- n 1 i)))
+                                (take 3 (reverse log)))]
     {:rez-event (get-rez-event recent-log)
      ;; ability + fired un-guarded: an ability's "uses X to prevent ..." effect
      ;; and a fired sub's embedded label ("... cannot jack out ...") legitimately
@@ -1141,42 +1160,86 @@
          :wake-reason :waiting-for-opponent
          :message reason}))))
 
+(defonce ^:private reported-events
+  ;; {:gameid <the game these belong to> :events #{event-key ...}}
+  ;; Log entries we have ALREADY paused the seat on. See handle-events for why
+  ;; this must exist.
+  ;;
+  ;; Scoped to the GAME, not the run. Event identity is the log INDEX, and a new
+  ;; game restarts the log at 0 — so entries from a previous game would collide
+  ;; with the new game's first entries and silently suppress them. Per-RUN reset
+  ;; would be wrong in the other direction: a seat re-issues `monitor-run`
+  ;; repeatedly within one run, and clearing on each re-issue would re-report the
+  ;; same event every time — the #31 latch again, one grain coarser. Keying on
+  ;; gameid is self-healing across new game, resync and reconnect alike, with no
+  ;; reset call to forget. (Guest review of the #31 fix.)
+  (atom {:gameid nil :events #{}}))
+
+(defn reset-reported-events!
+  "Forget which events we have reported."
+  []
+  (reset! reported-events {:gameid nil :events #{}}))
+
+(defn- reported-set
+  "The reported-event keys for the CURRENT game, dropping another game's."
+  []
+  (let [gameid (:gameid @state/client-state)
+        {:keys [events] :as cur} @reported-events]
+    (if (= gameid (:gameid cur))
+      events
+      (:events (reset! reported-events {:gameid gameid :events #{}})))))
+
+(defn- event-key
+  "Identity of a log entry for dedupe purposes. Index first (see
+   extract-run-events); timestamp and text keep it stable if an entry is ever
+   offered without an index (hand-built contexts, tests)."
+  [entry]
+  [(::log-index entry) (:timestamp entry) (:text entry)])
+
+(defn- unreported?
+  "True if `entry` exists and we have not already paused the seat on it."
+  [entry]
+  (boolean (and entry (not (contains? (reported-set) (event-key entry))))))
+
 (defn handle-events
   "Priority 4: Pause for important events (rez, subs, abilities, damage).
    Order is most-specific-first: a firing subroutine and its own 'uses <ice>
    to ...' effect line can co-occur in the same window, so :subs-fired is
    checked before :ability-used to label the headline event (#54). All four
-   statuses pause identically downstream (run-notable-event?), so the order
-   only affects the human-readable label, never behaviour."
+   statuses pause identically downstream (run-notable-event?), so within a
+   single call the order only affects the human-readable label, never
+   behaviour. ACROSS calls it now also affects how many pauses one physical
+   exchange produces: the old cond suppressed a co-occurring lower-priority
+   entry forever, whereas per-entry dedupe surfaces each DISTINCT co-window
+   entry on successive calls (a fired-sub line, then its companion 'uses <ice>
+   to ...' line). That direction is safe — more pauses, never fewer — but a
+   hand-driven seat will occasionally see two pauses for one exchange. A
+   single entry matching several categories still reports once, since the
+   dedupe key is the entry.
+
+   Reports each event EXACTLY ONCE (#31, game 4a6aef71). `extract-run-events`
+   is a pure function of the newest 3 log entries, so without a memory of what
+   has already been reported this handler LATCHES: it sits ahead of every pass
+   handler in the chain, so pausing here stops the run advancing, a stalled run
+   stops the log moving, and an unchanged log re-produces the same event on the
+   next call — forever. Three live `continue --single` calls each re-printed the
+   same 7-minute-old Overclock line (which by then was not even the newest
+   entry) while :no-action sat at false. The pause is a feature; the latch is
+   the bug. Dedupe is per-ENTRY, not a global mute, so a genuinely new rez still
+   stops the Runner."
   [{:keys [rez-event ability-event fired-event tag-damage-event]}]
-  (cond
-    rez-event
-    (do
-      (println "⚠️  Run paused - ICE rezzed!")
-      (println (format "   %s" (:text rez-event)))
-      (println "   → Use 'continue-run' again to proceed")
-      {:status :ice-rezzed :wake-reason :ice-rezzed :event rez-event})
-
-    fired-event
-    (do
-      (println "⚠️  Run paused - subroutines fired!")
-      (println (format "   %s" (:text fired-event)))
-      (println "   → Use 'continue-run' again to proceed")
-      {:status :subs-fired :wake-reason :subs-fired :event fired-event})
-
-    ability-event
-    (do
-      (println "⚠️  Run paused - ability triggered!")
-      (println (format "   %s" (:text ability-event)))
-      (println "   → Use 'continue-run' again to proceed")
-      {:status :ability-used :wake-reason :ability-used :event ability-event})
-
-    tag-damage-event
-    (do
-      (println "⚠️  Run paused - tag or damage!")
-      (println (format "   %s" (:text tag-damage-event)))
-      (println "   → Use 'continue-run' again to proceed")
-      {:status :tag-or-damage :wake-reason :tag-or-damage :event tag-damage-event})))
+  (when-let [[status headline event]
+             (cond
+               (unreported? rez-event)        [:ice-rezzed   "ICE rezzed!"        rez-event]
+               (unreported? fired-event)      [:subs-fired   "subroutines fired!" fired-event]
+               (unreported? ability-event)    [:ability-used "ability triggered!" ability-event]
+               (unreported? tag-damage-event) [:tag-or-damage "tag or damage!"    tag-damage-event])]
+    (reported-set)  ; ensure the set belongs to the current game before adding
+    (swap! reported-events update :events conj (event-key event))
+    (println (format "⚠️  Run paused - %s" headline))
+    (println (format "   %s" (:text event)))
+    (println "   → Use 'continue-run' again to proceed")
+    {:status status :wake-reason status :event event}))
 
 (defn handle-unexpected-state
   "Fallback: Unknown state - wait and retry rather than give up"
@@ -1557,7 +1620,14 @@
                 ;; run-event run (Jailbreak/Conduit) that enters via continue-run!
                 ;; would otherwise inherit stale [position ice] keys and skip a
                 ;; needed pass-continue.
-                (runner-handlers/reset-state!))
+                (runner-handlers/reset-state!)
+                ;; Same third-path hazard for the self-advance grace timer: a
+                ;; stale [phase position no-action] key (these collide readily)
+                ;; would make a card-initiated run's first window look instantly
+                ;; abandoned and self-advance with ZERO grace, skipping the
+                ;; fog-of-war paid-ability window the grace exists to protect.
+                ;; Run END is the boundary that covers every entry path.
+                (reset-window-grace!))
               (assoc result
                      :iterations (inc iteration)
                      :elapsed-ms (- (System/currentTimeMillis) start-time)))
@@ -1772,6 +1842,11 @@
   "Own one active run: (re)apply the pre-committed strategy, then loop."
   [flags]
   (reset-strategy!)
+  ;; Per-run scratch state, same as run! — the CORP seat never calls run!, it
+  ;; only ever enters a run through here. NB reported-events is deliberately NOT
+  ;; reset here: it is game-scoped, and clearing it on each monitor-run re-issue
+  ;; would re-report the same event every time. (Guest review of #31.)
+  (reset-window-grace!)
   (let [strategy-flags (dissoc flags :since :persistent :return-on-signal)]
     (when (seq strategy-flags)
       (set-strategy! strategy-flags)

--- a/dev/test/continue_run_rez_test.clj
+++ b/dev/test/continue_run_rez_test.clj
@@ -15,6 +15,12 @@
             [ai-run-corp-handlers :as corp-handlers]
             [ai-websocket-client-v2 :as ws]))
 
+;; `handle-events` keeps a per-game memory of already-reported log entries
+;; (#31), so it is no longer a pure function. Without this fixture the
+;; event-labeling tests below pass on a fresh JVM and FAIL on a second run in
+;; the same REPL, because their entries are already marked as reported.
+(use-fixtures :each (fn [t] (runs/reset-reported-events!) (t)))
+
 ;; =============================================================================
 ;; Test: Waiting for Opponent's Rez Decision
 ;; =============================================================================

--- a/dev/test/run_window_selfadvance_test.clj
+++ b/dev/test/run_window_selfadvance_test.clj
@@ -32,8 +32,8 @@
 
 (defn- runner-state
   "Runner-side client state at a run window."
-  [& {:keys [phase position no-action ices content prompt]
-      :or {phase "approach-ice" position 1 ices [] content []}}]
+  [& {:keys [phase position no-action ices content prompt log]
+      :or {phase "approach-ice" position 1 ices [] content [] log []}}]
   (mock-client-state
    :side "runner"
    :game-state
@@ -41,6 +41,7 @@
           :position position
           :no-action no-action
           :server [:remote1]}
+    :log log
     :runner {:prompt-state prompt}
     :corp {:prompt-state nil
            :servers {:remote1 {:ices ices :content content}}}}))
@@ -448,3 +449,178 @@
           "Should point at the patience/liveness signal instead")
       (is (re-find #"(?i)smell" text)
           "Should name jack-out as the smell it is"))))
+
+;; =============================================================================
+;; D. THE EVENT-PAUSE LATCH — the real #31 (game 4a6aef71, 2026-07-18)
+;; =============================================================================
+;;
+;; The both-pass handlers above (initiation auto-pass, self-advance) are correct
+;; and were never the problem: they are simply NEVER REACHED. `handle-events`
+;; sits ahead of them in the chain and is a pure function of the newest 3 log
+;; entries, with no memory of what it has already reported. So when the run
+;; stops advancing, the log stops moving, and the same event re-fires forever:
+;;
+;;   pause on event -> nothing passes -> log frozen -> same newest-3 -> pause ...
+;;
+;; A latch that manufactures the very condition that sustains it. The printed
+;; advice ("use continue-run again to proceed") is precisely what cannot work.
+;;
+;; Why the suite stayed green through two #31 fixes: every test above builds a
+;; state with NO :log, so extract-run-events finds nothing and handle-events
+;; never fires. The tests omitted the one field the bug lives in.
+
+(def ^:private overclock-entry
+  {:user "__system__"
+   :text "ai-runner uses Overclock to make a run on R&D."
+   :timestamp "2026-07-18T04:13:59.335700Z"})
+
+(def ^:private wedged-log
+  ;; Verbatim newest-3 from the wedged marquee game. Note the latched event is
+  ;; NOT even the newest line — the run had visibly moved past it.
+  [{:user "__system__" :text "ai-runner spends [Click] and pays 1 [Credits] to play Overclock."
+    :timestamp "2026-07-18T04:13:52.187223Z"}
+   overclock-entry
+   {:user "__system__" :text "ai-runner approaches Brân 1.0 protecting R&D at position 1."
+    :timestamp "2026-07-18T04:20:30.132582Z"}])
+
+(defn- wedged-state []
+  (runner-state :phase "approach-ice" :position 2 :no-action false
+                :ices [{:cid 1 :title "Brân 1.0" :rezzed true}]
+                :prompt {:prompt-type "run" :msg "You are running on R&D" :selectable []}
+                :log wedged-log))
+
+(deftest event-pause-reports-each-event-exactly-once
+  (testing "An event pauses the seat ONCE. Offered the same entry again, the
+            handler must yield so the pass handlers behind it get their turn."
+    (runs/reset-reported-events!)
+    (let [ctx {:ability-event overclock-entry}]
+      (is (= :ability-used (:status (runs/handle-events ctx)))
+          "First sight: pause and tell the seat")
+      (is (nil? (runs/handle-events ctx))
+          "Second sight: same entry, already reported -> must NOT re-latch"))))
+
+(deftest a-genuinely-new-event-still-pauses
+  (testing "SAFETY: dedupe must be per-entry, not a global mute. A real rez
+            arriving later must still stop the Runner."
+    (runs/reset-reported-events!)
+    (is (= :ability-used (:status (runs/handle-events {:ability-event overclock-entry}))))
+    (let [rez {:user "__system__" :text "ai-corp rezzes Brân 1.0 protecting R&D."
+               :timestamp "2026-07-18T04:21:00.000000Z"}]
+      (is (= :ice-rezzed (:status (runs/handle-events {:rez-event rez})))
+          "A new entry is a new event and must still pause"))))
+
+(deftest reset-reported-events-rearms-the-pause
+  (testing "A fresh run starts with a clean slate (run! resets)."
+    (runs/reset-reported-events!)
+    (is (= :ability-used (:status (runs/handle-events {:ability-event overclock-entry}))))
+    (is (nil? (runs/handle-events {:ability-event overclock-entry})))
+    (runs/reset-reported-events!)
+    (is (= :ability-used (:status (runs/handle-events {:ability-event overclock-entry})))
+        "After reset the event is reportable again")))
+
+(deftest continue-run-passes-the-window-after-reporting-the-event
+  (testing "THE MARQUEE REPRO (game 4a6aef71): Runner holds priority at a
+            both-pass approach-ice window, ICE already rezzed, decision-free run
+            prompt — i.e. can-auto-continue? is TRUE. Observed live: three
+            consecutive `continue --single` calls each re-printed the same
+            7-minute-old Overclock line and no-action stayed false forever.
+            After the fix the event is reported once, then the window is PASSED."
+    (let [sent (atom [])]
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (runs/reset-reported-events!)
+        (with-mock-state (wedged-state)
+          (let [first-call (runs/continue-run!)]
+            (is (= :ability-used (:status first-call))
+                "First call may pause to report the event — that is the feature")
+            (is (empty? @sent) "Reporting an event sends nothing")
+            (let [second-call (runs/continue-run!)]
+              (is (= :action-taken (:status second-call))
+                  "Second call MUST pass the window instead of re-latching (#31)")
+              (is (= 1 (count @sent)) "Exactly one continue")
+              (is (= "continue" (:command (first @sent)))))))))))
+
+(deftest a-decision-arriving-after-an-event-is-reported-still-blocks-the-pass
+  (testing "SAFETY, in the order that can actually bite. handle-real-decision
+            sits AHEAD of handle-events (chain ~1399/1400), so while I hold a
+            decision the event is never even reached — asserting that proves
+            nothing. The dangerous sequence is the reverse: an ICE rezzes at a
+            window where I hold NOTHING (event reported, entry now deduped),
+            and only THEN does the break decision appear. On that second call
+            handle-events is silent, so nothing stops fall-through to
+            handle-auto-continue except the decision itself."
+    (let [sent (atom [])
+          rez-log [{:text "ai-corp rezzes Bran 1.0 protecting R&D." :timestamp "T1"}]
+          break-prompt {:prompt-type "select" :msg "Break subroutine?"
+                        :choices [{:value "Yes"} {:value "No"}]}]
+      (runs/reset-reported-events!)
+      (with-redefs [ws/send-message! (fn [_evt data] (swap! sent conj data) true)]
+        (with-mock-state
+          (runner-state :phase "encounter-ice" :position 1 :no-action false
+                        :ices [{:cid 1 :title "Bran 1.0" :rezzed true}]
+                        :prompt nil :log rez-log)
+          ;; 1. Rez lands while I hold nothing -> reported, entry now deduped.
+          (is (= :ice-rezzed (:status (runs/continue-run!)))
+              "The rez must stop me the first time")
+          (is (nil? (runs/handle-events (runs/extract-run-events rez-log)))
+              "…and is now deduped, so it can no longer block anything")
+          ;; 2. NOW the break decision appears on the same (deduped) log.
+          (swap! state/client-state assoc-in
+                 [:game-state :runner :prompt-state] break-prompt)
+          (let [second-call (runs/continue-run!)]
+            (is (not= :action-taken (:status second-call))
+                "My decision must block the pass even with the event spent")
+            (is (empty? @sent)
+                "and no continue may be sent while I hold a real decision")))))))
+
+
+;; --- Event identity: the two failure modes the guest review flagged ----------
+
+(deftest the-same-text-twice-is-two-events
+  (testing "IDENTITY: a repeated action (same card, same engine wording) must
+            pause BOTH times. Dedupe is per log ENTRY, not per message text —
+            otherwise the client goes blind to a genuine second occurrence."
+    (runs/reset-reported-events!)
+    (let [line "ai-corp rezzes Brân 1.0 protecting R&D."
+          log-after-first  [{:text "x"} {:text line :timestamp "T1"}]
+          log-after-second [{:text "x"} {:text line :timestamp "T1"}
+                            {:text "y"} {:text line :timestamp "T1"}]]
+      ;; Identical text AND identical timestamp — the worst case for a
+      ;; [timestamp text] key. Distinct log positions make them distinct events.
+      (is (= :ice-rezzed (:status (runs/handle-events (runs/extract-run-events log-after-first)))))
+      (is (nil? (runs/handle-events (runs/extract-run-events log-after-first)))
+          "Same entry re-read -> no re-latch")
+      (is (= :ice-rezzed (:status (runs/handle-events (runs/extract-run-events log-after-second))))
+          "A SECOND occurrence is a new event and must pause again"))))
+
+(deftest entries-without-timestamps-still-dedupe-and-still-distinguish
+  (testing "IDENTITY: the engine always stamps log entries (say.clj defaults
+            :timestamp), but the key must not depend on that to stay correct."
+    (runs/reset-reported-events!)
+    (let [line "ai-runner uses Overclock to make a run on R&D."
+          log1 [{:text line}]
+          log2 [{:text line} {:text "z"} {:text line}]]
+      (is (= :ability-used (:status (runs/handle-events (runs/extract-run-events log1)))))
+      (is (nil? (runs/handle-events (runs/extract-run-events log1)))
+          "No timestamp -> still deduped, no latch")
+      (is (= :ability-used (:status (runs/handle-events (runs/extract-run-events log2))))
+          "No timestamp -> distinct occurrences still distinguished"))))
+
+(deftest reported-events-are-scoped-to-the-game-not-the-run
+  (testing "A new game restarts the log at index 0, so a previous game's keys
+            would collide with the new game's first entries and silently
+            suppress them. Scoping to gameid is self-healing. Conversely the set
+            must SURVIVE within a game: a seat re-issues monitor-run repeatedly
+            during one run, and forgetting on each re-issue would re-report the
+            same event every time — the #31 latch, one grain coarser.
+            (Guest review of #31.)"
+    (runs/reset-reported-events!)
+    (let [log [{:text "ai-corp rezzes Bran 1.0 protecting R&D." :timestamp "T1"}]]
+      (with-mock-state
+        (assoc (mock-client-state :side "corp" :game-state {:log log}) :gameid "game-A")
+        (is (= :ice-rezzed (:status (runs/handle-events (runs/extract-run-events log)))))
+        (is (nil? (runs/handle-events (runs/extract-run-events log)))
+            "WITHIN a game the report must stick across re-issues"))
+      (with-mock-state
+        (assoc (mock-client-state :side "corp" :game-state {:log log}) :gameid "game-B")
+        (is (= :ice-rezzed (:status (runs/handle-events (runs/extract-run-events log))))
+            "A DIFFERENT game must start from a clean slate")))))


### PR DESCRIPTION
## What #31 actually is

Not a both-pass priority bug. The initiation auto-pass (#62) and the self-advance handler (#31 §1) are both **correct** — they are simply **never reached**.

`handle-events` sits ahead of every pass handler in the chain and is a pure function of the newest 3 log entries, with no memory of what it already reported. So it latches:

```
pause on event -> nothing passes -> run stalls -> log frozen
               -> same newest-3 -> same pause -> ...
```

A latch that manufactures the very condition that sustains it. The advice it prints — "use continue-run again to proceed" — is precisely what cannot work.

## Live evidence (marquee game 4a6aef71)

At an approach-ice window where `can-auto-continue?` was **TRUE** (Brân 1.0 already rezzed, decision-free `run` prompt, Runner holding priority), three consecutive `continue --single` calls each re-printed the same **7-minute-old** Overclock line — which was not even the newest log entry — while `:no-action` sat at `false`. Only direct nREPL surgery on the engine could advance it. That surgery is what made this look like an engine bug in two previous investigations.

## Fix

Report each event exactly once. Identity is the entry's **index in the append-only log**, so a genuine repeat (same card, same wording, even the same timestamp) is still a new event and still pauses the seat. The dedupe is a per-entry memory, never a mute. The pause is the feature; the latch was the bug.

The set is scoped to the **game**. Per-run reset is wrong in both directions: a new game restarts the log at index 0 (old keys would suppress the new game's first entries), while a seat re-issues `monitor-run` many times within one run (clearing on re-issue would re-report the same event every time — the latch again, one grain coarser).

Also: `reset-window-grace!` had **no production caller at all**, so `window-first-seen` persisted across runs and a repeat window could look instantly stale and self-advance without ever granting the grace period. Now reset at both run-entry points.

## Why the suite stayed green through two prior #31 fixes

Every existing test builds a state with **no `:log`**, so `extract-run-events` finds nothing and `handle-events` never fires. The tests omitted the one field the bug lives in. The new cases carry the verbatim log from the wedged game.

## Verification

- Red→green: with dedupe disabled, 5 assertions fail including the marquee repro (`:ability-used` instead of `:action-taken`, zero continues sent) — exactly the live symptom.
- **Live**: same wedged window — 3 latched calls before; after, the event is reported once, the window passes (`:no-action` becomes `"runner"`), and the run proceeds to a real encounter decision.
- `make test`: 494 tests, 1340 assertions, 0 failures (was 486).

## Review

Guest review (gpt-5.6-terra, read-only) raised two HIGH findings, both addressed: the weak `[timestamp text]` identity (now index-based/sequence-aware) and the Corp seat's missing reset (now game-scoped, which is the correct boundary rather than the proposed per-run one). Its premise that timestamps may be absent is false here — `say.clj` defaults `:timestamp` on every message map — but the sequence-aware key it asked for is strictly better, and makes log truncation fail toward pausing rather than toward blindness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)