### PR TITLE
feat(ux): collapse the commonest send_command round-trips

### DIFF
--- a/dev/send_command
+++ b/dev/send_command
@@ -516,7 +516,14 @@ execute() {
         # Check if result is at least 2 chars (quoted)
         if [[ ${#RESULT} -ge 2 ]]; then
             LEN=$((${#RESULT}-2))
-            echo -e "${RESULT:1:$LEN}"
+            # echo -e expands \n and \t but leaves \" backslashed, so any quote
+            # a display fn printed came out as \" — which matters now that the
+            # prompt emits copy-pasteable commands like use-ability "Cleaver" 1.
+            # Unescape quotes (and literal backslashes) so printed text matches
+            # what a seat must actually type.
+            UNQUOTED="${RESULT:1:$LEN}"
+            UNQUOTED="${UNQUOTED//\\\"/\"}"
+            echo -e "$UNQUOTED"
         else
             echo "$RESULT"
         fi
@@ -547,6 +554,30 @@ show_last_log_if_enabled() {
         echo ""
         echo -e "${BLUE}--- Last Log Entry ---${NC}"
         execute "(ai-actions/show-log 1)"
+    fi
+    return $RET
+}
+
+# Post-action hook: show the last log entry (if enabled) AND the resulting
+# prompt, if there is one. Prints nothing extra when there is no prompt.
+#
+# The command log showed the commonest thing a seat does after changing state is
+# ask what the state now is (continue->prompt P=0.48, n=186; score->prompt 0.40;
+# choose-card->prompt 0.33). Answering it in the acting command's own output
+# removes that round-trip — and removes the misleading-output trap where a seat
+# that can't see its action's outcome just re-issues it.
+#
+# Set NR_NO_AUTO_PROMPT=1 to suppress (for scripts that parse output strictly).
+after_action() {
+    local RET=$?
+    show_last_log_if_enabled
+    if [[ "${NR_NO_AUTO_PROMPT:-0}" != "1" ]]; then
+        # Capture rather than print directly: with-out-str of a silent fn yields
+        # an empty string, which would still echo a stray blank line after every
+        # single action. True silence is the contract.
+        local out
+        out=$(execute "(ai-actions/show-prompt-if-any)")
+        [[ -n "${out//[[:space:]]/}" ]] && echo "$out"
     fi
     return $RET
 }
@@ -798,7 +829,7 @@ case "$COMMAND" in
         ensure_connection
         info "Starting turn..."
         execute '(ai-actions/start-turn!)'
-        show_last_log_if_enabled
+        after_action
         ;;
 
     indicate-action)
@@ -809,14 +840,30 @@ case "$COMMAND" in
 
     take-credit)
         ensure_connection
-        info "Taking credit..."
-        execute '(ai-actions/take-credit!)'
+        COUNT="${1:-1}"
+        [[ ! "$COUNT" =~ ^[0-9]+$ ]] && error "Usage: send_command take-credit [count]"
+        if [[ "$COUNT" -gt 1 ]]; then
+            info "Taking $COUNT credits..."
+            execute "(ai-actions/take-credit! $COUNT)"
+        else
+            info "Taking credit..."
+            execute '(ai-actions/take-credit!)'
+        fi
+        after_action
         ;;
 
     draw)
         ensure_connection
-        info "Drawing card..."
-        execute '(ai-actions/draw-card!)'
+        COUNT="${1:-1}"
+        [[ ! "$COUNT" =~ ^[0-9]+$ ]] && error "Usage: send_command draw [count]"
+        if [[ "$COUNT" -gt 1 ]]; then
+            info "Drawing $COUNT cards..."
+            execute "(ai-actions/draw-card! $COUNT)"
+        else
+            info "Drawing card..."
+            execute '(ai-actions/draw-card!)'
+        fi
+        after_action
         ;;
 
     end-turn)
@@ -840,6 +887,7 @@ case "$COMMAND" in
         ensure_connection
         info "Smart end-turn (auto-detects if safe)..."
         execute '(ai-actions/smart-end-turn!)'
+        after_action
         ;;
 
     # Tag and Virus actions
@@ -911,12 +959,14 @@ case "$COMMAND" in
         ensure_connection
         info "Keeping hand..."
         execute '(ai-actions/keep-hand)'
+        after_action
         ;;
 
     mulligan)
         ensure_connection
         info "Taking mulligan..."
         execute '(ai-actions/mulligan)'
+        after_action
         ;;
 
     discard)
@@ -970,7 +1020,7 @@ case "$COMMAND" in
             info "Playing card: $CARD_NAME"
             execute "(ai-actions/play-card! \"$CARD_NAME\")"
         fi
-        show_last_log_if_enabled
+        after_action
         ;;
 
     play-index)
@@ -980,7 +1030,7 @@ case "$COMMAND" in
         [[ ! "$INDEX" =~ ^[0-9]+$ ]] && error "Index must be a number"
         info "Playing card at index $INDEX"
         execute "(ai-actions/play-card! $INDEX)"
-        show_last_log_if_enabled
+        after_action
         ;;
 
     # Running
@@ -999,7 +1049,7 @@ case "$COMMAND" in
 
         info "Running on $SERVER..."
         execute "(ai-actions/run! \"$SERVER\"$FLAGS_ARGS)"
