### PR TITLE
fix(#105): install false-fails as timeout when its prompt wins the race

### DIFF
--- a/dev/src/clj/ai_card_actions.clj
+++ b/dev/src/clj/ai_card_actions.clj
@@ -70,14 +70,19 @@
                       gameid (:gameid client-state)
                       card-ref (core/create-card-ref card)
                       card-zone (:zone card)
-                      ;; Capture log size BEFORE sending to avoid race conditions
-                      initial-log-size (core/get-log-size)]
+                      ;; Capture log size AND prompt BEFORE sending to avoid race
+                      ;; conditions: a reply that beats verification would
+                      ;; otherwise become its own baseline (#105).
+                      initial-log-size (core/get-log-size)
+                      pre-prompt (state/get-prompt)]
                   (ws/send-message! :game/action
                                     {:gameid gameid
                                      :command "play"
                                      :args {:card card-ref}})
               ;; Wait and verify action - now returns status map
-              (let [result (core/verify-action-in-log card-title card-zone core/action-timeout initial-log-size)]
+              (let [result (core/verify-action-in-log card-title card-zone core/action-timeout
+                                                      {:pre-log-size initial-log-size
+                                                       :pre-prompt pre-prompt})]
                 (case (:status result)
                   :success
                   (let [after-state @state/client-state
@@ -209,14 +214,20 @@
         args (if normalized-server
                {:card card-ref :server normalized-server}
                {:card card-ref})
-        ;; Capture log size BEFORE sending to avoid race conditions
-        initial-log-size (core/get-log-size)]
+        ;; Capture log size AND prompt BEFORE sending to avoid race conditions.
+        ;; Installing ICE/assets/upgrades without a server opens a location
+        ;; prompt; if that reply beat verification, the prompt became its own
+        ;; baseline and a working install false-failed as a timeout (#105).
+        initial-log-size (core/get-log-size)
+        pre-prompt (state/get-prompt)]
     (ws/send-message! :game/action
                       {:gameid gameid
                        :command "play"
                        :args args})
     ;; Wait and verify action
-    (let [result (core/verify-action-in-log card-title card-zone core/action-timeout initial-log-size)]
+    (let [result (core/verify-action-in-log card-title card-zone core/action-timeout
+                                            {:pre-log-size initial-log-size
+                                             :pre-prompt pre-prompt})]
       (case (:status result)
         :success      (handle-install-success! card-title card-type normalized-server before-clicks before-credits card-cost side overwrite?)
         :waiting-input (handle-install-waiting! card-title (:prompt result))
@@ -753,15 +764,18 @@
                            :zone (:zone card)
                            :side (:side card)
                            :type (:type card)}
-                  ;; Capture log size BEFORE sending to avoid race conditions
-                  initial-log-size (core/get-log-size)]
+                  ;; Capture log size AND prompt BEFORE sending to avoid race conditions (#105)
+                  initial-log-size (core/get-log-size)
+                  pre-prompt (state/get-prompt)]
               (ws/send-message! :game/action
                                 {:gameid gameid
                                  :command "advance"
                                  :args {:card card-ref}})
               ;; Wait and verify action appeared in log
               ;; Note: Card doesn't change zones, so we pass its current zone
-              (let [result (core/verify-action-in-log card-name (:zone card) 3000 initial-log-size)]
+              (let [result (core/verify-action-in-log card-name (:zone card) 3000
+                                                      {:pre-log-size initial-log-size
+                                                       :pre-prompt pre-prompt})]
                 (if (= :success (:status result))
                   (let [after-state @state/client-state
                         updated-card (core/find-installed-corp-card card-name)
@@ -832,8 +846,9 @@
                 (let [gameid (:gameid client-state)
                       card-ref (core/create-card-ref card)
                       agenda-points (:agendapoints card)
-                      ;; Capture log size BEFORE sending to avoid race conditions
-                      initial-log-size (core/get-log-size)]
+                      ;; Capture log size AND prompt BEFORE sending to avoid race conditions (#105)
+                      initial-log-size (core/get-log-size)
+                      pre-prompt (state/get-prompt)]
                   (ws/send-message! :game/action
                                     {:gameid gameid
                                      :command "score"
@@ -842,7 +857,9 @@
                   ;; by the card name appearing in the log (which false-positives
                   ;; on prior scores / "cannot score" messages). Only a real
                   ;; increase in Corp agenda points means the agenda scored.
-                  (core/verify-action-in-log card-name (:zone card) core/action-timeout initial-log-size)
+                  (core/verify-action-in-log card-name (:zone card) core/action-timeout
+                                             {:pre-log-size initial-log-size
+                                              :pre-prompt pre-prompt})
                   (let [after-state @state/client-state
                         after-score (or (get-in after-state [:game-state :corp :agenda-point]) 0)
                         runner-score (or (get-in after-state [:game-state :runner :agenda-point]) 0)]

--- a/dev/src/clj/ai_core.clj
+++ b/dev/src/clj/ai_core.clj
@@ -294,81 +294,6 @@
     (when-let [match (re-find #"turn (\d+)" text)]
       (Integer/parseInt (second match)))))
 
-(defn verify-action-in-log
-  "Check if a card action appears in recent game log entries
-   Returns status map with:
-   - :status - :success (action completed), :waiting-input (prompt created), :error (failed)
-   - :prompt - the prompt that was created (if :waiting-input)
-   - :card-name - the card name being verified
-
-   Distinguishes between:
-   - Action completed: Card moved zones, log entry added, state changed
-   - Action waiting for input: Only prompt created, card still in hand
-   - Action failed: Nothing happened
-
-   Waits up to max-wait-ms for the log entry to appear
-
-   IMPORTANT: Pass initial-log-size captured BEFORE sending the action message
-   to avoid race conditions with fast WebSocket responses."
-  ([card-name card-initial-zone max-wait-ms]
-   (verify-action-in-log card-name card-initial-zone max-wait-ms nil))
-  ([card-name card-initial-zone max-wait-ms initial-log-size]
-  (let [initial-size (or initial-log-size (get-log-size))
-        initial-prompt (state/get-prompt)
-        deadline (+ (System/currentTimeMillis) max-wait-ms)
-        check-result (fn []
-                      (let [client-state @state/client-state
-                            log (get-in client-state [:game-state :log])
-                            current-size (count log)
-                            current-prompt (state/get-prompt)
-                            ;; Check if card is still in original zone (hand)
-                            side (keyword (:side client-state))
-                            hand (get-in client-state [:game-state side :hand])
-                            card-still-in-hand (some #(and (= (:title %) card-name)
-                                                           (= (:zone %) card-initial-zone))
-                                                    hand)
-                            ;; Check if new prompt was created
-                            new-prompt-created (and current-prompt
-                                                   (not= current-prompt initial-prompt))
-                            ;; Check if log entry mentions the card
-                            card-in-log (let [recent-log (take-last 5 log)]
-                                         (some #(when (string? (:text %))
-                                                 (str/includes? (:text %) card-name))
-                                              recent-log))]
-
-                        (cond
-                          ;; If card moved from hand AND log grew, it's a success
-                          (and (not card-still-in-hand)
-                               (or (> current-size initial-size)
-                                   card-in-log))
-                          {:status :success}
-
-                          ;; If card is STILL in hand but new prompt created, it's waiting for input
-                          (and card-still-in-hand new-prompt-created)
-                          {:status :waiting-input
-                           :prompt current-prompt
-                           :card-name card-name}
-
-                          ;; If log grew or card appears in log (even without zone change), might be success
-                          ;; (for Corp hidden cards where card name doesn't show)
-                          (or (> current-size initial-size) card-in-log)
-                          {:status :success}
-
-                          ;; Otherwise, no change yet
-                          :else
-                          nil)))]
-    ;; Poll until we get a result or timeout
-    (loop []
-      (if-let [result (check-result)]
-        result
-        (if (< (System/currentTimeMillis) deadline)
-          (do
-            (Thread/sleep polling-delay)
-            (recur))
-          {:status :error
-           :reason "Action not confirmed in game log (timeout)"
-           :card-name card-name}))))))
-
 (defn new-prompt?
   "Did a genuinely NEW prompt (a new decision point) appear, given the prompt
    seen before the action (`initial`) and the prompt seen now (`current`)?
@@ -388,6 +313,113 @@
     (and current
          (or (not= (:eid current) (:eid initial))
              (not= current initial)))))
+
+(defn classify-action-result
+  "Pure classifier for card-action verification. Given the prompt/log/hand seen
+   before the action and the current ones, decide the outcome. Returns a status
+   map (:success / :waiting-input) or nil if nothing has changed yet (keep
+   polling). Extracted from verify-action-in-log so the prompt-baseline logic is
+   unit-testable without the live atom or wall clock."
+  [card-name card-initial-zone
+   {:keys [initial-prompt current-prompt initial-size current-log hand]}]
+  (let [current-size (count current-log)
+        ;; Is the card still sitting in the zone it started in (i.e. hand)?
+        card-still-in-hand (some #(and (= (:title %) card-name)
+                                       (= (:zone %) card-initial-zone))
+                                 hand)
+        card-in-log (let [recent-log (take-last 5 current-log)]
+                      (some #(when (string? (:text %))
+                               (str/includes? (:text %) card-name))
+                            recent-log))]
+    (cond
+      ;; If card moved from hand AND log grew, it's a success
+      (and (not card-still-in-hand)
+           (or (> current-size initial-size)
+               card-in-log))
+      {:status :success}
+
+      ;; If card is STILL in hand but a new prompt appeared, it's waiting for
+      ;; input. This MUST be checked before the bare log-grew heuristic below:
+      ;; the click-spend line can land while the location prompt is still open,
+      ;; and reporting :success there is a false "installed".
+      (and card-still-in-hand (new-prompt? initial-prompt current-prompt))
+      {:status :waiting-input
+       :prompt current-prompt
+       :card-name card-name}
+
+      ;; If log grew or card appears in log (even without zone change), might be success
+      ;; (for Corp hidden cards where card name doesn't show)
+      (or (> current-size initial-size) card-in-log)
+      {:status :success}
+
+      ;; Otherwise, no change yet
+      :else
+      nil)))
+
+(defn verify-action-in-log
+  "Check if a card action appears in recent game log entries
+   Returns status map with:
+   - :status - :success (action completed), :waiting-input (prompt created), :error (failed)
+   - :prompt - the prompt that was created (if :waiting-input)
+   - :card-name - the card name being verified
+
+   Distinguishes between:
+   - Action completed: Card moved zones, log entry added, state changed
+   - Action waiting for input: Only prompt created, card still in hand
+   - Action failed: Nothing happened
+
+   Waits up to max-wait-ms for the log entry to appear
+
+   IMPORTANT: Pass pre-log-size AND pre-prompt captured BEFORE sending the
+   action message to avoid race conditions with fast WebSocket responses.
+
+   The 4th argument used to be a bare initial-log-size integer. That legacy
+   shape is still accepted (this var is re-exported by ai-actions and is
+   reachable from `eval`), and is normalized to {:pre-log-size <n>}."
+  ([card-name card-initial-zone max-wait-ms]
+   (verify-action-in-log card-name card-initial-zone max-wait-ms {}))
+  ([card-name card-initial-zone max-wait-ms opts]
+  (let [;; Normalize the legacy positional initial-log-size. This must happen
+        ;; BEFORE the contains? check below: contains? THROWS on a
+        ;; non-associative argument (it does NOT return false the way `get`
+        ;; returns nil), so an un-normalized integer would blow up rather than
+        ;; degrade. (Guest review, GPT-5.6.)
+        opts (if (map? opts) opts {:pre-log-size opts})
+        {:keys [pre-log-size pre-prompt]} opts
+        initial-size (or pre-log-size (get-log-size))
+        ;; A nil pre-prompt is MEANINGFUL: "no prompt was open when the command
+        ;; was sent". Reading the baseline here instead (i.e. AFTER the send)
+        ;; meant that whenever the WebSocket reply beat the start of
+        ;; verification, the freshly-opened prompt WAS the baseline -- it
+        ;; compared equal to itself forever, the waiting-input branch could
+        ;; never fire, and a perfectly good install false-failed as a timeout
+        ;; (#105; same trap as #97 one function over). Only fall back to a live
+        ;; read when the caller genuinely didn't supply the key.
+        initial-prompt (if (contains? opts :pre-prompt)
+                         pre-prompt
+                         (state/get-prompt))
+        deadline (+ (System/currentTimeMillis) max-wait-ms)
+        check-result (fn []
+                       (let [client-state @state/client-state
+                             side (keyword (:side client-state))]
+                         (classify-action-result
+                           card-name card-initial-zone
+                           {:initial-prompt initial-prompt
+                            :current-prompt (state/get-prompt)
+                            :initial-size initial-size
+                            :current-log (get-in client-state [:game-state :log])
+                            :hand (get-in client-state [:game-state side :hand])})))]
+    ;; Poll until we get a result or timeout
+    (loop []
+      (if-let [result (check-result)]
+        result
+        (if (< (System/currentTimeMillis) deadline)
+          (do
+            (Thread/sleep polling-delay)
+            (recur))
+          {:status :error
+           :reason "Action not confirmed in game log (timeout)"
+           :card-name card-name}))))))
 
 (defn classify-ability-result
   "Pure classifier for ability verification. Given the prompt/log seen before

--- a/dev/test/ai_pure_functions_test.clj
+++ b/dev/test/ai_pure_functions_test.clj
@@ -841,6 +841,148 @@
                    :initial-size 2 :current-log [{:text "a"} {:text "b"}]}))))))
 
 ;; ============================================================================
+;; classify-action-result / verify-action-in-log prompt baseline (issue #105)
+;;
+;; install! reported "❌ Failed to install: Karunā / Action not confirmed in
+;; game log (timeout)" while printing, in the same breath, the very prompt the
+;; install had just successfully opened. Reproduced 3 times in 4 installs on a
+;; fresh game -- a RACE, which is worse than a hard bug because the same
+;; command teaches a seat two different lessons about what its output means.
+;;
+;; Cause: the caller captured initial-LOG-SIZE before sending, but the PROMPT
+;; baseline was read inside verify-action-in-log, i.e. AFTER the send. When the
+;; WebSocket reply beat the start of verification, the freshly-opened prompt WAS
+;; the baseline, compared equal to itself forever, and the "new prompt created"
+;; branch could never fire -> poll to timeout -> :error.
+;;
+;; This is the same defect, one function over, as #97 (verify-ABILITY-in-log):
+;; the meaningful-nil `or`-fallback trap. verify-action-in-log never got the fix.
+;; ============================================================================
+
+(defn- install-prompt
+  "The location prompt a Corp install opens (ICE/asset/upgrade = the common case)."
+  [eid card-name]
+  {:eid {:eid eid}
+   :msg (str "Choose a location to install " card-name)
+   :prompt-type "select"
+   :choices [{:value "HQ"} {:value "R&D"} {:value "New remote"}]})
+
+(deftest test-classify-action-result-install-opens-prompt
+  (testing "card still in hand + a genuinely new prompt -> waiting-input, not error"
+    (let [p (install-prompt 200 "Karunā")
+          r (core/classify-action-result "Karunā" ["hand"]
+              {:initial-prompt nil :current-prompt p
+               :initial-size 3
+               :current-log [{:text "a"} {:text "b"} {:text "c"}]
+               :hand [{:title "Karunā" :zone ["hand"]}]})]
+      (is (= :waiting-input (:status r)))
+      (is (= p (:prompt r)))
+      (is (= "Karunā" (:card-name r)))))
+
+  (testing "stale leftover prompt of the SAME shape must still read as new (eid)"
+    ;; Install Palisade, choose a server, install Palisade again: prompt-state
+    ;; isn't cleared on resolve, so the leftover is byte-identical to the
+    ;; re-opened one. Structural inequality alone misses it.
+    (let [stale   (install-prompt 100 "Palisade")
+          re-open (install-prompt 300 "Palisade")
+          r (core/classify-action-result "Palisade" ["hand"]
+              {:initial-prompt stale :current-prompt re-open
+               :initial-size 3
+               :current-log [{:text "a"} {:text "b"} {:text "c"}]
+               :hand [{:title "Palisade" :zone ["hand"]}]})]
+      (is (= :waiting-input (:status r)))
+      (is (= re-open (:prompt r)))))
+
+  (testing "card left hand and log grew -> success (unchanged)"
+    (is (= {:status :success}
+           (core/classify-action-result "Hedge Fund" ["hand"]
+             {:initial-prompt nil :current-prompt nil
+              :initial-size 3
+              :current-log [{:text "a"} {:text "b"} {:text "c"}
+                            {:text "ai-corp plays Hedge Fund."}]
+              :hand []}))))
+
+  (testing "waiting-input wins over the bare log-grew heuristic"
+    ;; The click-spend line can land in the log while the location prompt is
+    ;; still open. Reporting :success there would be a false 'installed'.
+    (let [p (install-prompt 400 "Karunā")
+          r (core/classify-action-result "Karunā" ["hand"]
+              {:initial-prompt nil :current-prompt p
+               :initial-size 3
+               :current-log [{:text "a"} {:text "b"} {:text "c"}
+                             {:text "ai-corp spends [Click] to install a card."}]
+               :hand [{:title "Karunā" :zone ["hand"]}]})]
+      (is (= :waiting-input (:status r)))))
+
+  (testing "nothing happened yet -> nil (keep polling)"
+    (is (nil? (core/classify-action-result "Karunā" ["hand"]
+                {:initial-prompt nil :current-prompt nil
+                 :initial-size 3
+                 :current-log [{:text "a"} {:text "b"} {:text "c"}]
+                 :hand [{:title "Karunā" :zone ["hand"]}]})))))
+
+(deftest test-verify-action-in-log-prompt-arrives-before-verification
+  (testing "THE #105 RACE: prompt already in state when verification starts"
+    ;; Stage the losing side of the race: the WebSocket reply (prompt) has
+    ;; already landed, the card is still in hand, and the log has NOT grown.
+    ;; The caller captured pre-log-size AND pre-prompt (nil) before sending.
+    (let [p (install-prompt 200 "Karunā")
+          gs {:corp {:credit 5 :click 3
+                     :hand [{:title "Karunā" :zone ["hand"] :cid 1}]
+                     :prompt-state p}
+              :log [{:text "a"} {:text "b"} {:text "c"}]
+              :active-player "corp"}]
+      (with-mock-state (mock-client-state :side "corp" :game-state gs)
+        (let [r (core/verify-action-in-log "Karunā" ["hand"] 200
+                  {:pre-log-size 3 :pre-prompt nil})]
+          (is (= :waiting-input (:status r))
+              "install that opened a prompt must report :waiting-input, never a timeout :error")
+          (is (= p (:prompt r)))))))
+
+  (testing "a nil :pre-prompt is MEANINGFUL and must not trigger a live re-read"
+    ;; Same staging: if `(or pre-prompt (get-prompt))` re-reads, the baseline
+    ;; becomes the new prompt itself and this false-fails as a timeout.
+    (let [p (install-prompt 201 "Palisade")
+          gs {:corp {:credit 5 :click 3
+                     :hand [{:title "Palisade" :zone ["hand"] :cid 2}]
+                     :prompt-state p}
+              :log [{:text "a"}]
+              :active-player "corp"}]
+      (with-mock-state (mock-client-state :side "corp" :game-state gs)
+        (is (= :waiting-input
+               (:status (core/verify-action-in-log "Palisade" ["hand"] 200
+                          {:pre-log-size 1 :pre-prompt nil})))))))
+
+  (testing "legacy 4th-arg integer (bare initial-log-size) must not blow up"
+    ;; This var is re-exported by ai-actions and reachable from `eval`, so the
+    ;; old positional shape can still arrive. contains? THROWS on a
+    ;; non-associative arg -- it does NOT return false the way get returns nil
+    ;; -- so an un-normalized integer would be an IllegalArgumentException
+    ;; rather than a graceful degrade. (Guest review, GPT-5.6.)
+    (let [gs {:corp {:credit 5 :click 3
+                     :hand []
+                     :prompt-state nil}
+              :log [{:text "a"} {:text "b"} {:text "c"}
+                    {:text "ai-corp plays Hedge Fund."}]
+              :active-player "corp"}]
+      (with-mock-state (mock-client-state :side "corp" :game-state gs)
+        (is (= :success
+               (:status (core/verify-action-in-log "Hedge Fund" ["hand"] 200 3)))
+            "an integer 4th arg is normalized to {:pre-log-size n}, not thrown on"))))
+
+  (testing "genuinely nothing happened still times out as :error"
+    (let [gs {:corp {:credit 5 :click 3
+                     :hand [{:title "Karunā" :zone ["hand"] :cid 1}]
+                     :prompt-state nil}
+              :log [{:text "a"} {:text "b"} {:text "c"}]
+              :active-player "corp"}]
+      (with-mock-state (mock-client-state :side "corp" :game-state gs)
+        (let [r (core/verify-action-in-log "Karunā" ["hand"] 100
+                  {:pre-log-size 3 :pre-prompt nil})]
+          (is (= :error (:status r)))
+          (is (= "Karunā" (:card-name r))))))))
+
+;; ============================================================================
 ;; capture-state-snapshot / show-state-diff tests (ai-core)
 ;;
 ;; The before/after verification snapshot must read PUBLIC count fields for


### PR DESCRIPTION
Closes #105.

## The bug

`install "Karunā"` printed a hard failure and then, in the same output, printed the prompt it had just successfully opened:

```
❌ Failed to install: Karunā
   Reason: Action not confirmed in game log (timeout)
🔔 Current Prompt:
  Message: Choose a location to install Karunā
```

Reproduced 3 times in 4 installs on a fresh game. Michael characterized it as a race, which makes it worse than a hard bug — the same command teaches a seat two different lessons about what its own output means, so a seat either re-issues the install (now blocked by the open prompt) or abandons the card.

## Cause

Callers captured `initial-log-size` **before** sending, but the **prompt** baseline was read inside `verify-action-in-log` — i.e. **after** the send. When the WebSocket reply beat the start of verification, the freshly-opened prompt *was* the baseline, compared equal to itself forever, so `new-prompt-created` could never become true and the poll ran out to `:error`.

That's the same meaningful-nil `or`-fallback trap as #97, one function over: `verify-ability-in-log` was fixed then; `verify-action-in-log` never was. It's the common Corp case, since every ICE/asset/upgrade install opens a location prompt.

## Changes

- Extract pure `classify-action-result` from `verify-action-in-log`, mirroring the existing `classify-ability-result` split.
- `verify-action-in-log` takes an opts map (`{:pre-log-size :pre-prompt}`) like its already-fixed sibling; a supplied `nil` `:pre-prompt` is `contains?`-gated so it means "no prompt was open" rather than triggering a live re-read.
- Compare via eid-aware `new-prompt?` instead of raw `not=`, so a stale leftover prompt of the same shape still reads as a new decision.
- All four call sites (play / install / advance / score) capture `pre-prompt` before `send-message!`.
- `waiting-input` is now checked **before** the bare log-grew heuristic: the click-spend line can land while the location prompt is still open, and reporting `:success` there would be a false "installed".

## Guest review

Off-vendor panel seat (GPT-5.6) caught a MAJOR regression in the first cut **and corrected my reasoning**. I assumed a stale 4-arg integer caller would silently degrade because `(get 3 :x)` returns `nil` — but the guard is `contains?`, and `(contains? 3 :x)` *throws* `IllegalArgumentException`. Since this var is re-exported by the `ai-actions` facade and is reachable from `eval`, the legacy positional `initial-log-size` is now normalized to `{:pre-log-size n}` before the `contains?` check. Confirmed red (IllegalArgumentException) without the normalization.

## Tests

10 red→green assertions in `ai-pure-functions-test`: the pure classifier, the staged race through `verify-action-in-log`, and the legacy-arity guard.

Red was verified genuinely — reverting just the baseline fix gives 3 failures, `:error` where `:waiting-input` belongs:

```
expected: (= :waiting-input (:status r))
  actual: (not (= :waiting-input :error))
```

Suite: **625 tests / 1661 assertions, 0 failures** (was 623 / 1647).

Note: `make check` uses the running REPL, which is rooted in the main checkout — it does **not** verify worktree code. `lein test` is authoritative here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)