### PR TITLE
fix(end-turn): refuse off-turn end-turn; cut the re-send advice that caused it

### DIFF
--- a/dev/MARQUEE_RUNBOOK.md
+++ b/dev/MARQUEE_RUNBOOK.md
@@ -83,8 +83,13 @@ unanswered ping). On a ping:
    whole point of the umpire seat. Do NOT relay what you see.)
 2. Answer: `./dev/umpire-reply <side> "<harness-state answer>"`. The seat is polling
    `umpire-check` and will pick it up.
-3. If genuinely wedged, apply the documented recovery yourself where you can
-   (re-send end-turn, clear a stuck `:turn-started`, etc.) or `--wake`/ntfy Michael.
+3. If genuinely wedged, apply the documented recovery yourself where you can — but
+   **NEVER re-send an end-turn, and never instruct a seat to.** An off-turn end-turn
+   ends the opponent's turn and is logged under the sender's name; no game has ever
+   been recovered from it (it killed game 02995207). The client now refuses off-turn
+   end-turns, so treat that refusal as correct and look elsewhere. If you can't
+   recover without one, the game is dead — abandon it and `--wake`/ntfy Michael
+   rather than "fixing" it into an unrecoverable state.
 
 **HARD CONSTRAINT (you see both hands — do not blow fog-of-war):** reply about
 harness/tooling state ONLY. Keep recoveries **command-only and card-name-free**
@@ -93,7 +98,7 @@ redirect. The mailbox is opponent-readable, so a leak in YOUR reply is as bad as
 in a seat's ping. Canned replies to prefer (bland by design):
 - `not wedged — opponent has an open decision window, keep waiting`
 - `not wedged — opponent is mid-turn, keep waiting`
-- `wedged — re-send your last end-turn once, then resume the wait loop`
+- `wedged — hold position, do not re-send anything; I am investigating`
 - `harness channel only — I can't advise on play; re-ask about tooling state`
 
 **One umpire per match dir.** Two sessions Monitoring the same mailbox will both
@@ -105,9 +110,13 @@ reply and step on each other. If you're supervising, you're the only umpire.
   owns the whole Runner run; it wakes only for rez/fire/access/run-end. On a
   **timeout** during an active run the seat re-issues `monitor-run --persistent`
   (normal pacing vs a slow opponent — not a stall).
-- **End-turn rollback:** an end-turn right after a last-click action can be rolled
-  back on resync. Recovery: re-run `smart-end-turn` 2–3× ~3s apart before
-  concluding a genuine opponent stall. (Both seat briefs document this.)
+- **NEVER re-send end-turn** (this replaces the old "retry 2–3×" advice, which
+  killed game 02995207). An end-turn landing off-turn ends the OPPONENT's turn and
+  is logged under the sender's name, leaving no `<opponent> is ending` line — after
+  which log-derived turn state permanently disagrees with `:end-turn` and the match
+  wedges. The client now refuses off-turn end-turns; if a seat reports
+  `⛔ Refusing end-turn`, that guard is doing its job. A seat that thinks the game
+  won't advance should escalate, not retry.
 - **Symmetric priority window** (the original deadlock) is now side/priority-aware
   in the prompt (`013469b09`) AND auto-passed by the persistent Corp loop — this
   game is the test that those two fixes together let the models self-resolve.

--- a/dev/seat-corp.md
+++ b/dev/seat-corp.md
@@ -175,16 +175,22 @@ IN-PROGRESS, report the dead peer and stop rather than looping forever.
 burns credits and reveals the card. A cheap ICE on a server with nothing worth
 stealing is often a decline.
 
-### ⚠️ If the game won't advance after you end your turn — re-send end-turn
+### ⛔ NEVER re-send end-turn. If the game won't advance, call the umpire.
 
-Known rough edge: ending your turn right after a **last-click action whose
-resolution is still settling** can get **rolled back** on a resync. Symptom:
-`smart-end-turn` reports success and `game-over-status` shows
-`AWAITING-START next-player=runner`, **but the Runner never starts**. Do NOT
-conclude "Runner stalled" from this alone. **Recovery:** if you've ended and the
-Runner hasn't started after a `wait` (~10s+), simply re-run
-`./dev/send_command corp smart-end-turn`. Retry 2–3 times, ~3s apart, before
-deciding it's a genuine Runner-side stall.
+**Do not re-send `end-turn`/`smart-end-turn` to unstick anything, ever.** An
+end-turn that lands when it isn't your turn ends your OPPONENT's turn and is
+logged under your name. No game has ever been recovered from it. This destroyed
+game 02995207 at turn 8 — the seat was following earlier advice in this very
+document to "retry 2–3 times", which is why that advice is gone.
+
+The client now refuses off-turn end-turns outright (`⛔ Refusing end-turn: it is
+not your turn`). If you see that message, you are about to break the game:
+**stop and escalate.** Do not look for a way around it.
+
+Symptom you may still hit: `smart-end-turn` reports success and
+`game-over-status` shows `AWAITING-START next-player=runner`, **but the Runner
+never starts**. Do NOT conclude "Runner stalled", and do NOT re-send. Wait once,
+then escalate to the umpire.
 
 ## If you suspect a wedge — raise your hand to the umpire (don't spin)
 