-        show_last_log_if_enabled
+        after_action
         ;;
 
     # Card abilities
@@ -1012,6 +1062,7 @@ case "$COMMAND" in
         [[ ! "$ABILITY_INDEX" =~ ^[0-9]+$ ]] && error "Ability index must be a number"
         info "Using ability $ABILITY_INDEX on $CARD_NAME..."
         execute "(ai-actions/use-ability! \"$CARD_NAME\" $ABILITY_INDEX)"
+        after_action
         ;;
 
     use-runner-ability)
@@ -1023,6 +1074,7 @@ case "$COMMAND" in
         [[ ! "$ABILITY_INDEX" =~ ^[0-9]+$ ]] && error "Ability index must be a number"
         info "Using runner-ability $ABILITY_INDEX on $CARD_NAME (e.g., bioroid click-to-break)..."
         execute "(ai-actions/use-runner-ability! \"$CARD_NAME\" $ABILITY_INDEX)"
+        after_action
         ;;
 
     # Trash installed card
@@ -1032,6 +1084,7 @@ case "$COMMAND" in
         [[ -z "$CARD_NAME" ]] && error "Usage: send_command trash <card-name>"
         info "Trashing $CARD_NAME..."
         execute "(ai-actions/trash-installed! \"$CARD_NAME\")"
+        after_action
         ;;
 
     # Rez Corp card
@@ -1041,6 +1094,7 @@ case "$COMMAND" in
         [[ -z "$CARD_NAME" ]] && error "Usage: send_command rez <card-name>"
         info "Rezzing $CARD_NAME..."
         execute "(ai-actions/rez-card! \"$CARD_NAME\")"
+        after_action
         ;;
 
     # Fire ICE subroutines
@@ -1073,20 +1127,29 @@ case "$COMMAND" in
         ensure_connection
         CARD_NAME="${1:-}"
         OVERADVANCE=false
+        COUNT=1
         shift 2>/dev/null || true
         while [[ $# -gt 0 ]]; do
             case "$1" in
                 --overadvance) OVERADVANCE=true ;;
+                [0-9]*) COUNT="$1" ;;
             esac
             shift
         done
-        [[ -z "$CARD_NAME" ]] && error "Usage: send_command advance <card-name> [--overadvance]"
-        info "Advancing $CARD_NAME..."
-        if [[ "$OVERADVANCE" == "true" ]]; then
+        [[ -z "$CARD_NAME" ]] && error "Usage: send_command advance <card-name> [count] [--overadvance]"
+        OPTS="{}"
+        [[ "$OVERADVANCE" == "true" ]] && OPTS="{:overadvance true}"
+        if [[ "$COUNT" -gt 1 ]]; then
+            info "Advancing $CARD_NAME x$COUNT..."
+            execute "(ai-actions/advance-card-times! \"$CARD_NAME\" $COUNT $OPTS)"
+        elif [[ "$OVERADVANCE" == "true" ]]; then
+            info "Advancing $CARD_NAME..."
             execute "(ai-actions/advance-card! \"$CARD_NAME\" {:overadvance true})"
         else
+            info "Advancing $CARD_NAME..."
             execute "(ai-actions/advance-card! \"$CARD_NAME\")"
         fi
+        after_action
         ;;
 
     # Score agenda
@@ -1096,6 +1159,7 @@ case "$COMMAND" in
         [[ -z "$CARD_NAME" ]] && error "Usage: send_command score <card-name>"
         info "Scoring $CARD_NAME..."
         execute "(ai-actions/score-agenda! \"$CARD_NAME\")"
+        after_action
         ;;
 
     # Prompts
@@ -1106,6 +1170,7 @@ case "$COMMAND" in
         [[ ! "$CHOICE" =~ ^[0-9]+$ ]] && error "Choice must be a number"
         info "Choosing option $CHOICE..."
         execute "(ai-actions/choose-option! $CHOICE)"
+        after_action
         ;;
 
     choose-value)
@@ -1114,6 +1179,7 @@ case "$COMMAND" in
         [[ -z "$VALUE" ]] && error "Usage: send_command choose-value <text>"
         info "Choosing option matching: $VALUE..."
         execute "(ai-actions/choose-by-value! \"$VALUE\")"
+        after_action
         ;;
 
     choose-card)
@@ -1123,6 +1189,7 @@ case "$COMMAND" in
         [[ ! "$INDEX" =~ ^[0-9]+$ ]] && error "Index must be a number"
         info "Choosing card at index $INDEX..."
         execute "(ai-actions/choose-card! $INDEX)"
+        after_action
         ;;
 
     multi-choose)
@@ -1159,6 +1226,7 @@ case "$COMMAND" in
             done
             execute "(ai-actions/multi-choose!$ARGS_STR)"
         fi
+        after_action
         ;;
 
     continue)
@@ -1199,7 +1267,7 @@ case "$COMMAND" in
             info "Continuing until decision required..."
             execute "(ai-actions/monitor-run!$FLAGS_ARGS)"
         fi
-        show_last_log_if_enabled
+        after_action
         ;;
 
     continue-run)
@@ -1212,7 +1280,7 @@ case "$COMMAND" in
         done
         info "Single-step mode (continue-run is alias for 'continue --single')..."
         execute "(ai-actions/continue-run!$FLAGS_ARGS)"
