### PR TITLE
fix(#110): one continue verb, a real pay-all, and the R&D quoting trap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,13 @@ check-full:
 # Run unit tests
 test:
 	@echo "Running unit tests..."
-	lein test ai-actions-test ai-actions-sad-path-test ai-basic-actions-test ai-connection-test ai-heuristic-corp-test ai-heuristic-runner-test ai-runs-test ai-run-corp-decisions-test ai-stall-test ai-websocket-diff-test ai-websocket-error-recovery-test ai-display-test ai-state-test ai-prompts-test ai-pure-functions-test ai-turn-validation-test ai-wait-test continue-run-rez-test run-window-selfadvance-test game.ai-upgrade-rez-timing-test game.ai-duplicate-continue-test web.lobby-disconnect-test
+	lein test ai-actions-test ai-actions-sad-path-test ai-basic-actions-test ai-connection-test ai-heuristic-corp-test ai-heuristic-runner-test ai-runs-test ai-run-corp-decisions-test ai-stall-test ai-websocket-diff-test ai-websocket-error-recovery-test ai-display-test ai-state-test ai-prompts-test ai-pure-functions-test ai-turn-validation-test ai-wait-test continue-run-rez-test run-window-selfadvance-test game.ai-upgrade-rez-timing-test game.ai-duplicate-continue-test game.ai-pay-all-test web.lobby-disconnect-test
 
 # Run shell-level tests (fast, no REPL/server needed) — e.g. send_command output filters
 test-shell:
 	@echo "Running shell tests..."
 	@./dev/test/send_command_filter_test.sh
+	@./dev/test/send_command_help_test.sh
 	@./dev/test/ai_eval_charset_test.sh
 	@./dev/test/peer_status_test.sh
 

--- a/dev/instructions/runner_play_structure.md
+++ b/dev/instructions/runner_play_structure.md
@@ -251,6 +251,11 @@ When you encounter ICE, use `abilities "<breaker>"` to see available actions:
 
 **ALWAYS use the "Fully break" ability [2] when available** (unless you want some subs to fire).
 
+> **Quote `"R&D"`.** `&` is a shell metacharacter, so `run R&D` is split by the
+> shell before `send_command` ever sees it and you get `zsh: command not found: D`
+> — an error that names neither the command nor the server. `HQ` and `Archives`
+> need no quotes, but quoting every server name is the habit that never bites.
+
 ```bash
 ./dev/send_command runner run "R&D"
 ./dev/send_command runner continue                    # Approach ICE

--- a/dev/send_command
+++ b/dev/send_command
@@ -211,10 +211,12 @@ show_help_compact() {
   score <name>     Score an advanced agenda
   rez <name>       Rez ICE / asset / upgrade"
             role_running="${GREEN}Defending Runs:${NC}
-  monitor-run      Participate in the opponent's run (auto-pass priority
-                   windows, surface real Corp decisions). Required during
-                   runner runs — see 'help --full' for flags.
-  continue         Pass priority (e.g. decline to rez / fire)."
+  continue         Participate in the opponent's run: auto-pass priority
+                   windows, surface real Corp decisions, pass priority when you
+                   decline to rez / fire. Required during runner runs — see
+                   'help --full' for flags.
+  monitor-run      The SAME command under an older name. Both are accepted;
+                   'continue' is the one everything else refers to."
             role_examples="  ./send_command corp status
   ./send_command corp install \"Hedge Fund\" HQ
   ./send_command corp advance \"Project Atlas\"
@@ -225,7 +227,9 @@ show_help_compact() {
   play <name>      Play an event
   install <name>   Install a program / resource / hardware"
             role_running="${GREEN}Running:${NC}
-  run <server>     Start a run (HQ, R&D, Archives, remote1, etc.)
+  run <server>     Start a run (HQ, \"R&D\", Archives, remote1, etc.)
+                   QUOTE \"R&D\" — unquoted, the shell splits on & and you get
+                   'command not found: D' instead of a run.
   continue         Continue run / pass priority
   jack-out         Abort the run (movement window only — not mid-encounter)"
             role_examples="  ./send_command runner status
@@ -241,7 +245,9 @@ show_help_compact() {
   score <name>     Score agenda (Corp)
   rez <name>       Rez ICE/asset/upgrade (Corp)"
             role_running="${GREEN}Running:${NC}
-  run <server>     Runner: start a run (HQ, R&D, Archives, remote1, etc.)
+  run <server>     Runner: start a run (HQ, \"R&D\", Archives, remote1, etc.)
+                   QUOTE \"R&D\" — unquoted, the shell splits on & and you get
+                   'command not found: D' instead of a run.
   continue         Continue run / pass priority
   jack-out         Runner: abort the run (movement window only — not mid-encounter)
   monitor-run      Corp: participate in opponent's run (auto-pass priority
@@ -378,9 +384,20 @@ ${GREEN}Card Actions:${NC}
   score <name>    - Score agenda with sufficient advancement counters
 
 ${GREEN}Running:${NC}
-  run <server> [flags] - Run on server (HQ, "R&D", Archives, remote1, etc.)
+  run <server> [flags] - Run on server (HQ, "R&D", Archives, remote1, etc.).
+                         QUOTE "R&D": the & is a shell metacharacter, so an
+                         unquoted R&D never reaches this script — the shell
+                         splits it first and reports 'command not found: D'.
   let-subs-fire <name> - Signal intent to let ICE subroutines fire
-  continue [flags]     - Auto-continue until decision required
+  continue [flags]     - Auto-continue until decision required. This is THE verb
+                         for advancing a run and for passing priority; both seats
+                         use it. Prefer it over the two aliases below.
+  monitor-run [flags]  - Alias for 'continue'. Same command, kept because the Corp
+                         brief names it (participate in the opponent's run).
+  continue-run [flags] - Alias for 'continue --single': take exactly ONE step and
+                         return, instead of looping to the next decision. Only
+                         reach for this when you are debugging a run window and
+                         want to inspect state between steps.
   jack-out             - Jack out (LEGAL ONLY in a movement window you have not
                          passed: not at initiation, an approach, or an encounter)
   tank <ice-name>      - Authorize letting subs fire on ICE
@@ -391,6 +408,7 @@ ${GREEN}Running:${NC}
     --fire-unbroken  Corp: auto-fire unbroken subroutines
     --full-break     Runner: auto-break all ICE with available breakers
     --no-continue    Don't auto-continue after run start
+    --single         Take ONE step and return (what 'continue-run' is an alias for)
 
   ${BLUE}monitor-run Flags:${NC} (Corp)
     --fire-if-asked  Sleep mode: auto-fire, auto-continue, wake for rez/upgrade
@@ -406,8 +424,18 @@ ${GREEN}Prompts:${NC}
   choose-value <text> - Choose by matching text (e.g., "Yes", "Steal").
                         Also presses a SELECT prompt's meta-button, e.g.
                         choose-value "Done" to stop selecting cards.
-  choose-card <N> - Select card N from selectable cards
-  multi-choose <cards...> - Select MULTIPLE cards
+  choose-card <N> [--all] - Select card N from selectable cards.
+                        --all: on a "Choose a credit providing card (i of n
+                        [Credits])" prompt, keep taking credits from that source
+                        until the COST is met (or the source runs dry), in one
+                        call. It pays what is needed, not the card's whole
+                        balance — a 3-credit source covering a 1-credit cost
+                        keeps 2. Without it the prompt re-asks once per credit
+                        (5 calls to pay Overclock's 5). Inert on any other
+                        prompt.
+  multi-choose <cards...> - Select MULTIPLE cards. This is for picking several
+                        DIFFERENT cards (discard down to N). To pay a cost out
+                        of ONE source, use choose-card <N> --all.
 
 ${GREEN}Waiting / Synchronization:${NC}
   wait [seconds] [--since N] - Block until something you care about happens.
@@ -1058,10 +1086,23 @@ case "$COMMAND" in
 
     # Running
     run)
-        ensure_connection
         SERVER="${1:-}"
         shift
         [[ -z "$SERVER" ]] && error "Usage: send_command run <server> [--flags...]"
+
+        # #110 §3: `run R&D` unquoted is split by the SHELL before we are called.
+        # The shell backgrounds `... run R` and then tries to execute `D`, so the
+        # error the seat sees is `command not found: D` — naming neither the
+        # command nor the server. We can't stop the split, but we are the half of
+        # it that still runs, and "R" is not a server, so this is an unambiguous
+        # diagnosis rather than a guess.
+        if [[ "$SERVER" == "R" || "$SERVER" == "r" ]]; then
+            error "Bare 'R' is not a server — this is 'run R&D' with the quotes missing.
+       The shell split it on '&' before send_command saw it (and separately
+       reported 'command not found: D'). Retry with:  run \"R&D\""
+        fi
+
+        ensure_connection
 
         # Build flag arguments for varargs call
         FLAGS_ARGS=""
@@ -1215,10 +1256,24 @@ case "$COMMAND" in
     choose-card)
         ensure_connection
         INDEX="${1:-}"
-        [[ -z "$INDEX" ]] && error "Usage: send_command choose-card <index>"
+        [[ -z "$INDEX" ]] && error "Usage: send_command choose-card <index> [--all]"
         [[ ! "$INDEX" =~ ^[0-9]+$ ]] && error "Index must be a number"
-        info "Choosing card at index $INDEX..."
-        execute "(ai-actions/choose-card! $INDEX)"
+        shift
+        # --all is the seat's shift-click: on the engine's per-credit payment
+        # prompt it takes that source's FULL remaining amount in one call
+        # instead of one call per credit (#104, #110). Inert elsewhere.
+        PAY_ALL="false"
+        if [[ "${1:-}" == "--all" ]]; then
+            PAY_ALL="true"
+            shift
+        fi
+        [[ $# -gt 0 ]] && error "Unknown argument: $1 (usage: choose-card <index> [--all])"
+        if [[ "$PAY_ALL" == "true" ]]; then
+            info "Choosing card at index $INDEX (paying from it until the cost is met)..."
+        else
+            info "Choosing card at index $INDEX..."
+        fi
+        execute "(ai-actions/choose-card! $INDEX $PAY_ALL)"
         after_action
         ;;
 

--- a/dev/src/clj/ai_core.clj
+++ b/dev/src/clj/ai_core.clj
@@ -976,6 +976,30 @@
     (or (some #(when (:title %) %) matches)
         (first matches))))
 
+(def ^:private credit-payment-prompt-re
+  ;; game.core.pick-counters/pick-credit-providing-cards builds exactly:
+  ;;   "Choose a credit providing card (N of M [Credits])"
+  ;; with an optional ", X of Y stealth" clause before the closing paren. Anchor
+  ;; on BOTH the phrase and the bracketed count so an unrelated prompt that
+  ;; happens to say "credit" can't match.
+  #"(?i)credit providing card\s*\((\d+) of (\d+) \[Credits\]")
+
+(defn credit-payment-prompt
+  "Classify a prompt message as the engine's PER-CREDIT payment prompt.
+
+   This prompt re-asks once per credit: picking a source pays 1, then the engine
+   re-issues the same prompt with the count advanced (0 of 2 → 1 of 2 → …). Two
+   different models hit this as friction — 5 choose-card calls for Overclock
+   (#104), 2 for Unity (#110) — because nothing said how many calls were coming
+   or that one call could cover them all.
+
+   Returns {:paid N :target M :remaining (- M N)} on a match, else nil."
+  [msg]
+  (when-let [[_ paid target] (re-find credit-payment-prompt-re (str msg))]
+    (let [paid (Long/parseLong paid)
+          target (Long/parseLong target)]
+      {:paid paid :target target :remaining (max 0 (- target paid))})))
+
 (defn resolve-selectable
   "Resolve a prompt's :selectable list, separating cards this seat can actually
    pick from PHANTOM entries — CIDs absent from the seat's visible game state

--- a/dev/src/clj/ai_display.clj
+++ b/dev/src/clj/ai_display.clj
@@ -1542,10 +1542,29 @@
                                  (and is-discard? (pos? cards-to-discard)) cards-to-discard
                                  :else nil)]
             ;; Show multi-select warning if applicable
-            (if cards-required
+            (cond
+              cards-required
               (do
                 (println (str "  ⚠️  MULTI-SELECT: Choose " cards-required " card(s)"))
                 (println "     Use: multi-choose <card1> <card2> ... OR multi-choose 0 1 2 ..."))
+
+              ;; Per-credit payment prompt. It re-asks once per credit, and the
+              ;; count in the message is the ONLY hint that more calls are
+              ;; coming — which is why two models independently reported it as
+              ;; friction (#104 Overclock ×5, #110 Unity ×2). Say how many are
+              ;; owed and name the one-call form. This is NOT a multi-choose
+              ;; case: multi-choose re-selects DIFFERENT cards, whereas paying
+              ;; a cost out of ONE source is what --all does.
+              (core/credit-payment-prompt prompt-msg)
+              (let [{:keys [remaining]} (core/credit-payment-prompt prompt-msg)]
+                ;; "[Credits]" unpluralised — it's the game's credit icon (see
+                ;; ai-prompts/payment-progress).
+                (println (format "  💳 PAYMENT: %d [Credits] still owed. Each pick pays ONE credit."
+                                 remaining))
+                (println "     Use: choose-card <N> --all   (pay from that source until the cost is met)")
+                (println "     Or:  choose-card <N>         (one credit, prompt re-asks)"))
+
+              :else
               (println "  Selectable cards: (Use choose-card to select by index)"))
             ;; Render via the shared helper: pickable cards with their true
             ;; indices + a single warning line for phantom (unresolvable) CIDs,
@@ -2168,7 +2187,11 @@
       (:in-run? ts)
       (do
         (println (format "🏃 A run is in progress on %s." (or (:run-server ts) "?")))
-        (println "   → Use: monitor-run (or continue-run) to participate / advance it."))
+        ;; #110: this offered `continue-run` — the single-step alias — as a way to
+        ;; "advance" a run, which is both the undocumented verb and the wrong one
+        ;; for the job. Name `continue`; monitor-run stays because the Corp brief
+        ;; uses that name for the same command.
+        (println "   → Use: continue (Corp brief calls the same command monitor-run)."))
 
       ;; Turn boundary — my turn but not started (0 clicks).
       (and (:waiting-to-start? ts) (= next-lc (clojure.string/lower-case (or side ""))))

--- a/dev/src/clj/ai_prompts.clj
+++ b/dev/src/clj/ai_prompts.clj
@@ -279,100 +279,159 @@
         (println "   → Press by index instead with: choose <N>")
         (core/with-cursor {:status :error :reason "No matching choice"})))))
 
+(defn- payment-progress
+  "Report a per-credit payment step honestly, or nil if this wasn't one.
+
+   `before` is the (core/credit-payment-prompt …) reading taken BEFORE the
+   selection was sent; the current prompt supplies the after-reading. A payment
+   prompt that is GONE means the cost settled, so the remainder was paid.
+
+   Without this, a pay-all call that settled a 5-credit cost still printed
+   '📇 Selected card: Overclock (index 0)' — true but useless for deciding
+   whether another call is owed, which is exactly the question the per-credit
+   prompt leaves open (#104, #110)."
+  [before]
+  (when before
+    (let [after (core/credit-payment-prompt (:msg (state/get-prompt)))
+          ;; Is the prompt still the SAME cost, or has the engine moved on to a
+          ;; new one? An ability with two credit costs back to back shows a
+          ;; second "0 of N" prompt, and naively diffing the counters against a
+          ;; before-reading of "2 of 2" yields "Paid -2 [Credits]". Same cost
+          ;; requires the same target AND a counter that did not go backwards.
+          same-cost? (and after
+                          (= (:target after) (:target before))
+                          (>= (:paid after) (:paid before)))
+          ;; Not the same cost (or no payment prompt left) ⇒ the one we were on
+          ;; is finished, so everything that was outstanding on it got paid.
+          paid-now (if same-cost?
+                     (- (:paid after) (:paid before))
+                     (- (:target before) (:paid before)))
+          owed (if same-cost? (:remaining after) 0)]
+      ;; "[Credits]" is the game's credit ICON, not a word: the engine writes it
+      ;; unpluralised at every count ("1 [Credits] from bad publicity"), and the
+      ;; prompt we are echoing says "(0 of 2 [Credits])". Pluralising it to
+      ;; "[Credit]s" would emit a token the game never produces.
+      (str (format "💳 Paid %d [Credits]" paid-now)
+           (if (pos? owed)
+             (format " — %d [Credits] still owed; choose another source (add --all to pay from one source until the cost is met)." owed)
+             " — cost settled.")))))
+
 (defn choose-card!
   "Choose a card from selectable cards in current prompt by index.
    Used for select prompts like 'Send a Message' (choose card to trash).
 
-   Usage: (choose-card! 0)  ; Select first selectable card
-          (choose-card! 2)  ; Select third selectable card"
-  [index]
-  (let [client-state @state/client-state
-        side-str (:side client-state)
-        side (when side-str (keyword (clojure.string/lower-case side-str)))
-        prompt (get-in client-state [:game-state side :prompt-state])
-        selectable (:selectable prompt)
-        eid (:eid prompt)]
-    (cond
-      ;; choose-card resolves a card-targeting prompt. The canonical wire type is
-      ;; "select", but some engine prompts (e.g. Mutual Favor's stack search) carry
-      ;; :selectable cards under a different :prompt-type ("other"). Gate on the
-      ;; PRESENCE of selectable cards, not the type string, so choose-card works
-      ;; wherever there are cards to pick — and steer text-choice prompts to
-      ;; `choose` rather than the misleading "No select prompt active". (backlog #3)
-      (empty? selectable)
-      (do
-        (if (and prompt (seq (:choices prompt)))
-          (do (println "❌ This prompt has text choices, not selectable cards.")
-              (println "   → Use: choose <N>  (or choose-value \"<text>\")"))
-          (println "❌ No selectable cards in current prompt"))
-        (when prompt
-          (println (format "   Current prompt type: %s" (:prompt-type prompt))))
-        (core/with-cursor {:status :error :reason "No selectable cards"}))
+   Usage: (choose-card! 0)        ; Select first selectable card
+          (choose-card! 2)        ; Select third selectable card
+          (choose-card! 0 true)   ; PAY-ALL: take every remaining credit from
+                                  ; this source in one call
 
-      (not (< -1 index (count selectable)))
-      (do
-        (println (format "❌ Invalid index: %d (only %d selectable cards, use 0-%d)"
-                        index (count selectable) (dec (count selectable))))
-        (core/with-cursor {:status :error :reason "Invalid index"}))
+   `pay-all?` is the seat's version of the human UI's shift-click. On the
+   engine's per-credit payment prompt it keeps taking credits from the chosen
+   source until the COST is met, so one call replaces one-call-per-credit
+   (#104 Overclock ×5, #110 Unity ×2). It pays what is needed, not the card's
+   whole balance — pick-credit-providing-cards exits at
+   (<= target-count counter-count), so a richer source keeps the difference
+   (pinned by game.ai-pay-all-test). It is
+   inert on every other prompt — only pick-credit-providing-cards reads the
+   flag — so passing it where it does nothing costs a redundant selection, not a
+   wrong one."
+  ([index] (choose-card! index false))
+  ([index pay-all?]
+   (let [client-state @state/client-state
+         side-str (:side client-state)
+         side (when side-str (keyword (clojure.string/lower-case side-str)))
+         prompt (get-in client-state [:game-state side :prompt-state])
+         selectable (:selectable prompt)
+         eid (:eid prompt)]
+     (cond
+       ;; choose-card resolves a card-targeting prompt. The canonical wire type is
+       ;; "select", but some engine prompts (e.g. Mutual Favor's stack search) carry
+       ;; :selectable cards under a different :prompt-type ("other"). Gate on the
+       ;; PRESENCE of selectable cards, not the type string, so choose-card works
+       ;; wherever there are cards to pick — and steer text-choice prompts to
+       ;; `choose` rather than the misleading "No select prompt active". (backlog #3)
+       (empty? selectable)
+       (do
+         (if (and prompt (seq (:choices prompt)))
+           (do (println "❌ This prompt has text choices, not selectable cards.")
+               (println "   → Use: choose <N>  (or choose-value \"<text>\")"))
+           (println "❌ No selectable cards in current prompt"))
+         (when prompt
+           (println (format "   Current prompt type: %s" (:prompt-type prompt))))
+         (core/with-cursor {:status :error :reason "No selectable cards"}))
 
-      :else
-      (let [cid-or-card (nth selectable index)
-            ;; Selectable can be CID strings or card maps - resolve CIDs to cards.
-            ;; Use the selectable-aware resolver so a FACE-DOWN card at a breach
-            ;; (title-less in the Runner's view) still resolves — the title-gated
-            ;; find-card-by-cid dropped it and wedged multi-card remote breaches. (#70)
-            card (if (string? cid-or-card)
-                   (core/find-selectable-card-by-cid cid-or-card)
-                   cid-or-card)]
-        ;; Card-shape guard mirrors resolve-selectable: a real pick has :title OR
-        ;; :zone. This keeps a raw junk map that the engine might drop directly
-        ;; into :selectable from reaching select-card! by index. (#70 review)
-        (if (and (map? card) (or (:title card) (:zone card)))
-          ;; Don't claim success before the prompt confirms registration: print
-          ;; the confirmation only AFTER the prompt moves. A non-select prompt
-          ;; that doesn't move means choose-card was the WRONG verb (the engine
-          ;; wanted a text choice) — error + steer to `choose`, instead of the
-          ;; old "📇 Selecting card …" + spurious :success on a stall. (issue #40)
-          (let [select? (state/select-prompt-type? (:prompt-type prompt))]
-            (ws/select-card! card eid)
-            (cond
-              ;; Prompt moved → selection registered and resolved. Only here is it
-              ;; safe to run the auto-end-turn hook (a partial multi-select leaves
-              ;; the prompt put — see the select? branch). (#18 tail)
-              (wait-for-prompt-change! eid :old-msg (:msg prompt))
-              (do
-                (println (format "📇 Selected card: %s (index %d)" (:title card) index))
-                (maybe-auto-end-turn-after-prompt!)
-                (core/with-cursor {:status :success :card card}))
+       (not (< -1 index (count selectable)))
+       (do
+         (println (format "❌ Invalid index: %d (only %d selectable cards, use 0-%d)"
+                          index (count selectable) (dec (count selectable))))
+         (core/with-cursor {:status :error :reason "Invalid index"}))
 
-              ;; Unchanged but a genuine multi-select toggle (discard-to-N): the
-              ;; server accumulates selections to :max and only then resolves.
-              ;; wait-for-prompt-change! already printed the multi-choose tip.
-              select?
-              (do
-                (println (format "📇 Toggled card: %s (index %d) — more selections needed"
-                                (:title card) index))
-                (core/with-cursor {:status :success :card card}))
+       :else
+       (let [cid-or-card (nth selectable index)
+             ;; Selectable can be CID strings or card maps - resolve CIDs to cards.
+             ;; Use the selectable-aware resolver so a FACE-DOWN card at a breach
+             ;; (title-less in the Runner's view) still resolves — the title-gated
+             ;; find-card-by-cid dropped it and wedged multi-card remote breaches. (#70)
+             card (if (string? cid-or-card)
+                    (core/find-selectable-card-by-cid cid-or-card)
+                    cid-or-card)]
+         ;; Card-shape guard mirrors resolve-selectable: a real pick has :title OR
+         ;; :zone. This keeps a raw junk map that the engine might drop directly
+         ;; into :selectable from reaching select-card! by index. (#70 review)
+         (if (and (map? card) (or (:title card) (:zone card)))
+           ;; Don't claim success before the prompt confirms registration: print
+           ;; the confirmation only AFTER the prompt moves. A non-select prompt
+           ;; that doesn't move means choose-card was the WRONG verb (the engine
+           ;; wanted a text choice) — error + steer to `choose`, instead of the
+           ;; old "📇 Selecting card …" + spurious :success on a stall. (issue #40)
+           (let [select? (state/select-prompt-type? (:prompt-type prompt))
+                 ;; Captured BEFORE the send: the success branch diffs it against
+                 ;; the post-send prompt to report credits actually paid.
+                 pay-before (core/credit-payment-prompt (:msg prompt))]
+             (ws/select-card! card eid pay-all?)
+             (cond
+               ;; Prompt moved → selection registered and resolved. Only here is it
+               ;; safe to run the auto-end-turn hook (a partial multi-select leaves
+               ;; the prompt put — see the select? branch). (#18 tail)
+               (wait-for-prompt-change! eid :old-msg (:msg prompt))
+               (do
+                 ;; On a payment prompt "Selected card: X" understates what
+                 ;; happened — with pay-all? one call can settle the whole cost.
+                 ;; Report the credits, and say plainly whether more are owed.
+                 (if-let [paid (payment-progress pay-before)]
+                   (println paid)
+                   (println (format "📇 Selected card: %s (index %d)" (:title card) index)))
+                 (maybe-auto-end-turn-after-prompt!)
+                 (core/with-cursor {:status :success :card card}))
 
-              ;; Unchanged on a NON-select prompt: choose-card is the wrong verb
-              ;; here (this prompt resolves by text choice). (issue #40)
-              :else
-              (do
-                (println (format "↪️  choose-card %d did not register — this prompt isn't a card-select."
-                                index))
-                (if (seq (:choices prompt))
-                  (println "   → It's a numbered CHOICE prompt. Use:  choose <N>")
-                  (println "   → Use 'prompt' to inspect, then choose / choose-value."))
-                (core/with-cursor {:status :error
-                                   :reason "Not a card-select prompt — use choose"}))))
-          (let [{:keys [pickable]} (core/resolve-selectable selectable)
-                pickable-idxs (map :idx pickable)]
-            (println (format "❌ Index %d isn't a card you can select — it's hidden/opponent (not in your view)." index))
-            (if (seq pickable-idxs)
-              (println (format "   Selectable indices: %s. Use 'prompt' to see them by name."
-                              (clojure.string/join ", " pickable-idxs)))
-              (println "   No selectable cards resolve from this seat — use 'prompt' / choose-value for meta-options."))
-            (core/with-cursor {:status :error :reason "Card resolution failed"})))))))
+               ;; Unchanged but a genuine multi-select toggle (discard-to-N): the
+               ;; server accumulates selections to :max and only then resolves.
+               ;; wait-for-prompt-change! already printed the multi-choose tip.
+               select?
+               (do
+                 (println (format "📇 Toggled card: %s (index %d) — more selections needed"
+                                  (:title card) index))
+                 (core/with-cursor {:status :success :card card}))
+
+               ;; Unchanged on a NON-select prompt: choose-card is the wrong verb
+               ;; here (this prompt resolves by text choice). (issue #40)
+               :else
+               (do
+                 (println (format "↪️  choose-card %d did not register — this prompt isn't a card-select."
+                                  index))
+                 (if (seq (:choices prompt))
+                   (println "   → It's a numbered CHOICE prompt. Use:  choose <N>")
+                   (println "   → Use 'prompt' to inspect, then choose / choose-value."))
+                 (core/with-cursor {:status :error
+                                    :reason "Not a card-select prompt — use choose"}))))
+           (let [{:keys [pickable]} (core/resolve-selectable selectable)
+                 pickable-idxs (map :idx pickable)]
+             (println (format "❌ Index %d isn't a card you can select — it's hidden/opponent (not in your view)." index))
+             (if (seq pickable-idxs)
+               (println (format "   Selectable indices: %s. Use 'prompt' to see them by name."
+                                (clojure.string/join ", " pickable-idxs)))
+               (println "   No selectable cards resolve from this seat — use 'prompt' / choose-value for meta-options."))
+             (core/with-cursor {:status :error :reason "Card resolution failed"}))))))))
 
 (defn- find-card-in-selectable
   "Find a card in the selectable list by name (case-insensitive substring match).

--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -1445,11 +1445,22 @@
     (swap! reported-events update :events conj (event-key event))
     (println (format "⚠️  Run paused - %s" headline))
     (println (format "   %s" (:text event)))
-    ;; #104: the continue-run hint is the Runner's verb; on the Corp side it
-    ;; pointed at a command the seat doesn't drive the run with.
-    (println (if (core/side= "Corp" (or side ""))
-               "   → Resume with 'monitor-run' (or 'continue' to pass priority)"
-               "   → Use 'continue-run' again to proceed"))
+    ;; #110: ONE verb, and it is `continue`.
+    ;;
+    ;; The history here is a defect that kept moving instead of leaving. #104
+    ;; made this hint side-flavoured: the Runner arm named `continue-run` (the
+    ;; single-step alias, undocumented) and the Corp arm named `monitor-run`
+    ;; "(or 'continue')". Both arms then disagreed with the prompt block printed
+    ;; two lines later, which says `continue` — and a Luna seat, handed two verbs
+    ;; for one act in a single output, reached for the undocumented one.
+    ;;
+    ;; The side split was never load-bearing: `continue`, `monitor-run` and
+    ;; `continue-run` all dispatch into the same run handler (send_command's
+    ;; `continue` and `monitor-run` branches are byte-identical; `continue-run`
+    ;; is `continue --single`). Offering a seat a choice between aliases of one
+    ;; command is the ambiguity, not a service to it. The aliases stay reachable
+    ;; and are now documented in `help --full`; runtime guidance names one.
+    (println "   → Use 'continue' again to proceed")
     {:status status :wake-reason status :event event}))
 
 (defn handle-unexpected-state

--- a/dev/src/clj/ai_websocket_client_v2.clj
+++ b/dev/src/clj/ai_websocket_client_v2.clj
@@ -542,15 +542,31 @@
 (defn select-card!
   "Select a card for prompts like discard.
    Takes a card object and prompt eid.
-   Card should have :cid, :zone, :side, :type fields."
-  [card eid]
-  (safe-action! "select"
-                {:card {:cid (:cid card)
-                        :zone (:zone card)
-                        :side (:side card)
-                        :type (:type card)}
-                 :eid eid
-                 :shift-key-held false}))
+   Card should have :cid, :zone, :side, :type fields.
+
+   `shift-key-held` mirrors the human UI's shift-click (board.cljs
+   `handle-card-click`). The engine stores it at [side :shift-key-select]
+   (game.core.actions/select) and ONE consumer reads it:
+   pick-credit-providing-cards' `should-auto-repeat?`, which keeps taking
+   credits from the SAME card until the cost is met instead of re-prompting per
+   credit. Its own comment: \"taking 5cr from miss bones with one click, instead
+   of waiting for 5 server round-trips\".
+
+   We hardcoded false here, so seats had no way to do what a human does in one
+   click — 5 separate choose-card calls for Overclock (#104), 2 for Unity
+   (#110). Nothing else in the engine reads the flag, so on a non-payment
+   prompt (a discard select) it is inert; and because `select` re-stamps the key
+   on EVERY selection, a later plain choose-card resets it to false. Default
+   stays false so existing callers are unchanged."
+  ([card eid] (select-card! card eid false))
+  ([card eid shift-key-held]
+   (safe-action! "select"
+                 {:card {:cid (:cid card)
+                         :zone (:zone card)
+                         :side (:side card)
+                         :type (:type card)}
+                  :eid eid
+                  :shift-key-held (boolean shift-key-held)})))
 
 (defn handle-discard-prompt!
   "Handle discard down to hand size prompt.

--- a/dev/test/ai_display_test.clj
+++ b/dev/test/ai_display_test.clj
@@ -1780,3 +1780,52 @@
             "fixture sanity: this state is the one #93 calls GAME-GONE")
         (is (false? (:in-game? (ai-state/get-turn-status)))
             "a GAME-GONE state is not a game we are in")))))
+
+;; ============================================================================
+;; Per-credit payment prompts (#110 §2, corroborating #104)
+;;
+;; "Choose a credit providing card (0 of 5 [Credits])" re-asks once per credit.
+;; The count in the message was the ONLY signal that four more calls were
+;; coming, and nothing named the one-call form — so a Fable seat spent 5 calls
+;; on Overclock and a Luna seat 2 on Unity, each reporting it as friction.
+;; ============================================================================
+
+(defn- payment-prompt-output [msg]
+  (with-mock-state
+    (mock-client-state
+     :side "runner"
+     :game-state {:active-player "runner" :turn 5
+                  :runner {:hand []
+                           :prompt-state {:prompt-type "select"
+                                          :eid "pay-1"
+                                          :msg msg
+                                          :selectable [{:cid "c1" :title "Overclock"}]}}
+                  :corp {:hand []}})
+    (with-out-str (display/show-prompt-detailed))))
+
+(deftest show-prompt-detailed-explains-per-credit-payment
+  (testing "the prompt states how many credits are still owed and names --all"
+    (let [out (payment-prompt-output "Choose a credit providing card (0 of 5 [Credits])")]
+      (is (str/includes? out "5 [Credits] still owed")
+          (str "must say how many more picks are coming:\n" out))
+      (is (str/includes? out "--all")
+          (str "must name the one-call form:\n" out))
+      ;; multi-choose selects several DIFFERENT cards; it is not the verb for
+      ;; paying a cost out of one source, and steering there would waste a seat's
+      ;; turn the same way the silence did.
+      (is (not (str/includes? out "multi-choose"))
+          (str "must not steer a payment to the multi-select verb:\n" out))))
+
+  (testing "a partially-paid prompt counts the REMAINDER, not the target"
+    (let [out (payment-prompt-output "Choose a credit providing card (3 of 5 [Credits])")]
+      (is (str/includes? out "2 [Credits] still owed")
+          (str "owed is target minus paid:\n" out))))
+
+  (testing "an ordinary select is untouched — payment advice must not leak"
+    (let [out (payment-prompt-output "Choose a card to trash")]
+      (is (str/includes? out "Selectable cards")
+          (str "normal prompts keep the plain header:\n" out))
+      (is (not (str/includes? out "--all"))
+          (str "--all does nothing here and must not be advertised:\n" out))
+      (is (not (str/includes? out "still owed"))
+          (str "no payment line on a non-payment prompt:\n" out)))))

--- a/dev/test/ai_prompts_test.clj
+++ b/dev/test/ai_prompts_test.clj
@@ -190,7 +190,7 @@
   (testing "choose-card on an 'other'-typed prompt WITH selectable cards selects, not rejects"
     (let [sent (atom nil)]
       (with-mock-state (mock-client-state :side "runner" :prompt other-typed-card-select-prompt)
-        (with-redefs [ws/select-card! (fn [card _eid] (reset! sent card) true)
+        (with-redefs [ws/select-card! (fn [card _eid & _] (reset! sent card) true)
                       prompts/wait-for-prompt-change! (fn [_eid & _] true)
                       basic/check-auto-end-turn! (fn [] nil)]
           (let [out (with-out-str
@@ -208,7 +208,7 @@
                         :side "runner"
                         :prompt {:prompt-type "choice" :eid "ch-1" :msg "Pick one"
                                  :choices [{:value "A"} {:value "B"}]})
-        (with-redefs [ws/select-card! (fn [_card _eid] (reset! sent :sent) true)]
+        (with-redefs [ws/select-card! (fn [_card _eid & _] (reset! sent :sent) true)]
           (let [out (with-out-str
                       (let [r (prompts/choose-card! 0)]
                         (is (= :error (:status r)))))]
@@ -220,7 +220,7 @@
   (testing "multi-choose on an 'other'-typed prompt WITH selectable cards selects, not rejects"
     (let [sent (atom [])]
       (with-mock-state (mock-client-state :side "runner" :prompt other-typed-card-select-prompt)
-        (with-redefs [ws/select-card! (fn [card _eid] (swap! sent conj (:title card)) true)
+        (with-redefs [ws/select-card! (fn [card _eid & _] (swap! sent conj (:title card)) true)
                       prompts/wait-for-prompt-change! (fn [_eid & _] true)]
           (let [out (with-out-str
                       (let [r (prompts/multi-choose! 0 1)]
@@ -249,7 +249,7 @@
                                :msg "Discard down to 5 cards"
                                :selectable [{:cid "c1" :title "Hedge Fund"}
                                             {:cid "c2" :title "IPO"}]})
-      (with-redefs [ws/select-card! (fn [_card _eid] true)
+      (with-redefs [ws/select-card! (fn [_card _eid & _] true)
                     ;; server toggled the cards but the prompt did not resolve
                     prompts/wait-for-prompt-change! (fn [_eid & _] false)]
         (let [out (with-out-str
@@ -269,7 +269,7 @@
                                :msg "Discard down to 5 cards"
                                :selectable [{:cid "c1" :title "Hedge Fund"}
                                             {:cid "c2" :title "IPO"}]})
-      (with-redefs [ws/select-card! (fn [_card _eid] true)
+      (with-redefs [ws/select-card! (fn [_card _eid & _] true)
                     prompts/wait-for-prompt-change! (fn [_eid & _] true)]
         (let [out (with-out-str
                     (let [r (prompts/multi-choose! 0 1)]
@@ -284,7 +284,7 @@
                                :msg "Choose an icebreaker"
                                :choices [{:value "Corroder"}]
                                :selectable [{:cid "c1" :title "Corroder"}]})
-      (with-redefs [ws/select-card! (fn [_card _eid] true)
+      (with-redefs [ws/select-card! (fn [_card _eid & _] true)
                     prompts/wait-for-prompt-change! (fn [_eid & _] false)]
         (let [out (with-out-str
                     (let [r (prompts/multi-choose! 0)]
@@ -312,7 +312,7 @@
                                         :msg "Click a card to access it."
                                         :selectable ["fd-1"]}}
                                      :active-player "runner"})
-        (with-redefs [ws/select-card! (fn [card _eid] (swap! sent conj (:cid card)) true)
+        (with-redefs [ws/select-card! (fn [card _eid & _] (swap! sent conj (:cid card)) true)
                       prompts/wait-for-prompt-change! (fn [_eid & _] true)]
           (let [out (with-out-str
                       (let [r (prompts/multi-choose! 0)]
@@ -349,7 +349,7 @@
                                  :msg "Discard down to 5 cards"
                                  :selectable [{:cid "c1" :title "Hedge Fund"}
                                               {:cid "c2" :title "IPO"}]})
-        (with-redefs [ws/select-card! (fn [_card _eid] true)
+        (with-redefs [ws/select-card! (fn [_card _eid & _] true)
                       ;; partial select: server toggles, prompt unchanged
                       prompts/wait-for-prompt-change! (fn [_eid & _] false)
                       basic/check-auto-end-turn! (fn [] (reset! auto-end-called? true))]
@@ -365,7 +365,7 @@
                         :prompt {:prompt-type "select" :eid "disc-1"
                                  :msg "Discard down to 5 cards"
                                  :selectable [{:cid "c1" :title "Hedge Fund"}]})
-        (with-redefs [ws/select-card! (fn [_card _eid] true)
+        (with-redefs [ws/select-card! (fn [_card _eid & _] true)
                       ;; final select reaches :max → prompt resolves/moves
                       prompts/wait-for-prompt-change! (fn [_eid & _] true)
                       basic/check-auto-end-turn! (fn [] (reset! auto-end-called? true))]
@@ -394,7 +394,7 @@
                                :choices [{:value "Unity"} {:value "Cleaver"}]
                                :selectable [{:cid "c1" :title "Unity"}
                                             {:cid "c2" :title "Cleaver"}]})
-      (with-redefs [ws/select-card! (fn [_card _eid] true)
+      (with-redefs [ws/select-card! (fn [_card _eid & _] true)
                     ;; engine wanted a text choice; the select never registered
                     prompts/wait-for-prompt-change! (fn [_eid & _] false)]
         (let [out (with-out-str
@@ -410,7 +410,7 @@
   (testing "choose-card prints the card confirmation only AFTER the prompt moves (#40)"
     (with-mock-state (mock-client-state
                       :side "runner" :prompt other-typed-card-select-prompt)
-      (with-redefs [ws/select-card! (fn [_card _eid] true)
+      (with-redefs [ws/select-card! (fn [_card _eid & _] true)
                     prompts/wait-for-prompt-change! (fn [_eid & _] true)
                     basic/check-auto-end-turn! (fn [] nil)]
         (let [out (with-out-str
@@ -662,3 +662,144 @@
             (is (= :success (:status @result)))
             (is (not (:duplicate-prompt @result))
                 "card-less prompts must not be identified by msg alone (nil cid = nil cid is not identity)")))))))
+
+;; ============================================================================
+;; Per-credit payment prompts: --all / pay-all? (#110 §2, corroborating #104)
+;;
+;; game.core.pick-counters/pick-credit-providing-cards re-asks once per credit,
+;; UNLESS the client sets :shift-key-held — which the engine stores at
+;; [side :shift-key-select] and reads back as `should-auto-repeat?`. Its own
+;; comment: "taking 5cr from miss bones with one click, instead of waiting for
+;; 5 server round-trips". board.cljs sends it on shift-click; our select-card!
+;; hardcoded false, so seats could not do what a human does in one click.
+;; ============================================================================
+
+(defn- capture-select-action
+  "Run `f` with the wire layer stubbed, returning the args of the 'select'
+   action it sent (or nil). Bypasses safe-action!'s connection check by
+   redefining send-action! — the payload shape is what we care about."
+  [f]
+  (let [sent (atom nil)]
+    (with-redefs [ws/ensure-connected! (constantly true)
+                  ws/send-action! (fn [command args]
+                                    (when (= "select" command) (reset! sent args))
+                                    true)]
+      (f))
+    @sent))
+
+(deftest select-card!-defaults-to-no-shift-and-opts-in
+  (testing "the default stays shift-less, so non-payment callers are unchanged"
+    (let [args (capture-select-action
+                #(ws/select-card! {:cid 7 :zone ["hand"] :side "Runner" :type "Event"}
+                                  {:eid 1}))]
+      (is (false? (:shift-key-held args))
+          (str "default select must not auto-repeat payments, got: " args))))
+
+  (testing "the opt-in reaches the wire — this is the whole fix; without the flag
+            the engine's should-auto-repeat? can never be true for a seat"
+    (let [args (capture-select-action
+                #(ws/select-card! {:cid 7 :zone ["hand"] :side "Runner" :type "Event"}
+                                  {:eid 1} true))]
+      (is (true? (:shift-key-held args))
+          (str "pay-all must set :shift-key-held, got: " args))))
+
+  (testing "a truthy non-boolean is normalised — the engine stores this value
+            verbatim, so a stray string would linger as a truthy shift state"
+    (let [args (capture-select-action
+                #(ws/select-card! {:cid 7 :zone ["hand"] :side "Runner" :type "Event"}
+                                  {:eid 1} "yes"))]
+      (is (true? (:shift-key-held args))))))
+
+(deftest choose-card!-plumbs-pay-all-to-the-wire
+  (let [prompt {:prompt-type "select"
+                :msg "Choose a credit providing card (0 of 2 [Credits])"
+                :eid {:eid 42}
+                :selectable [{:cid 7 :title "Overclock" :zone ["play-area"]
+                              :side "Runner" :type "Event"}]}
+        run-choose (fn [& args]
+                     (with-mock-state (mock-client-state :side "runner" :prompt prompt)
+                       (capture-select-action
+                        (fn []
+                          (with-redefs [prompts/wait-for-prompt-change! (constantly true)
+                                        basic/check-auto-end-turn! (fn [] nil)]
+                            (with-out-str (apply prompts/choose-card! args)))))))]
+    (testing "one-arg choose-card is unchanged (regression guard)"
+      (is (false? (:shift-key-held (run-choose 0)))))
+    (testing "choose-card <N> --all reaches the wire as a shift-click"
+      (is (true? (:shift-key-held (run-choose 0 true)))))))
+
+(deftest choose-card!-reports-credits-not-just-the-card-title
+  ;; The misleading-output class: "📇 Selected card: Overclock (index 0)" is true
+  ;; but does not answer the only question the per-credit prompt leaves open —
+  ;; is another call owed?
+  (let [prompt {:prompt-type "select"
+                :msg "Choose a credit providing card (0 of 5 [Credits])"
+                :eid {:eid 42}
+                :selectable [{:cid 7 :title "Overclock" :zone ["play-area"]
+                              :side "Runner" :type "Event"}]}
+        run-choose (fn [after-msg]
+                     (with-mock-state (mock-client-state :side "runner" :prompt prompt)
+                       (with-redefs [ws/ensure-connected! (constantly true)
+                                     ws/send-action! (constantly true)
+                                     basic/check-auto-end-turn! (fn [] nil)
+                                     prompts/wait-for-prompt-change!
+                                     (fn [_eid & _]
+                                       (swap! state/client-state assoc-in
+                                              [:game-state :runner :prompt-state]
+                                              (when after-msg (assoc prompt :msg after-msg)))
+                                       true)]
+                         (with-out-str (prompts/choose-card! 0 true)))))]
+    (testing "a settled cost says so, and reports the full amount paid"
+      (let [out (run-choose nil)]
+        (is (str/includes? out "Paid 5 [Credits]")
+            (str "must report credits actually paid, got: " out))
+        (is (str/includes? out "cost settled")
+            (str "a resolved payment must say no more calls are owed, got: " out))))
+
+    (testing "a partial payment names what is STILL owed rather than implying done"
+      (let [out (run-choose "Choose a credit providing card (2 of 5 [Credits])")]
+        (is (str/includes? out "Paid 2 [Credits]"))
+        (is (str/includes? out "3 [Credits] still owed")
+            (str "must state the remainder, got: " out))
+        (is (not (str/includes? out "cost settled"))
+            (str "an unfinished payment must not claim to be settled, got: " out))))
+
+    ;; "[Credits]" is the game's credit ICON and is never pluralised — the engine
+    ;; itself writes "1 [Credits] from bad publicity". Our output must not invent
+    ;; a "[Credit]s" token the game never emits.
+    ;; A cost chain (an ability with two credit costs) shows a SECOND "0 of N"
+    ;; prompt. Diffing counters naively against a "0 of 5" baseline would print
+    ;; "Paid -0"/a negative for a real payment; the same-cost? guard treats a
+    ;; reset counter as "the cost we were on is finished".
+    (testing "the prompt moving on to a DIFFERENT cost never prints a negative"
+      (let [out (run-choose "Choose a credit providing card (0 of 3 [Credits])")]
+        (is (str/includes? out "Paid 5 [Credits]")
+            (str "the finished cost is reported in full, got: " out))
+        (is (not (re-find #"Paid -\d" out))
+            (str "a new cost must not read as a negative payment, got: " out))))
+
+    (testing "a remainder of one still uses the game's unpluralised icon"
+      (let [out (run-choose "Choose a credit providing card (4 of 5 [Credits])")]
+        (is (str/includes? out "Paid 4 [Credits]"))
+        (is (str/includes? out "1 [Credits] still owed")
+            (str "must echo the game's own credit token, got: " out))
+        (is (not (str/includes? out "[Credit]s"))
+            (str "invented token, got: " out))))))
+
+(deftest choose-card!-keeps-the-card-line-on-non-payment-prompts
+  (testing "an ordinary select still reports the card — the payment line must not
+            leak onto prompts that aren't payments"
+    (let [prompt {:prompt-type "select"
+                  :msg "Choose a card to trash"
+                  :eid {:eid 42}
+                  :selectable [{:cid 7 :title "Palisade" :zone ["servers"]
+                                :side "Corp" :type "ICE"}]}
+          out (with-mock-state (mock-client-state :side "runner" :prompt prompt)
+                (with-redefs [ws/ensure-connected! (constantly true)
+                              ws/send-action! (constantly true)
+                              basic/check-auto-end-turn! (fn [] nil)
+                              prompts/wait-for-prompt-change! (constantly true)]
+                  (with-out-str (prompts/choose-card! 0))))]
+      (is (str/includes? out "Selected card: Palisade"))
+      (is (not (str/includes? out "Paid"))
+          (str "non-payment prompts must not print a payment line, got: " out)))))

--- a/dev/test/ai_pure_functions_test.clj
+++ b/dev/test/ai_pure_functions_test.clj
@@ -1096,3 +1096,42 @@
                "#104 complains about. Got: " out))
       (is (str/includes? out "can't see")
           (str "the entries still exist and still can't be picked. Got: " out)))))
+
+;; ============================================================================
+;; credit-payment-prompt — classify the engine's per-credit payment prompt
+;;
+;; Built by game.core.pick-counters/pick-credit-providing-cards. Both the
+;; display hint and choose-card!'s paid-credits report key off this, so a false
+;; positive would paste payment advice onto an unrelated prompt.
+;; ============================================================================
+
+(deftest credit-payment-prompt-reads-the-engine-message
+  (testing "the plain form yields paid / target / remaining"
+    (is (= {:paid 0 :target 2 :remaining 2}
+           (core/credit-payment-prompt
+            "Choose a credit providing card (0 of 2 [Credits])")))
+    (is (= {:paid 4 :target 5 :remaining 1}
+           (core/credit-payment-prompt
+            "Choose a credit providing card (4 of 5 [Credits])"))))
+
+  (testing "the stealth clause the engine may append doesn't break the match"
+    (is (= {:paid 1 :target 3 :remaining 2}
+           (core/credit-payment-prompt
+            "Choose a credit providing card (1 of 3 [Credits], 0 of 2 stealth)"))))
+
+  (testing "a fully-paid prompt reports nothing remaining, never a negative"
+    (is (= {:paid 5 :target 5 :remaining 0}
+           (core/credit-payment-prompt
+            "Choose a credit providing card (5 of 5 [Credits])")))))
+
+(deftest credit-payment-prompt-rejects-everything-else
+  (testing "prompts that merely mention credits or cards must not match —
+            a false positive prints '--all' advice where --all does nothing"
+    (are [msg] (nil? (core/credit-payment-prompt msg))
+      "Choose a card to trash"
+      "Gain 2 [Credits]?"
+      "Choose a credit providing card"          ; no bracketed count yet
+      "You accessed Hedge Fund"
+      "Pay 3 [Credits] to continue?"
+      ""
+      nil)))

--- a/dev/test/run_window_selfadvance_test.clj
+++ b/dev/test/run_window_selfadvance_test.clj
@@ -528,7 +528,15 @@
           (str "a non-ICE rez must not claim to be ICE, got:\n" out))
       (is (not (str/includes? out "ICE rezzed!")))
       (is (not (str/includes? out "continue-run"))
-          "the Corp side must not be told to use the Runner's continue-run"))
+          "the Corp side must not be told to use the Runner's continue-run")
+      ;; #110: the Corp arm used to offer "monitor-run (or 'continue')" — two
+      ;; names for the SAME dispatcher branch. Offering a seat a choice between
+      ;; aliases of one command is the ambiguity #110 is about, so runtime
+      ;; guidance names exactly one verb on both arms.
+      (is (str/includes? out "'continue'")
+          (str "the Corp side gets the one documented verb, got:\n" out))
+      (is (not (str/includes? out "monitor-run"))
+          (str "naming a second alias re-creates the two-verb ambiguity, got:\n" out)))
     (runs/reset-reported-events!)
     (let [ice-rez {:user "__system__"
                    :text "ai-corp rezzes Palisade protecting Server 2."
@@ -539,7 +547,15 @@
                                                  :state state
                                                  :side "runner"}))]
       (is (str/includes? out "ICE rezzed!") "a real ICE rez keeps its banner")
-      (is (str/includes? out "continue-run") "the Runner keeps its hint")))
+      (is (str/includes? out "'continue'") "the Runner still gets a resume verb")
+      ;; #110: this assertion used to read (includes? out "continue-run") and so
+      ;; PINNED the defect — the Runner arm named the single-step alias, which
+      ;; `help --full` does not document and which contradicts the `continue`
+      ;; the prompt block prints two lines later. Assert the framing (one verb,
+      ;; the documented one), never that a token appears.
+      (is (not (str/includes? out "continue-run"))
+          (str "the Runner must be pointed at the documented verb, not the "
+               "undocumented single-step alias, got:\n" out))))
   (testing "title-substring collisions don't misclassify: rezzing the ASSET
             'Hostile Architecture' with ICE 'Architect' installed is non-ICE"
     (runs/reset-reported-events!)

--- a/dev/test/send_command_help_test.sh
+++ b/dev/test/send_command_help_test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# send_command_help_test.sh — the help text must be TEXT, not shell.
+#
+# Why this exists: the role help blocks are plain double-quoted assignments, so
+# an unescaped " inside them CLOSES the string and hands the rest to the shell.
+# Adding the line that documents quoting "R&D" (#110 §3) did exactly that: the
+# inner quotes ended the assignment, the shell saw a bare &, and `runner help`
+# printed
+#
+#     ./dev/send_command: line 229: D, Archives, remote1, etc.)
+#                        QUOTE R: command not found
+#
+# instead of the Running section. Nothing caught it but running the command by
+# hand — the same class of failure as the EDN-tail leak next door, and shipped
+# for the same reason: no committed test. This is that test.
+#
+# It renders every help variant and asserts (a) no shell diagnostics leak into
+# the output, and (b) the sections a seat actually needs are present.
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SEND_CMD="$SCRIPT_DIR/../send_command"
+
+PASS=0
+FAIL=0
+
+fail() { echo "  ✗ $1"; FAIL=$((FAIL + 1)); }
+pass() { echo "  ✓ $1"; PASS=$((PASS + 1)); }
+
+# A rendered help must never contain shell DIAGNOSTICS. The discriminator has to
+# be precise, because the help text legitimately QUOTES an error message: the
+# R&D note says  'command not found: D'  on purpose. So match the shape the
+# shell actually emits — "<word>: command not found" (trailing) — not the phrase
+# itself, which appears leading-and-quoted in our documentation.
+assert_no_shell_errors() {
+    local label="$1" out="$2"
+    if [[ -z "$out" ]]; then
+        fail "$label: produced NO output (broken invocation, not a pass)"
+        return
+    fi
+    local bad=""
+    grep -qE ': command not found' <<<"$out" && bad+="command-not-found "
+    grep -qE ': No such file or directory' <<<"$out" && bad+="no-such-file "
+    grep -qE 'send_command: line [0-9]+' <<<"$out" && bad+="bash-line-diagnostic "
+    grep -qE 'unexpected (EOF|token)' <<<"$out" && bad+="parse-error "
+    if [[ -n "$bad" ]]; then
+        fail "$label: shell leaked into help output [$bad]"
+        echo "$out" | head -8 | sed 's/^/      /'
+    else
+        pass "$label: renders as text"
+    fi
+}
+
+assert_contains() {
+    local label="$1" out="$2" needle="$3"
+    if grep -qF -- "$needle" <<<"$out"; then
+        pass "$label: contains '$needle'"
+    else
+        fail "$label: missing '$needle'"
+    fi
+}
+
+echo "Rendering every help variant from $SEND_CMD"
+echo
+
+for role in runner corp ""; do
+    label="${role:-generic}"
+    out="$("$SEND_CMD" $role help 2>&1)"
+    assert_no_shell_errors "$label help" "$out"
+done
+
+echo
+echo "Full help (--full)"
+full="$("$SEND_CMD" help --full 2>&1)"
+assert_no_shell_errors "full help" "$full"
+
+echo
+echo "Content the seats depend on"
+
+# #110 §1: continue-run is a real command in the dispatcher allowlist. If help
+# doesn't document it, a seat told to run it (as the run-pause hint used to say)
+# has no way to learn what it does.
+assert_contains "full help" "$full" "continue-run"
+assert_contains "full help" "$full" "monitor-run"
+
+# #110 §2: the per-credit payment escape hatch.
+assert_contains "full help" "$full" "--all"
+
+# #110 §3: the quoting note must survive rendering in the runner brief — this is
+# the exact string whose inner quotes broke the script.
+runner_help="$("$SEND_CMD" runner help 2>&1)"
+assert_contains "runner help" "$runner_help" '"R&D"'
+assert_contains "runner help" "$runner_help" "command not found: D"
+
+echo
+echo "─────────────────────────────"
+echo "Passed: $PASS   Failed: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/test/clj/game/ai_pay_all_test.clj
+++ b/test/clj/game/ai_pay_all_test.clj
@@ -1,0 +1,167 @@
+(ns game.ai-pay-all-test
+  "Issue #110 §2 (and the open #104 Overclock item): the ENGINE-level contract
+   behind `choose-card <N> --all`.
+
+   The per-credit payment prompt (\"Choose a credit providing card (0 of 2
+   [Credits])\") re-asks once per credit, so a seat paying 2 from one source
+   makes two calls and a seat paying 5 makes five. Two different models reported
+   this independently — Fable on Overclock, Luna on Unity — as the tool making
+   them spend their turn on bookkeeping.
+
+   Humans never see it. game.core.pick-counters/pick-credit-providing-cards
+   defines
+
+     should-auto-repeat? (fn [state side] (get-in @state [side :shift-key-select]))
+
+   with the comment \"this allows holding the shift key while clicking a card to
+   keep picking that card while possible ie: taking 5cr from miss bones with one
+   click, instead of waiting for 5 server round-trips\". board.cljs sends
+   :shift-key-held on shift-click; game.core.actions/select stores it. Our
+   client hardcoded :shift-key-held false, so the seat had no shift key.
+
+   These tests pin what the seat's --all now depends on. The wire-level tests in
+   dev/test/ai_prompts_test.clj only prove we SEND the flag; nothing there would
+   notice if the engine stopped honouring it. This is the other half.
+
+   Note the sibling test `ghost-runner-can-be-used-in-psi-games-issue-1149` in
+   resources_test.clj, which pays 2 credits with two consecutive click-cards —
+   the friction, already sitting in the engine's own suite."
+  (:require [game.core :as core]
+            [game.core.card :refer :all]
+            [game.test-framework :refer :all]
+            [clojure.test :refer :all]))
+
+(defn- select-card-shift!
+  "Select `card` on the current select prompt with the shift key HELD — exactly
+   the wire payload dev/src/clj/ai_websocket_client_v2.clj select-card! sends for
+   `choose-card <N> --all`. The framework's click-card always sends a plain
+   click, so it cannot exercise this path."
+  [state side card]
+  (core/process-action "select" state side
+                       {:card card
+                        :eid (:eid (get-prompt state side))
+                        :shift-key-held true}))
+
+(deftest shift-held-select-pays-the-whole-cost-from-one-source
+  ;; A1: the load-bearing assumption behind --all.
+  (testing "one shift-held selection settles a 2-credit cost that otherwise
+            needs two selections"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Snowflake"]}
+                 :runner {:hand ["Ghost Runner"]
+                          :credits 1}})
+      (play-from-hand state :corp "Snowflake" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Ghost Runner")
+      (run-on state :hq)
+      (rez state :corp (get-ice state :hq 0))
+      (run-continue state)
+      (let [sf (get-ice state :hq 0)
+            gr (get-resource state 0)]
+        (card-subroutine state :corp sf 0)
+        (is (zero? (:credit (get-runner))) "Runner has no pool credits to fall back on")
+        (click-prompt state :corp "0 [Credits]")
+        (click-prompt state :runner "2 [Credits]")
+        (is (= 3 (get-counters (refresh gr) :credit)) "Ghost Runner starts at 3")
+        ;; ONE call, where the plain-click test needs two.
+        (select-card-shift! state :runner (refresh gr))
+        (is (= 1 (get-counters (refresh gr) :credit))
+            "both credits came off Ghost Runner in a single selection")
+        (is (zero? (:credit (get-runner))) "and none came out of the credit pool")
+        (is (not (prompt-is-type? state :runner :select))
+            "the payment prompt is resolved — no second call is owed")))))
+
+(deftest plain-select-still-pays-exactly-one-credit
+  ;; The control. If this ever passes for 2 credits, the flag stopped being the
+  ;; thing that distinguishes the two paths and the test above proves nothing.
+  (testing "without the shift flag the prompt still re-asks per credit"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Snowflake"]}
+                 :runner {:hand ["Ghost Runner"]
+                          :credits 1}})
+      (play-from-hand state :corp "Snowflake" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Ghost Runner")
+      (run-on state :hq)
+      (rez state :corp (get-ice state :hq 0))
+      (run-continue state)
+      (let [sf (get-ice state :hq 0)
+            gr (get-resource state 0)]
+        (card-subroutine state :corp sf 0)
+        (click-prompt state :corp "0 [Credits]")
+        (click-prompt state :runner "2 [Credits]")
+        (click-card state :runner (refresh gr))
+        (is (= 2 (get-counters (refresh gr) :credit))
+            "a plain click pays ONE credit")
+        (is (prompt-is-type? state :runner :select)
+            "and the prompt is still open, asking for the second")))))
+
+(deftest shift-held-select-stops-at-the-cost-not-at-the-source
+  ;; A4 / the guest reviewer's MINOR: --all does NOT drain the card. The engine
+  ;; exits at (<= target-count counter-count), so a source richer than the cost
+  ;; keeps its remainder. Our help text must not promise "the full amount".
+  (testing "a source with more credits than the cost keeps the difference"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Snowflake"]}
+                 :runner {:hand ["Ghost Runner"]
+                          :credits 1}})
+      (play-from-hand state :corp "Snowflake" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Ghost Runner")
+      (run-on state :hq)
+      (rez state :corp (get-ice state :hq 0))
+      (run-continue state)
+      (let [sf (get-ice state :hq 0)
+            gr (get-resource state 0)]
+        (card-subroutine state :corp sf 0)
+        (click-prompt state :corp "0 [Credits]")
+        ;; Cost 1, source holds 3.
+        (click-prompt state :runner "1 [Credits]")
+        (select-card-shift! state :runner (refresh gr))
+        (is (= 2 (get-counters (refresh gr) :credit))
+            "paid only what the cost needed; 2 credits stay on the card")))))
+
+(deftest shift-state-does-not-persist-into-the-next-payment
+  ;; A3: the assumption I was least sure of. game.core.actions/select re-stamps
+  ;; [side :shift-key-select] on EVERY selection, so a later plain choose-card
+  ;; must clear it. If it latched, a seat that used --all once would silently
+  ;; auto-drain sources for the rest of the game.
+  ;; Two SEPARATE runs: Snowflake ends the run whenever the psi bids differ, so
+  ;; both payments cannot happen inside one run.
+  (testing "a plain selection on a later run pays one credit again"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)]
+                        :hand ["Snowflake"]}
+                 :runner {:hand ["Ghost Runner"]
+                          :credits 1}})
+      (play-from-hand state :corp "Snowflake" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Ghost Runner")
+      (let [gr (fn [] (refresh (get-resource state 0)))
+            psi-game (fn [runner-bid]
+                       (run-on state :hq)
+                       ;; Rez only on the first pass — it stays rezzed for run 2.
+                       (when-not (rezzed? (get-ice state :hq 0))
+                         (rez state :corp (get-ice state :hq 0)))
+                       (run-continue state)
+                       (card-subroutine state :corp (get-ice state :hq 0) 0)
+                       (click-prompt state :corp "0 [Credits]")
+                       (click-prompt state :runner runner-bid))]
+        ;; Run 1: pay 1 with the shift HELD.
+        (psi-game "1 [Credits]")
+        (select-card-shift! state :runner (gr))
+        (is (= 2 (get-counters (gr) :credit)) "first payment took 1")
+        (is (true? (get-in @state [:runner :shift-key-select]))
+            "sanity: the engine did record the held shift")
+
+        ;; Run 2: a PLAIN click must be back to one-credit-per-click. If the
+        ;; stale true latched, this would drain both remaining credits.
+        (psi-game "2 [Credits]")
+        (click-card state :runner (gr))
+        (is (= 1 (get-counters (gr) :credit))
+            "the stale shift state did NOT drain the source")
+        (is (prompt-is-type? state :runner :select)
+            "prompt still open — the plain click paid exactly one")))))


### PR DESCRIPTION
Closes the three send_command friction items a **GPT-5.6 Luna seat** hit driving
the Runner (#110), and the corresponding Overclock item in #104.

Suite **643/1723 → 654/1879, 0 failures**. Shell suites green (1 new).

## §1 — one verb

The run-pause hint said `continue-run` while the prompt block two lines later
said `continue`. The defect had been *moved* by the #104 pass, not fixed: that
pass corrected the Corp arm and left the Runner arm naming the undocumented
single-step alias.

The side split was never load-bearing — `continue` and `monitor-run` are
byte-identical dispatcher branches and `continue-run` is `continue --single`, so
offering a seat a choice between them *is* the ambiguity. Runtime guidance now
names one verb on both arms; the aliases are documented in `help --full`. The
Corp brief stopped presenting monitor-run as a separate command.

## §2 — not a docs gap; a missing capability

The issue suggested advertising `multi-choose`. I didn't, because it's the wrong
verb: multi-choose selects several *different* cards, whereas paying a cost out
of *one* source is a different operation.

The real cause is ours:

```clojure
;; game/core/pick_counters.clj:162-164
;; note - this allows holding the shift key while clicking a card to keep picking
;; that card while possible ie: taking 5cr from miss bones with one click,
;; instead of waiting for 5 server round-trips
should-auto-repeat? (fn [state side] (get-in @state [side :shift-key-select]))
```

`board.cljs` sends `:shift-key-held` on shift-click; `actions/select` stores it.
**Our `select-card!` hardcoded it to `false`**, so a human paid Overclock's 5 in
one click and a seat made five calls. Adds `choose-card <N> --all`.

The payment prompt now states how many credits are owed and names the flag, and
`choose-card` reports **credits paid** rather than echoing the card title.

### Engine behaviour is pinned, not assumed

`test/clj/game/ai_pay_all_test.clj`:
- one shift-held select settles a 2-credit cost that otherwise needs two;
- a plain select still pays exactly one — **the control**, without which the
  first test proves nothing;
- a source richer than the cost **keeps the difference** (`--all` pays the cost,
  not the card's balance);
- the shift state does **not** latch into a later payment.

## §3 — documented, plus the half of the split that still runs

Unfixable inside the client (the shell splits on `&` first), so: quoting is
explained **with the reason** in all three help variants and the runner brief.
And since the shell backgrounds `... run R` before failing on `D`,
`send_command` *is* still invoked — a bare `R` now reports the real diagnosis.

## Test notes

- `run_window_selfadvance_test` asserted `(includes? out "continue-run")` and so
  **pinned §1's defect** — a green suite was evidence *for* the bug. Re-aimed at
  the framing.
- `dev/test/send_command_help_test.sh` is new because writing §3's fix **broke
  `runner help`**: the inner quotes in my `"R&D"` example closed the shell string
  and the `&` leaked. Caught only by hand-running the command. Verified red
  against the exact break.

## Review

Off-vendor panel (GPT-5.6 via `codex exec`) on the full diff, with load-bearing
assumptions stated explicitly in the prompt. Three findings, **all confirmed and
taken**: the Corp arm was the same defect unfixed (a scope call I had made *and
defended*); `--all` was described as taking a source's "full amount"; and the
wire-level tests proved only that we send the flag — which is why the engine
tests exist. No omission findings.

Archived in `review-metrics` under the exception rule.