@@ -193,13 +199,20 @@ it is genuinely undecidable from one side. So don't silently burn 10 minutes
 re-sending a command that isn't advancing. There is an **umpire**: a supervisor who
 can legitimately see BOTH seats' public status, there for exactly this.
 
+**DEFAULT POSTURE: if something weird happened, or the game might be broken, or
+the opponent might be stuck — ESCALATE. Do not try to fix it by re-sending.**
+Re-sending is how a recoverable oddity becomes an unrecoverable one. The umpire
+is cheap; a broken game costs the whole match.
+
 **Escalate when ANY of these holds:**
-- you've re-sent the same advancing command (`start-turn`, `continue`,
-  `monitor-run --persistent`, `smart-end-turn`) **~3×** with **no state change**; or
+- anything looks wrong, out of order, or contradictory — including a command whose
+  output disagrees with `game-over-status`, `prompt`, or the log; or
+- you've issued the same advancing command (`start-turn`, `continue`,
+  `monitor-run --persistent`) **twice** with **no state change** — do not go to a
+  third; or
 - you've waited **> ~5 min** with no progress AND `peer-status` says the opponent is
   still **alive** (so it's not a dead peer — smells like a boundary wedge); or
-- a run window won't advance and the documented recoveries above (re-issue
-  `monitor-run`, re-send `end-turn`) haven't moved it.
+- a run window won't advance and re-issuing `monitor-run` hasn't moved it.
 
 **How — ping, then poll for the reply (bounded), then follow it:**
 ```

--- a/dev/seat-runner-devin.md
+++ b/dev/seat-runner-devin.md
@@ -143,15 +143,25 @@ C=$(./dev/send_command runner get-cursor)
 ./dev/send_command runner wait --since "$C"
 ```
 
-### ⚠️ If the game won't advance after you end your turn — re-send end-turn
-Known rough edge: when you end your turn right after a last-click action whose
-resolution is still settling, the engine can roll your end-turn back on a resync.
-Symptom: `smart-end-turn` reports success and `game-over-status` shows
-`AWAITING-START next-player=corp`, but the Corp never starts. Do NOT conclude
-"Corp stalled" from this alone. **Recovery:** if you've ended your turn and the
-Corp hasn't started after a `wait` (~10s+), simply re-run
-`./dev/send_command runner smart-end-turn`. Retry 2–3 times, ~3s apart, before
-deciding it's a genuine Corp-side stall.
+### ⛔ NEVER re-send end-turn. If the game won't advance, call the umpire.
+**Do not re-send `end-turn`/`smart-end-turn` to unstick anything, ever.** An
+end-turn that lands when it isn't your turn ends your OPPONENT's turn and is
+logged under your name. No game has ever been recovered from it. This destroyed
+game 02995207 at turn 8 — the seat was following earlier advice in this very
+document to "retry 2–3 times", which is why that advice is gone.
+
+The client now refuses off-turn end-turns outright (`⛔ Refusing end-turn: it is
+not your turn`). If you see that, you are about to break the game: stop and
+escalate. Do not look for a way around it.
+
+Symptom you may still hit: `smart-end-turn` reports success and
+`game-over-status` shows `AWAITING-START next-player=corp`, but the Corp never
+starts. Do NOT conclude "Corp stalled", and do NOT re-send. Wait once, then
+escalate to the umpire.
+
+**DEFAULT POSTURE: something weird happened, or the game might be broken, or the
+opponent might be stuck → ESCALATE.** Do not try to fix it by re-sending;
+re-sending is how a recoverable oddity becomes an unrecoverable one.
 
 ### If you suspect a wedge — raise your hand to the umpire (do NOT exit)
 You cannot tell "slow opponent" from "harness wedged" from your own seat. There is