-        show_last_log_if_enabled
+        after_action
         ;;
 
     monitor-run)
@@ -1225,7 +1293,7 @@ case "$COMMAND" in
         done
         info "Loop mode (monitor-run is alias for 'continue')..."
         execute "(ai-actions/monitor-run!$FLAGS_ARGS)"
-        show_last_log_if_enabled
+        after_action
         # Peer-liveness footer: on a monitor-run timeout the seat must judge
         # whether the opponent is thinking or gone before re-issuing.
         PEER_LINE="$(peer_liveness_line)"; [[ -n "$PEER_LINE" ]] && echo "$PEER_LINE"
@@ -1280,7 +1348,7 @@ case "$COMMAND" in
                     (runs/set-strategy! {:tank (conj current-tank ice-name)})
                     (println (format \"✅ Authorized tank on: %s\" ice-name))
                     (runs/continue-run!)))"
-        show_last_log_if_enabled
+        after_action
         ;;
 
     concede)
@@ -1534,7 +1602,7 @@ case "$COMMAND" in
             info "Installing card: $CARD_NAME"
             execute "(ai-actions/install-card! \"$CARD_NAME\")"
         fi
-        show_last_log_if_enabled
+        after_action
         ;;
 
     install-index)
@@ -1550,7 +1618,7 @@ case "$COMMAND" in
             info "Installing card at index $INDEX"
             execute "(ai-actions/install-card! $INDEX)"
         fi
-        show_last_log_if_enabled
+        after_action
         ;;
 
     # Advanced
@@ -1658,7 +1726,7 @@ case "$COMMAND" in
         execute "(do
                    (require (quote [$BOT_NS :as bot]))
                    (bot/play-turn))"
-        show_last_log_if_enabled
+        after_action
         ;;
 
     bot-turn)
@@ -1667,7 +1735,7 @@ case "$COMMAND" in
         execute "(do
                    (require (quote [$BOT_NS :as bot]))
                    (bot/play-full-turn))"
-        show_last_log_if_enabled
+        after_action
         ;;
 
     bot-status)
@@ -1750,7 +1818,7 @@ case "$COMMAND" in
         execute '(do
                    (require (quote [ai-heuristic-corp :as bot]))
                    (bot/respond-to-run!))'
-        show_last_log_if_enabled
+        after_action
         ;;
 
     bot-watch)

--- a/dev/src/clj/ai_actions.clj
+++ b/dev/src/clj/ai_actions.clj
@@ -84,6 +84,7 @@
 (def show-archives display/show-archives)
 (def show-heap display/show-heap)
 (def show-prompt-detailed display/show-prompt-detailed)
+(def show-prompt-if-any display/show-prompt-if-any)
 (def show-card-text display/show-card-text)
 (def show-cards display/show-cards)
 (def show-hand-cards display/show-hand-cards)
@@ -104,6 +105,7 @@
 (def indicate-action! basic/indicate-action!)
 (def take-credit! basic/take-credit!)
 (def draw-card! basic/draw-card!)
+(def repeat-action! basic/repeat-action!)
 (def end-turn! basic/end-turn!)
 (def check-auto-end-turn! basic/check-auto-end-turn!)
 (def smart-end-turn! basic/smart-end-turn!)
@@ -152,6 +154,7 @@
 (def toggle-auto-no-action! cards/toggle-auto-no-action!)
 (def fire-unbroken-subs! cards/fire-unbroken-subs!)
 (def advance-card! cards/advance-card!)
+(def advance-card-times! cards/advance-card-times!)
 (def score-agenda! cards/score-agenda!)
 
 ;; ============================================================================

--- a/dev/src/clj/ai_basic_actions.clj
+++ b/dev/src/clj/ai_basic_actions.clj
@@ -418,10 +418,53 @@
                        :command "indicate-action"
                        :args nil})))
 
+(defn- clicks-left
+  "Clicks remaining for my side, or nil if unknown."
+  []
+  (let [s @state/client-state]
+    (get-in s [:game-state (keyword (:side s)) :click])))
+
+(defn repeat-action!
+  "Run a click action up to `n` times, stopping early on failure or when the
+   clicks run out.
+
+   The command log showed these arrive in BURSTS, not as deliberate repeats:
+   take-credit ran back-to-back 125 times at a 2s median (98% inside 5s),
+   advance 74 times at 1s, draw 56 times. That is one intent typed N times
+   because the command took no count. (Contrast `status`, which repeats at a
+   15s median — that is a seat waiting, a different problem.)
+
+   Stopping on click exhaustion is load-bearing, not defensive: the underlying
+   actions call check-auto-end-turn!, so the click that empties the pool can END
+   THE TURN mid-loop. Continuing would then fire actions into the opponent's
+   turn. The clicks check is skipped before the first action because the turn may
+   legitimately not be started yet (the actions auto-start it)."
+  [n action! label]
+  (loop [done 0]
+    (cond
+      (>= done n)
+      (do (when (> n 1) (println (format "✅ Completed %d %s" done label)))
+          (core/with-cursor {:status :success :data {:times done :requested n}}))
+
+      (and (pos? done) (some? (clicks-left)) (not (pos? (clicks-left))))
+      (do (println (format "⏹️  Stopped after %d of %d %s — no clicks left" done n label))
+          (core/with-cursor {:status :partial :data {:times done :requested n}}))
+
+      :else
+      (let [r (action!)]
+        (if (= :success (:status r))
+          (recur (inc done))
+          (do (when (pos? done)
+                (println (format "⏹️  Stopped after %d of %d %s" done n label)))
+              (update r :data merge {:times done :requested n})))))))
+
 (defn take-credit!
   "Click for credit (shows before/after).
-   Auto-starts turn if needed (opponent has ended and we haven't started yet)."
-  []
+   Auto-starts turn if needed (opponent has ended and we haven't started yet).
+
+   With `n`, clicks for credit up to n times (stops early if clicks run out)."
+  ([n] (repeat-action! n take-credit! "credit clicks"))
+  ([]
   (if (ensure-turn-started!)
     (let [client-state @state/client-state
           side (:side client-state)
@@ -439,22 +482,40 @@
             after-clicks (get-in client-state [:game-state (keyword side) :click])]
         (core/show-before-after "💰 Credits" before-credits after-credits)
         (core/show-before-after "⏱️  Clicks" before-clicks after-clicks)
-        ;; Show turn indicator only if we won't auto-end (which shows its own)
-        (when (> after-clicks 0)
-          (core/show-turn-indicator))
-        (check-auto-end-turn!)
-        (core/with-cursor
-          {:status :success
-           :data {:before-credits before-credits
-                  :after-credits after-credits
-                  :before-clicks before-clicks
-                  :after-clicks after-clicks}})))
-    (core/with-cursor {:status :error :reason "Failed to start turn"})))
+        ;; NEITHER credits NOR clicks moved => the engine refused the action
+        ;; (e.g. clicking for credit during a run). Reporting :success here is
+        ;; the misleading-output bug: `take-credit` mid-run printed
+        ;; "💰 Credits: 2 → 2" and still claimed success. Harmless-looking alone,
+        ;; but a count argument then repeats the no-op and cheerfully reports
+        ;; "Completed 2 credit clicks". Both signals together, because a state
+        ;; sync arriving late could leave one of them briefly stale.
+        (if (and (= before-credits after-credits)
+                 (= before-clicks after-clicks))
+          (do (println "❌ No credit gained — action was refused (in a run? not your turn?)")
+              (core/with-cursor {:status :error
+                                 :reason "Credit action had no effect"
+                                 :data {:before-credits before-credits
+                                        :before-clicks before-clicks}}))
+          (do
+            ;; Show turn indicator only if we won't auto-end (which shows its own)
+            (when (> after-clicks 0)
+              (core/show-turn-indicator))
+            (check-auto-end-turn!)
+            (core/with-cursor
+              {:status :success
+               :data {:before-credits before-credits
+                      :after-credits after-credits
+                      :before-clicks before-clicks
+                      :after-clicks after-clicks}})))))
+    (core/with-cursor {:status :error :reason "Failed to start turn"}))))
 
 (defn draw-card!
   "Draw a card (shows before/after).
-   Auto-starts turn if needed (opponent has ended and we haven't started yet)."
-  []
+   Auto-starts turn if needed (opponent has ended and we haven't started yet).
+
+   With `n`, draws up to n times (stops early if clicks run out)."
+  ([n] (repeat-action! n draw-card! "draws"))
+  ([]
   (if (ensure-turn-started!)
     (let [client-state @state/client-state
           side (:side client-state)
@@ -475,12 +536,23 @@
             new-card (last hand)
             card-title (get new-card :title "Unknown")]
         (println (str "🃏 Hand: " before-hand " → " after-hand " cards"))
-        (println (str "   Drew: " card-title))
-        (core/show-card-on-first-sight! card-title)
-        (core/show-before-after "⏱️  Clicks" before-clicks after-clicks)
-        (check-auto-end-turn!)
-        (core/with-cursor {:status :success :card-drawn card-title})))
-    (core/with-cursor {:status :error :reason "Failed to start turn"})))
+        ;; Same no-op guard as take-credit!, and sharper here: "Drew: X" reads
+        ;; the LAST card in hand, so a refused draw doesn't just claim success —
+        ;; it names a card that was already there as the one just drawn.
+        (if (and (= before-hand after-hand)
+                 (= before-clicks after-clicks))
+          (do (println "❌ No card drawn — action was refused (in a run? not your turn? deck empty?)")
+              (core/with-cursor {:status :error
+                                 :reason "Draw action had no effect"
+                                 :data {:before-hand before-hand
+                                        :before-clicks before-clicks}}))
+          (do
+            (println (str "   Drew: " card-title))
+            (core/show-card-on-first-sight! card-title)
+            (core/show-before-after "⏱️  Clicks" before-clicks after-clicks)
+            (check-auto-end-turn!)
+            (core/with-cursor {:status :success :card-drawn card-title})))))
+    (core/with-cursor {:status :error :reason "Failed to start turn"}))))
 
 (defn- burn-clicks-for-credits!
   "Spend all remaining clicks taking credits. Used by force-end-turn.

--- a/dev/src/clj/ai_basic_actions.clj
+++ b/dev/src/clj/ai_basic_actions.clj
@@ -424,6 +424,35 @@
   (let [s @state/client-state]
     (get-in s [:game-state (keyword (:side s)) :click])))
 