--- a/dev/seat-runner.md
+++ b/dev/seat-runner.md
@@ -103,22 +103,22 @@ C=$(./dev/send_command runner get-cursor)          # capture cursor first
 ./dev/send_command runner wait --since "$C"        # blocks until something relevant
 ```
 
-### ⚠️ If the game won't advance after you end your turn — re-send end-turn
+### ⛔ NEVER re-send end-turn. If the game won't advance, call the umpire.
 
-There is a known rough edge: when you end your turn right after a **last-click
-action whose resolution is still settling** (a run/access that just finished, or
-an event that made the Corp choose something like Wildcat Strike), the engine can
-**roll your end-turn back** on a resync. The symptom is sneaky: `smart-end-turn`
-reports success and `game-over-status` shows `AWAITING-START next-player=corp`,
-**but the Corp never starts** — because your end-turn never actually landed
-server-side. Do NOT conclude "Corp bot stalled" from this alone.
+**Do not re-send `end-turn`/`smart-end-turn` to unstick anything, ever.** An
+end-turn that lands when it isn't your turn ends your OPPONENT's turn and is
+logged under your name. No game has ever been recovered from it. This destroyed
+game 02995207 at turn 8 — the seat was following earlier advice in this very
+document to "retry 2–3 times", which is why that advice is gone.
 
-**Recovery (do this before reporting any post-turn stall):** if you've ended your
-turn and the Corp hasn't started after a `wait` (you're still at 0 clicks and the
-game sits at `AWAITING-START next-player=corp` / your turn for ~10s+), simply
-**re-run `./dev/send_command runner smart-end-turn`.** Once the rollback has
-settled it will cleanly re-send and the Corp will pick up. Retry it 2–3 times,
-~3s apart, before deciding it's a genuine Corp-side stall.
+The client now refuses off-turn end-turns outright (`⛔ Refusing end-turn: it is
+not your turn`). If you see that message, you are about to break the game:
+**stop and escalate.** Do not look for a way around it.
+
+Symptom you may still hit: `smart-end-turn` reports success and
+`game-over-status` shows `AWAITING-START next-player=corp`, **but the Corp never
+starts**. Do NOT conclude "Corp bot stalled", and do NOT re-send. Wait once, then
+escalate to the umpire.
 
 ## If you suspect a wedge — raise your hand to the umpire (don't spin)
 

--- a/dev/src/clj/ai_basic_actions.clj
+++ b/dev/src/clj/ai_basic_actions.clj
@@ -700,8 +700,30 @@
         clicks (get-in client-state [:game-state side-kw :click])
         hand-size (count (get-in client-state [:game-state side-kw :hand]))
         max-hand-size (get-in client-state [:game-state side-kw :hand-size :total] 5)
-        gameid (:gameid client-state)]
+        gameid (:gameid client-state)
+        active-player (get-in client-state [:game-state :active-player])
+        ;; nil active-player = pre-game / unpopulated mock; don't refuse on it.
+        my-turn? (or (nil? active-player)
+                     (= (str/lower-case (name side-kw))
+                        (str/lower-case active-player)))]
     (cond
+      ;; OFF-TURN GUARD (game 02995207, turn 8). An end-turn sent while we are NOT
+      ;; the active player ends the OPPONENT's turn, and the engine logs it under
+      ;; OUR name — leaving no "<opponent> is ending" line at all. Every consumer
+      ;; that derives turn state from the log then disagrees with :end-turn, and
+      ;; the match wedges permanently. No game has ever been recovered from it.
+      ;;
+      ;; The Bug #2 guard below cannot catch this: it scans only the last 3 log
+      ;; entries, so once the opponent takes a couple of actions our own "is ending"
+      ;; line scrolls out of the window and the guard goes blind. This check keys on
+      ;; :active-player instead, which does not scroll.
+      (not my-turn?)
+      (do
+        (println "⛔ Refusing end-turn: it is not your turn.")
+        (println (format "   Active player is %s; ending a turn you don't own corrupts engine state." active-player))
+        (println "   If the game looks stuck, escalate to the umpire — do NOT re-send.")
+        (core/with-cursor {:status :error :reason :not-my-turn :active-player active-player}))
+
       ;; Bug #2 guard: refuse to double-end the turn. The engine treats a
       ;; second end-turn message as state corruption and deadlocks the next
       ;; turn cycle (Run #4 1:11:32). Detected via our own recent log line.
@@ -865,6 +887,12 @@
         ;; Check if we've actually started our turn
         turn-started? (turn-started-since-last-opp-end?)
 
+        ;; Off-turn guard input (see the cond's first branch).
+        active-player (get-in client-state [:game-state :active-player])
+        my-turn? (or (nil? active-player)
+                     (= (str/lower-case (name side))
+                        (str/lower-case active-player)))
+
         ;; Turn number at entry, so the self-heal re-read can detect a real
         ;; transition (:turn advanced) vs a rolled-back end-turn.
         turn (get-in client-state [:game-state :turn] 0)
@@ -889,6 +917,16 @@
                               (vals installed))]
 
     (cond
+      ;; OFF-TURN GUARD — mirrors end-turn!'s. Checked FIRST so the self-heal
+      ;; below can never re-send into the opponent's turn. See end-turn! for why
+      ;; this is fatal and why the log-scan guards cannot catch it.
+      (not my-turn?)
+      (do
+        (println "⛔ Refusing end-turn: it is not your turn.")
+        (println (format "   Active player is %s." active-player))
+        (println "   If the game looks stuck, escalate to the umpire — do NOT re-send.")
+        (core/with-cursor {:status :error :reason :not-my-turn :active-player active-player}))
+
       ;; Can't end: Turn hasn't started yet
       (not turn-started?)
       (do

--- a/dev/test/ai_basic_actions_test.clj
+++ b/dev/test/ai_basic_actions_test.clj
@@ -382,3 +382,82 @@
         (binding [*out* out]
           (basic/repeat-action! 3 (fn [] {:status :success}) "clicks"))
         (is (not (re-find #"only 0 click" (str out))))))))
+
+;; ---------------------------------------------------------------------------
+;; Off-turn end-turn guard (game 02995207, turn 8)
+;;
+;; An end-turn sent while we are NOT the active player ends the OPPONENT's turn
+;; and is logged under OUR name, leaving no "<opponent> is ending" line. Turn
+;; state derived from the log then permanently disagrees with :end-turn and the
+;; match wedges. These tests assert NOTHING IS SENT — asserting only on the
+;; returned :status would stay green on a client that still transmits, which is
+;; the whole failure mode.
+;; ---------------------------------------------------------------------------
+
+(defn- off-turn-state
+  "Runner at 0 clicks during the CORP's turn, with the runner's own 'is ending'
+   line already scrolled out of the 3-entry window that already-ended-this-turn?
+   inspects — i.e. exactly the state at the wedge."
+  []
+  (mock-client-state
+   :side "runner"
+   :game-state {:runner {:click 0 :credit 5 :hand [] :hand-count 0}
+                :corp {:click 0 :credit 12 :hand []}
+                :turn 8
+                :active-player "corp"
+                :log [{:text "ai-runner is ending their turn 7 with 0 [Credit] and 5 cards in their Grip."}
+                      {:text "ai-corp started their turn 8 with 12 [Credit] and 3 cards in HQ."}
+                      {:text "ai-corp spends [Click] to install a card in the root of Server 1."}
+                      {:text "ai-corp spends [Click] and pays 1 [Credits] to advance a card in Server 1."}]}))
+
+(deftest end-turn-refuses-off-turn-and-sends-nothing
+  (testing "end-turn! must not transmit while the opponent is the active player"
+    (let [sent (atom [])]
+      (with-mock-state (off-turn-state)
+        (with-redefs [ws/send-message! (mock-websocket-send! sent)]
+          (let [result (binding [*out* (java.io.StringWriter.)] (basic/end-turn!))]
+            (is (= :error (:status result)))
+            (is (= :not-my-turn (:reason result)))
+            (is (empty? @sent)
+                "MUST NOT SEND — an off-turn end-turn ends the opponent's turn")))))))
+
+(deftest smart-end-turn-refuses-off-turn-and-sends-nothing
+  (testing "smart-end-turn! mirrors the guard, so its self-heal can never
+            re-send into the opponent's turn"
+    (let [sent (atom [])]
+      (with-mock-state (off-turn-state)
+        (with-redefs [ws/send-message! (mock-websocket-send! sent)]
+          (let [result (binding [*out* (java.io.StringWriter.)] (basic/smart-end-turn!))]
+            (is (= :error (:status result)))
+            (is (= :not-my-turn (:reason result)))
+            (is (empty? @sent))))))))
+
+(deftest off-turn-guard-survives-the-log-window-scrolling
+  (testing "The pre-existing duplicate guard scans only the last 3 log entries, so
+            our own 'is ending' line scrolls out once the opponent acts and the
+            guard goes blind. The off-turn guard keys on :active-player, which does
+            not scroll — this is the case that actually wedged game 02995207."
+    (let [sent (atom [])]
+      (with-mock-state (off-turn-state)
+        ;; Precondition: the old guard IS blind here. If this ever goes false the
+        ;; test has stopped covering the real bug.
+        (is (not (#'basic/already-ended-this-turn? @state/client-state))
+            "precondition: the 3-entry duplicate guard cannot see our end-turn")
+        (with-redefs [ws/send-message! (mock-websocket-send! sent)]
+          (binding [*out* (java.io.StringWriter.)] (basic/end-turn!))
+          (is (empty? @sent) "off-turn guard must cover what the log-scan guard misses"))))))
+
+(deftest end-turn-still-works-on-our-own-turn
+  (testing "The guard must not block a legitimate end-turn (active-player = us)"
+    (let [sent (atom [])]
+      (with-mock-state (mock-client-state
+                        :side "runner"
+                        :game-state {:runner {:click 0 :credit 5 :hand [] :hand-count 0}
+                                     :corp {:click 0 :credit 12 :hand []}
+                                     :turn 8
+                                     :active-player "runner"
+                                     :log [{:text "ai-runner spends [Click] to make a run on R&D."}]})
+        (with-redefs [ws/send-message! (mock-websocket-send! sent)]
+          (let [result (binding [*out* (java.io.StringWriter.)] (basic/end-turn!))]
+            (is (= :success (:status result)))
+            (is (= 1 (count @sent)) "legitimate end-turn must still be sent")))))))


### PR DESCRIPTION
Killed marquee game 02995207 at turn 8 (Corp 4–0). Found by running the game, not by reading the code.

## What happens
An end-turn landing while you are **not** the active player ends the **opponent's** turn and is logged under **your** name. No `<opponent> is ending` line is ever emitted, so anything deriving turn state from the log permanently disagrees with `:end-turn`, and the match wedges. Per Michael: we have never successfully resurrected a game from this.

Downstream symptom: the Runner's `start-turn` gates on a log scan for that line, so it refused a legal action forever — while `AWAITING-START` (derived from state) said it was fine, and `diagnose-blocker` actively recommended the command that refused.

## Root cause — two halves, either of which alone would have saved the game

**1. No off-turn guard.** `end-turn!` checked already-ended / clicks / prompt, never `:active-player`. The existing duplicate guard can't cover it: `already-ended-this-turn?` scans only the **last 3 log entries**, so once the opponent acts a couple of times our own `is ending` line scrolls out and the guard goes blind. That's why the 1st re-send was harmless and the 3rd landed. `opponent-turn-underway?` exists to compensate for exactly this scroll-out — but only the self-heal path used it.

**2. The briefs instructed the re-send.** *"Recovery: re-run `smart-end-turn` 2–3× ~3s apart"* was in three briefs and the runbook. `logs/commands.log` shows the Runner complying precisely — bursts of 3, ~5s apart, at 12:42 / 12:47 / 12:57. The 12:57:09 and 12:57:14 sends landed during the Corp's turn. **The agent did what we told it to.**

## Fix
- Off-turn guard as the **first** branch of `end-turn!` and `smart-end-turn!`, keyed on `:active-player` (which doesn't scroll). First position in `smart-end-turn!` so its self-heal can never re-send into the opponent's turn.
- All "retry 2–3×" advice deleted from `seat-corp.md`, `seat-runner.md`, `seat-runner-devin.md`, `MARQUEE_RUNBOOK.md` — replaced with a prohibition and a default posture: **something weird / possibly broken / opponent possibly stuck ⇒ escalate to the umpire, never re-send.** Also removed the canned umpire reply telling seats to re-send, and the runbook line authorising the umpire to do it himself.

**Not changed:** `end-turn-self-heal-decision` already returns `:confirmed-ended` on `turn-advanced?`/`opponent-underway?`. An earlier diagnosis of mine blamed it; that was wrong, and the code was already correct.

## Tests
4 new, all asserting **nothing is transmitted**. A test asserting only on `:status` stays green on a client that still sends — which is the entire failure mode, and the same trap that let the #31 suite stay green through two fixes.

Red-proof: with the guard disabled, `end-turn!` transmits `{:command "end-turn"}` in the reconstructed turn-8 state. One test pins the precondition that the 3-entry log guard *is* blind there, so it keeps covering the real bug rather than drifting into a tautology.

510 tests, 0 failures (was 506).

## Still open (separate issues, not in this PR)
- `start-turn` gating a legal action on a log scan — wrong regardless of what emits the line
- `diagnose-blocker` recommending a command that refuses (shares no predicate with it)
- `monitor-run` showing `1 unbroken of 1` after the sub had fired — the *inverse* of the above, so "trust the log" is not the general fix; both want one source

🤖 Generated with [Claude Code](https://claude.com/claude-code)