+(defn- my-vitals
+  "[credits clicks hand-size] for my side — the cheap observable proof that an
+   action actually did something."
+  []
+  (let [s @state/client-state
+        side (keyword (:side s))]
+    [(get-in s [:game-state side :credit])
+     (get-in s [:game-state side :click])
+     (count (get-in s [:game-state side :hand]))]))
+
+(defn- wait-for-vitals-change!
+  "Poll until my vitals differ from `before`, or the timeout expires. Returns
+   true if something moved.
+
+   Replaces a bare `(Thread/sleep medium-delay)` + compare. That pattern cannot
+   tell 'the engine refused this' from 'the state diff has not landed yet': the
+   client applies each diff atomically via differ/patch, so a not-yet-arrived
+   update leaves EVERY field at its old value, which is indistinguishable from a
+   refusal by inspection. Waiting for a change and only then concluding
+   'refused' makes the negative meaningful — and it also returns as soon as the
+   diff lands, so the happy path gets faster, not slower."
+  [before timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (cond
+        (not= before (my-vitals)) true
+        (>= (System/currentTimeMillis) deadline) false
+        :else (do (Thread/sleep 50) (recur))))))
+
 (defn repeat-action!
   "Run a click action up to `n` times, stopping early on failure or when the
    clicks run out.
@@ -440,6 +469,15 @@
    turn. The clicks check is skipped before the first action because the turn may
    legitimately not be started yet (the actions auto-start it)."
   [n action! label]
+  ;; Pre-flight: say up front that the count exceeds the clicks in hand, rather
+  ;; than discovering it N-1 actions in. Only when the turn is already started
+  ;; (clicks > 0) — at 0 clicks we cannot distinguish 'spent' from 'not started
+  ;; yet', and the actions auto-start the turn, so refusing there would break
+  ;; the first action of a turn.
+  (let [avail (clicks-left)]
+    (when (and (some? avail) (pos? avail) (> n avail))
+      (println (format "⚠️  Asked for %d %s but only %d click(s) in hand — will stop at %d"
+                       n label avail avail))))
   (loop [done 0]
     (cond
       (>= done n)
@@ -470,12 +508,13 @@
           side (:side client-state)
           before-credits (get-in client-state [:game-state (keyword side) :credit])
           before-clicks (get-in client-state [:game-state (keyword side) :click])
+          vitals-before (my-vitals)
           gameid (:gameid client-state)]
       (ws/send-message! :game/action
                         {:gameid gameid
                          :command "credit"
                          :args nil})
-      (Thread/sleep core/medium-delay)
+      (wait-for-vitals-change! vitals-before core/action-timeout)
       (let [client-state @state/client-state
             side (:side client-state)
             after-credits (get-in client-state [:game-state (keyword side) :credit])
@@ -521,12 +560,13 @@
           side (:side client-state)
           before-hand (count (get-in client-state [:game-state (keyword side) :hand]))
           before-clicks (get-in client-state [:game-state (keyword side) :click])
+          vitals-before (my-vitals)
           gameid (:gameid client-state)]
       (ws/send-message! :game/action
                         {:gameid gameid
                          :command "draw"
                          :args nil})
-      (Thread/sleep core/medium-delay)
+      (wait-for-vitals-change! vitals-before core/action-timeout)
       (let [client-state @state/client-state
             side (:side client-state)
             hand (get-in client-state [:game-state (keyword side) :hand])

--- a/dev/src/clj/ai_card_actions.clj
+++ b/dev/src/clj/ai_card_actions.clj
@@ -691,6 +691,19 @@
                     (println (str "⚠️  Sent advance command for: " card-name " - but action not confirmed in game log (may have failed)"))
                     (flush))))))))))))
 
+(defn advance-card-times!
+  "Advance `card-name` up to `n` times, stopping early on failure or when the
+   clicks run out.
+
+   Advancing is the burstiest command in the log: 74 back-to-back repeats at a
+   1s median, and `advance` is followed by `score` P=0.33 (n=45) — the whole
+   sequence is one intent — get this to scorable — typed one click at a time.
+   Overadvance protection still applies per step via advance-card!, so a count
+   cannot push a card past its requirement unless {:overadvance true} is set."
+  ([card-name n] (advance-card-times! card-name n {}))
+  ([card-name n opts]
+   (basic/repeat-action! n #(advance-card! card-name opts) "advancements")))
+
 (defn score-agenda!
   "Score an installed agenda (Corp only)
    Agenda must have enough advancement counters to be scored

--- a/dev/src/clj/ai_display.clj
+++ b/dev/src/clj/ai_display.clj
@@ -981,10 +981,19 @@
             (when (seq playable-breakers)
               (println "  💪 Icebreakers with playable abilities:")
               (doseq [b playable-breakers]
-                (let [playable-abs (filter :playable (:abilities b))]
+                ;; keep-indexed, NOT filter: `use-ability` takes the index into
+                ;; the card's FULL :abilities vector, so the position within a
+                ;; filtered playable-only list is the wrong number — printing it
+                ;; would be worse than printing nothing. Emitting the whole
+                ;; invocation is the point: the command log had abilities ->
+                ;; use-ability at P=0.59 (n=68), a round-trip that existed only
+                ;; to look this index up.
+                (let [playable-abs (keep-indexed (fn [i ab] (when (:playable ab) [i ab]))
+                                                 (:abilities b))]
                   (println (format "     • %s (str %s)" (:title b) (or (:current-strength b) (:strength b))))
-                  (doseq [ab playable-abs]
-                    (println (format "       → %s" (:label ab)))))))))))))
+                  (doseq [[idx ab] playable-abs]
+                    (println (format "       → %s" (:label ab)))
+                    (println (format "         use-ability \"%s\" %d" (:title b) idx))))))))))))
 
 (defn run-server-display
   "Human-readable name for a run's target server, given the last element of the
@@ -1368,6 +1377,31 @@
 
           :else
           (println (format "ℹ️  %s" (:status-text ts))))))))
+
+(defn show-prompt-if-any
+  "Append the current prompt to an action's output — or print NOTHING if there
+   isn't one.
+
+   Exists because the command log says the single most common thing a seat does
+   after changing the game state is ask what the state now is: continue→prompt
+   ran P=0.48 (n=186 in the marquee era alone), with the same shape at
+   score→prompt (0.40), choose-card→prompt (0.33) and run→prompt (0.27). Roughly
+   half of all `prompt` calls are a round-trip the acting command could have
+   answered itself. It is also the misleading-output failure surface: a seat that
+   cannot see the outcome of its own action re-issues it (Terra looped `continue`
+   three times off a misread phase in marquee g1).
+
+   Silence when there is no prompt is the whole contract — this runs after EVERY
+   action, so a 'No active prompt' line would be pure noise on the majority of
+   commands and would train seats to stop reading the tail of the output.
+
+   A passive waiting prompt is rendered as one line rather than the full block:
+   it carries no choices, and the useful information is just 'not your move'."
+  []
+  (when-let [prompt (state/get-prompt)]
+    (if (state/waiting-prompt-type? (:prompt-type prompt))
+      (println (format "\n⏳ %s" (or (:msg prompt) "Waiting for opponent")))
+      (show-prompt-detailed))))
 
 (defn show-snapshot
   "One-shot per-decision snapshot: compact status, the current prompt (only when

--- a/dev/test/ai_basic_actions_test.clj
+++ b/dev/test/ai_basic_actions_test.clj
@@ -245,3 +245,120 @@
             (is (= :already-ended (:status result)) "must report already-ended")
             (is (empty? @sent)
                 "opponent took over -> must NOT re-send (avoid corrupting double-end)")))))))
+
+;; =============================================================================
+;; repeat-action! — count arguments for burst commands
+;; =============================================================================
+;;
+;; The command log showed take-credit/advance/draw arriving in BURSTS (125/74/56
+;; back-to-back repeats at a 1-2s median), i.e. one intent typed N times because
+;; the command took no count. These pin the loop's stopping rules — especially
+;; click exhaustion, which is load-bearing rather than defensive: the underlying
+;; actions call check-auto-end-turn!, so the click that empties the pool can END
+;; THE TURN mid-loop, and continuing would fire actions into the opponent's turn.
+
+(defn- clicking-state
+  "Client state whose click count decrements on each successful action."
+  [clicks]
+  (mock-client-state :side "runner"
+                     :game-state {:runner {:click clicks :credit 5 :hand []}
+                                  :corp {:click 0 :credit 5 :hand []}
+                                  :turn 5 :active-player "Runner" :log []}))
+
+(deftest repeat-action-runs-exactly-n-times
+  (testing "A count does what typing it N times did"
+    (with-mock-state (clicking-state 4)
+      (let [calls (atom 0)
+            result (basic/repeat-action! 3 (fn [] (swap! calls inc) {:status :success}) "things")]
+        (is (= 3 @calls))
+        (is (= :success (:status result)))
+        (is (= 3 (get-in result [:data :times])))))))
+
+(deftest repeat-action-stops-when-clicks-run-out
+  (testing "CRITICAL: the click that empties the pool can auto-end the turn, so
+            the loop must stop rather than act into the opponent's turn."
+    (with-mock-state (clicking-state 2)
+      (let [calls (atom 0)
+            action (fn []
+                     (swap! calls inc)
+                     ;; mimic the real actions: each one spends a click
+                     (swap! state/client-state update-in [:game-state :runner :click] dec)
+                     {:status :success})
+            result (basic/repeat-action! 5 action "clicks")]
+        (is (= 2 @calls) "Must spend only the clicks actually available")
+        (is (= :partial (:status result)) "and report the shortfall, not claim success")
+        (is (= 2 (get-in result [:data :times])))
+        (is (= 5 (get-in result [:data :requested])))))))
+
+(deftest repeat-action-stops-on-first-failure
+  (testing "A failed step aborts the rest — never plough on through an error"
+    (with-mock-state (clicking-state 4)
+      (let [calls (atom 0)
+            action (fn []
+                     (swap! calls inc)
+                     (if (= 2 @calls)
+                       {:status :error :reason "blocked"}
+                       {:status :success}))
+            result (basic/repeat-action! 4 action "things")]
+        (is (= 2 @calls) "Stops at the failure, does not attempt 3 or 4")
+        (is (= :error (:status result)) "and surfaces the failure, not a success")
+        (is (= 1 (get-in result [:data :times])) "reporting how many DID land")))))
+
+(deftest repeat-action-first-call-is-not-blocked-by-zero-clicks
+  (testing "The turn may legitimately not be started yet (the actions auto-start
+            it), so the clicks guard must not fire before the first action."
+    (with-mock-state (clicking-state 0)
+      (let [calls (atom 0)
+            result (basic/repeat-action! 1 (fn [] (swap! calls inc) {:status :success}) "things")]
+        (is (= 1 @calls) "Must still attempt the first action at 0 clicks")
+        (is (= :success (:status result)))))))
+
+;; =============================================================================
+;; No-op detection — the misleading-output class
+;; =============================================================================
+;;
+;; Found by smoke-testing the count argument: `take-credit 2` during a run
+;; printed "💰 Credits: 2 → 2", "⏱️  Clicks: 3 → 3" and then "✅ Completed 2
+;; credit clicks". The engine had refused both actions. The count argument did
+;; not cause this — it AMPLIFIED a pre-existing lie (same no-op seen in marquee
+;; g1) into a confident summary, which is what made it visible.
+
+(defn- no-op-state []
+  (mock-client-state :side "runner"
+                     :game-state {:runner {:click 3 :credit 2 :hand [{:cid 1 :title "Sure Gamble"}]}
+                                  :corp {:click 0 :credit 5 :hand []}
+                                  :turn 5 :active-player "Runner"
+                                  :run {:phase "encounter-ice"} :log []}))
+
+(deftest take-credit-reports-error-when-nothing-changed
+  (testing "Refused action (neither credits NOR clicks moved) must not claim success"
+    (with-mock-state (no-op-state)
+      (with-redefs [ws/send-message! (fn [_ _] true)
+                    basic/ensure-turn-started! (fn [] true)]
+        (let [result (basic/take-credit!)]
+          (is (= :error (:status result))
+              "A no-op that reports :success is how a seat ends up repeating it")
+          (is (re-find #"no effect" (str (:reason result)))))))))
+
+(deftest draw-reports-error-when-nothing-changed
+  (testing "A refused draw must not name the pre-existing last card as 'Drew:'"
+    (with-mock-state (no-op-state)
+      (with-redefs [ws/send-message! (fn [_ _] true)
+                    basic/ensure-turn-started! (fn [] true)]
+        (let [out (java.io.StringWriter.)
+              result (binding [*out* out] (basic/draw-card!))]
+          (is (= :error (:status result)))
+          (is (not (re-find #"Drew:" (str out)))
+              "Must not claim to have drawn a card it did not draw"))))))
+
+(deftest repeat-action-does-not-amplify-a-no-op
+  (testing "The count must stop on the refusal rather than repeat it N times
+            and summarise with a confident '✅ Completed N'."
+    (with-mock-state (no-op-state)
+      (with-redefs [ws/send-message! (fn [_ _] true)
+                    basic/ensure-turn-started! (fn [] true)]
+        (let [out (java.io.StringWriter.)
+              result (binding [*out* out] (basic/take-credit! 3))]
+          (is (= :error (:status result)))
+          (is (= 0 (get-in result [:data :times])) "Zero actions actually landed")
+          (is (not (re-find #"Completed 3" (str out)))))))))

--- a/dev/test/ai_basic_actions_test.clj
+++ b/dev/test/ai_basic_actions_test.clj
@@ -362,3 +362,23 @@
           (is (= :error (:status result)))
           (is (= 0 (get-in result [:data :times])) "Zero actions actually landed")
           (is (not (re-find #"Completed 3" (str out)))))))))
+
+(deftest repeat-action-warns-when-count-exceeds-clicks
+  (testing "Say up front that the count exceeds the clicks in hand, rather than
+            discovering it N-1 actions in. (Michael's review of the count arg.)"
+    (with-mock-state (clicking-state 2)
+      (let [out (java.io.StringWriter.)]
+        (binding [*out* out]
+          (basic/repeat-action! 5 (fn [] {:status :success}) "clicks"))
+        (is (re-find #"only 2 click" (str out))
+            "Must warn before starting, naming the real ceiling")))))
+
+(deftest repeat-action-does-not-warn-at-zero-clicks
+  (testing "0 clicks cannot distinguish 'spent' from 'turn not started yet', and
+            the actions auto-start the turn — warning there would be noise on
+            the first action of every turn."
+    (with-mock-state (clicking-state 0)
+      (let [out (java.io.StringWriter.)]
+        (binding [*out* out]
+          (basic/repeat-action! 3 (fn [] {:status :success}) "clicks"))
+        (is (not (re-find #"only 0 click" (str out))))))))

--- a/dev/test/ai_display_test.clj
+++ b/dev/test/ai_display_test.clj
@@ -995,3 +995,44 @@
             (str "a Corp seat's own installed card must resolve:\n" out))
         (is (str/includes? out "Take 3")
             (str "should list the card's ability:\n" out))))))
+
+;; ============================================================================
+;; show-prompt-if-any — collapse the "act, then ask what happened" round-trip
+;; ============================================================================
+;;
+;; Command-log evidence: continue->prompt ran P=0.48 (n=186 in the marquee era),
+;; with the same shape at score->prompt (0.40), choose-card->prompt (0.33) and
+;; run->prompt (0.27). Roughly half of all `prompt` calls were a round-trip the
+;; acting command could have answered itself. This runs after EVERY action, so
+;; silence-when-there-is-nothing is the load-bearing part of the contract.
+
+(defn- prompt-state [prompt]
+  (mock-client-state :side "runner"
+                     :game-state {:runner {:prompt-state prompt}
+                                  :corp {} :log []}))
+
+(deftest show-prompt-if-any-is-silent-with-no-prompt
+  (testing "Runs after every action — a 'No active prompt' line would be noise on
+            the majority of commands and would train seats to stop reading the
+            tail of the output."
+    (with-mock-state (prompt-state nil)
+      (is (= "" (with-out-str (display/show-prompt-if-any)))))))
+
+(deftest show-prompt-if-any-renders-a-real-prompt
+  (testing "A decision must appear in the acting command's own output"
+    (with-mock-state (prompt-state {:prompt-type "select"
+                                    :msg "Choose a card to trash"
+                                    :choices [{:value "Yes"} {:value "No"}]})
+      (let [out (with-out-str (display/show-prompt-if-any))]
+        (is (str/includes? out "Choose a card to trash"))
+        (is (str/includes? out "Yes"))))))
+
+(deftest show-prompt-if-any-collapses-a-waiting-prompt-to-one-line
+  (testing "A passive wait carries no choices — the useful content is just
+            'not your move', so it must not print the full decision block."
+    (with-mock-state (prompt-state {:prompt-type "waiting"
+                                    :msg "Waiting for Corp to rez"})
+      (let [out (with-out-str (display/show-prompt-if-any))]
+        (is (str/includes? out "Waiting for Corp to rez"))
+        (is (< (count (str/split-lines (str/trim out))) 3)
+            "One line, not the full prompt block")))))


### PR DESCRIPTION
Driven by bigram analysis of `logs/commands.log` — 9,966 player-issued commands. Harness pollers (`watch_game.sh`'s `get-cursor`/`wait` loop, the umpire's `game-over-status`) are excluded: they're ~6k events of pure noise and completely dominate the table if you don't strip them. That filtering step is the one methodological trap if we re-run this.

## 1. action → prompt

The commonest thing a seat does after changing state is ask what the state now is:

| pattern | P(Y\|X) | n |
|---|---|---|
| `continue` → `prompt` | 0.48 | 186 |
| `score` → `prompt` | 0.40 | 17 |
| `choose-card` → `prompt` | 0.33 | 29 |
| `run` → `prompt` | 0.27 | 29 |

Roughly half of all `prompt` calls were a round-trip the acting command could have answered itself. New `show-prompt-if-any` appends the resulting prompt — and prints **nothing** when there isn't one, which is the load-bearing part of the contract since it runs after every action. Wired via a generalised `after_action` hook; the existing `show_last_log_if_enabled` pattern already sat at 13 action sites, now 28.

This is also the misleading-output surface: a seat that can't see the outcome of its own action re-issues it. Terra looped `continue` three times off a misread phase in marquee g1.

## 2. abilities → use-ability (P=0.59, n=68)

Not a name-support gap — `send_command` hard-errors unless the index is numeric. The prompt *already* listed each breaker's playable abilities, but `filter`ed them, so **the displayed position was not the index `use-ability` wants**. Printing that number would have been worse than printing none. `keep-indexed` preserves the true index and the display now emits the whole invocation:

```
     • Cleaver (str 3)
       → Add 1 strength
         use-ability "Cleaver" 1
```

That exposed a latent bug in `execute`'s capture path: `echo -e` leaves `\"` backslashed, so any quote a display fn printed came out escaped — harmless until the text became something you copy verbatim.

## 3. Count args

`take-credit`/`advance`/`draw` arrived in **bursts** — 125/74/56 back-to-back repeats at a 1–2s median (98%/97%/84% inside 5s). One intent typed N times because the command took no count. Added via a shared `repeat-action!`.

Stopping on click exhaustion is load-bearing, not defensive: these actions call `check-auto-end-turn!`, so the click that empties the pool can **end the turn mid-loop**, and further actions would fire into the opponent's turn.

Contrast `status`, which repeats 728 times at a **15s** median — that's a seat waiting without knowing `wait` exists. Different problem, docs fix, not in this PR.

## 4. No-op detection (found by smoke-testing #3)

`take-credit 2` during a run printed `Credits: 2 → 2`, `Clicks: 3 → 3`, then `✅ Completed 2 credit clicks`. The engine had refused both actions. The count argument didn't cause this — it **amplified a pre-existing lie** (same no-op seen in marquee g1) into a confident summary, which is what made it visible.

`take-credit!`/`draw-card!` now report `:error` when neither their resource nor clicks moved. Sharper for `draw`, which read the *last card in hand* and so named an already-held card as "Drew:". Both signals required, since a late state sync could leave one briefly stale.

## Verification

Live on game 4a6aef71: the same `take-credit 2` that claimed success now reports the refusal, lands zero actions, and appends the encounter prompt with copy-pasteable break commands.

- `make test`: 504 tests, 1367 assertions, 0 failures (was 494/1343)
- `send_command_filter_test`: all passed

## Deferred

`run` → `continue` (P=0.48) — worth re-checking after the #31 fix has some games on it; it may already be gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)