### PR TITLE
fix: wire the seat to the reference client — :host, prompt :eid, phase windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ check-full:
 # Run unit tests
 test:
 	@echo "Running unit tests..."
-	lein test ai-actions-test ai-actions-sad-path-test ai-basic-actions-test ai-connection-test ai-heuristic-corp-test ai-heuristic-runner-test ai-runs-test ai-run-corp-decisions-test ai-stall-test ai-websocket-diff-test ai-websocket-error-recovery-test ai-display-test ai-state-test ai-prompts-test ai-pure-functions-test ai-turn-validation-test ai-wait-test continue-run-rez-test run-window-selfadvance-test game.ai-upgrade-rez-timing-test game.ai-duplicate-continue-test web.lobby-disconnect-test
+	lein test ai-actions-test ai-actions-sad-path-test ai-basic-actions-test ai-connection-test ai-heuristic-corp-test ai-heuristic-runner-test ai-runs-test ai-run-corp-decisions-test ai-stall-test ai-websocket-diff-test ai-websocket-error-recovery-test ai-display-test ai-state-test ai-prompts-test ai-pure-functions-test ai-turn-validation-test ai-wait-test ai-phase-window-test ai-wire-card-ref-test continue-run-rez-test run-window-selfadvance-test game.ai-upgrade-rez-timing-test game.ai-duplicate-continue-test game.ai-hosted-card-ref-test game.ai-phase-windows-test web.lobby-disconnect-test
 
 # Run shell-level tests (fast, no REPL/server needed) — e.g. send_command output filters
 test-shell:

--- a/dev/send_command
+++ b/dev/send_command
@@ -26,7 +26,7 @@ BOT_NS="ai-heuristic-corp"
 
 # Check if first argument looks like a client name (not a command)
 FIRST_ARG="${1:-help}"
-if [[ "$FIRST_ARG" =~ ^(runner|corp|[a-z][a-z0-9-]*)$ ]] && [[ ! "$FIRST_ARG" =~ ^(help|status|snapshot|game-over\?|game-over-status|board|hand|prompt|credits|clicks|archives|heap|log|card-text|hand-text|abilities|list-playables|diagnose-blocker|start-turn|indicate-action|take-credit|draw|end-turn|smart-end-turn|remove-tag|purge|trash-resource|change|fix-credits|discard-card|draw-to-card|find-card|keep-hand|mulligan|discard|play|play-index|run|use-ability|use-runner-ability|trash|rez|fire-subs|let-subs-fire|auto-pass|advance|score|choose|choose-value|choose-card|multi-choose|continue|continue-run|monitor-run|jack-out|tank|wait|get-cursor|ping|peer-status|clear-heartbeats|create-game|start-game|leave-game|list-lobbies|join|resync|chat|install|install-index|connect|eval|debug-chat|dashboard|dashboard-compact|bot|bot-turn|bot-status|bot-loop|bot-loop-status|bot-loop-stop)$ ]]; then
+if [[ "$FIRST_ARG" =~ ^(runner|corp|[a-z][a-z0-9-]*)$ ]] && [[ ! "$FIRST_ARG" =~ ^(help|status|snapshot|game-over\?|game-over-status|board|hand|prompt|credits|clicks|archives|heap|log|card-text|hand-text|abilities|list-playables|diagnose-blocker|start-turn|end-phase-12|end-post-discard|indicate-action|take-credit|draw|end-turn|smart-end-turn|remove-tag|purge|trash-resource|change|fix-credits|discard-card|draw-to-card|find-card|keep-hand|mulligan|discard|play|play-index|run|use-ability|use-runner-ability|trash|rez|fire-subs|let-subs-fire|auto-pass|advance|score|choose|choose-value|choose-card|multi-choose|continue|continue-run|monitor-run|jack-out|tank|wait|get-cursor|ping|peer-status|clear-heartbeats|create-game|start-game|leave-game|list-lobbies|join|resync|chat|install|install-index|connect|eval|debug-chat|dashboard|dashboard-compact|bot|bot-turn|bot-status|bot-loop|bot-loop-status|bot-loop-stop)$ ]]; then
     CLIENT_NAME="$1"
     shift
 
@@ -88,7 +88,7 @@ did_you_mean() {
             echo -e "${YELLOW}💡 Did you mean: take-credit  (gain 1 [Credit]) — or credits  (show credit pools)${NC}" >&2; return;;
     esac
     # Fallback: substring match against the player-facing commands.
-    local known="status board hand prompt credits clicks archives heap log card-text abilities list-playables diagnose-blocker start-turn end-turn smart-end-turn draw take-credit play install advance score rez run continue jack-out tank choose choose-card choose-value multi-choose wait get-cursor ping peer-status keep-hand mulligan discard remove-tag game-over-status"
+    local known="status board hand prompt credits clicks archives heap log card-text abilities list-playables diagnose-blocker start-turn end-phase-12 end-post-discard end-turn smart-end-turn draw take-credit play install advance score rez run continue jack-out tank choose choose-card choose-value multi-choose wait get-cursor ping peer-status keep-hand mulligan discard remove-tag game-over-status"
     local hits
     # `|| true`: grep exits non-zero on no match, which under `set -euo pipefail`
     # would abort the whole script *here* — silently swallowing both this hint and
@@ -275,6 +275,7 @@ ${GREEN}Inspect (read-only — use these to decide):${NC}
 
 ${GREEN}Turn Actions:${NC}
   start-turn       Start your turn
+  end-phase-12     Close a start-of-turn (1.2) window, if one is open
   take-credit      Spend click for credit
   draw             Spend click to draw
   end-turn         End your turn
@@ -349,6 +350,10 @@ ${GREEN}Status Commands:${NC}
 
 ${GREEN}Basic Actions:${NC}
   start-turn      - Start your turn (gain clicks, Corp draws card)
+  end-phase-12    - Close the start-of-turn (1.2) window. Only needed when a card
+                    holds it open; until then the mandatory draw and every
+                    start-of-turn trigger have NOT happened. 'status' says so.
+  end-post-discard - Close a forced end-of-turn window so the turn can end.
   indicate-action - Signal you want to use paid ability (pauses game)
   take-credit     - Spend 1 click to gain 1 credit
   draw            - Spend 1 click to draw 1 card
@@ -853,6 +858,19 @@ case "$COMMAND" in
         info "Starting turn..."
         execute '(ai-actions/start-turn!)'
         after_action
+        ;;
+
+    end-phase-12)
+        ensure_connection
+        info "Closing the start-of-turn (1.2) window..."
+        execute '(ai-actions/end-phase-12!)'
+        after_action
+        ;;
+
+    end-post-discard)
+        ensure_connection
+        info "Closing the end-of-turn (post-discard) window..."
+        execute '(ai-actions/end-post-discard!)'
         ;;
 
     indicate-action)

--- a/dev/src/clj/ai_actions.clj
+++ b/dev/src/clj/ai_actions.clj
@@ -102,6 +102,8 @@
 ;; ============================================================================
 
 (def start-turn! basic/start-turn!)
+(def end-phase-12! basic/end-phase-12!)
+(def end-post-discard! basic/end-post-discard!)
 (def indicate-action! basic/indicate-action!)
 (def take-credit! basic/take-credit!)
 (def draw-card! basic/draw-card!)

--- a/dev/src/clj/ai_basic_actions.clj
+++ b/dev/src/clj/ai_basic_actions.clj
@@ -10,6 +10,7 @@
 (declare start-turn!)
 (declare turn-started-since-last-opp-end?)
 (declare get-my-username)
+(declare open-phase-window)
 
 ;; ============================================================================
 ;; Auto-Start Turn Helpers
@@ -301,7 +302,9 @@
       (do
         (println "❌ ERROR: Previous turn still resolving post-discard phase")
         (println "   A card requires both players to pass priority before the turn truly ends")
-        (println "   Use 'wait' until the post-discard pause clears")
+        ;; This window has no timer: 'wait' alone never clears it (see
+        ;; game.ai-phase-windows-test). Name the command that does.
+        (println "   Use 'end-post-discard' to pass — then 'wait' if the opponent still has to")
         (core/with-cursor {:status :error :reason :post-discard-pending}))
 
       ;; ERROR: Bug #11 fix - Runner trying to start first turn (Corp always goes first)
@@ -347,6 +350,11 @@
                 (when (> after-hand before-hand)
                   (println (str "🃏 Drew: " card-title))
                   (core/show-card-on-first-sight! card-title))))
+            (when-let [w (open-phase-window :phase-12)]
+              (when (= (:owner w) my-side)
+                (println "⏸️  Start-of-turn (phase 1.2) window is open — a card is holding it.")
+                (println "   Your mandatory draw and ALL start-of-turn triggers have NOT happened yet.")
+                (println "   Use any start-of-turn paid abilities now, then 'end-phase-12'.")))
             (core/with-cursor {:status :success}))))
 
       ;; ERROR: Already have clicks (turn already started)
@@ -401,7 +409,136 @@
                 (when (> after-hand before-hand)
                   (println (str "🃏 Drew: " card-title))
                   (core/show-card-on-first-sight! card-title))))
+            (when-let [w (open-phase-window :phase-12)]
+              (when (= (:owner w) my-side)
+                (println "⏸️  Start-of-turn (phase 1.2) window is open — a card is holding it.")
+                (println "   Your mandatory draw and ALL start-of-turn triggers have NOT happened yet.")
+                (println "   Use any start-of-turn paid abilities now, then 'end-phase-12'.")))
             (core/with-cursor {:status :success})))))))
+
+;; ============================================================================
+;; Phase windows (start-of-turn 1.2, and the forced post-discard pause)
+;; ============================================================================
+;;
+;; The engine opens both windows on every turn boundary and, when no card is
+;; holding one, closes it again in the same breath (turns.clj:136, :262) — which
+;; is why tutorial-deck games never saw one. When a card DOES hold it open there
+;; is no timer and no implicit exit: an explicit command is the only way out. The
+;; reference client puts a button on each (`board.cljs/basic-actions`); we had
+;; none, so a seat that hit one waited forever. Pinned in
+;; game.ai-phase-windows-test.
+;;
+;; Which command to send is not a free choice — it mirrors the button:
+;;   active player, no consent needed -> the plain "end" command
+;;   consent needed (either seat)     -> the "pass-priority" command, and the
+;;                                       window closes only once BOTH have passed.
+
+(def ^:private phase-windows
+  {:phase-12
+   {:name "start-of-turn (phase 1.2)"
+    :zone-keys {:corp :corp-phase-12 :runner :runner-phase-12}
+    :end-command "end-phase-12"
+    :pass-command "phase-12-pass-priority"
+    :what-it-unblocks {:corp "the mandatory draw and every start-of-turn trigger"
+                       :runner "the Runner's first click and every start-of-turn trigger"}}
+   :post-discard
+   {:name "end-of-turn (post-discard)"
+    :zone-keys {:corp :corp-post-discard :runner :runner-post-discard}
+    :end-command "end-post-discard"
+    :pass-command "post-discard-pass-priority"
+    :what-it-unblocks {:corp "the end of the Corp's turn"
+                       :runner "the end of the Runner's turn"}}})
+
+(defn open-phase-window
+  "The open window of the given kind (:phase-12 / :post-discard), or nil.
+
+   Returns {:owner :corp|:runner  ; whose phase it is — the active player
+            :window {...}          ; the raw state map
+            :requires-consent? bool
+            :i-passed? bool}"
+  [kind]
+  (let [{:keys [zone-keys]} (get phase-windows kind)
+        gs (get-in @state/client-state [:game-state])
+        my-side (keyword (:side @state/client-state))]
+    (some (fn [[owner k]]
+            (let [w (get gs k)]
+              (when (:active w)
+                {:owner owner
+                 :window w
+                 :requires-consent? (boolean (:requires-consent w))
+                 :i-passed? (boolean (get w my-side))})))
+          zone-keys)))
+
+(defn- close-phase-window!
+  "Send the command that closes an open phase window, mirroring board.cljs."
+  [kind]
+  (let [{:keys [name end-command pass-command what-it-unblocks]} (get phase-windows kind)
+        my-side (keyword (:side @state/client-state))
+        opponent (core/other-side (:side @state/client-state))
+        gameid (:gameid @state/client-state)
+        {:keys [owner requires-consent? i-passed?] :as open} (open-phase-window kind)]
+    (cond
+      (nil? open)
+      (do
+        (println (format "❌ ERROR: No %s window is open" name))
+        (println "   Nothing to close — check 'status' for what is actually blocking you")
+        (core/with-cursor {:status :error :reason :no-window-open}))
+
+      i-passed?
+      (do
+        (println (format "⏳ You have already passed the %s window" name))
+        (println (format "   Waiting on %s to pass too — use 'wait'" opponent))
+        (core/with-cursor {:status :waiting-input :reason :already-passed}))
+
+      ;; The opponent's window, with no consent required, is not ours to close.
+      (and (not= owner my-side) (not requires-consent?))
+      (do
+        (println (format "❌ ERROR: This %s window belongs to %s alone" name (clojure.core/name owner)))
+        (println "   No card is forcing a shared window, so only they can close it — use 'wait'")
+        (core/with-cursor {:status :error :reason :not-my-window}))
+
+      :else
+      (let [command (if requires-consent? pass-command end-command)
+            sent? (ws/send-message! :game/action
+                                    {:gameid gameid :command command :args nil})]
+        (if-not sent?
+          (do
+            (println "❌ ERROR: Failed to send (server unreachable?)")
+            (core/with-cursor {:status :error :reason :send-failed}))
+          (do
+            (Thread/sleep core/standard-delay)
+            (let [still-open (open-phase-window kind)]
+              (cond
+                (nil? still-open)
+                (do
+                  (println (format "✅ Closed the %s window — this releases %s"
+                                   name (get what-it-unblocks owner)))
+                  (core/with-cursor {:status :success}))
+
+                (:requires-consent? still-open)
+                (do
+                  (println (format "✅ Passed on the %s window" name))
+                  (println (format "   It stays open until %s passes as well — use 'wait'" opponent))
+                  (core/with-cursor {:status :waiting-input :reason :awaiting-opponent-pass}))
+
+                :else
+                (do
+                  (println (format "⚠️  Sent '%s' but the %s window is still open" command name))
+                  (println "   Check 'status'; this should not happen")
+                  (core/with-cursor {:status :error :reason :window-still-open}))))))))))
+
+(defn end-phase-12!
+  "Close the start-of-turn (phase 1.2) window.
+
+   Until this is sent, the active player's mandatory draw and ALL start-of-turn
+   triggers have not happened, however many clicks have been spent."
+  []
+  (close-phase-window! :phase-12))
+
+(defn end-post-discard!
+  "Close the forced end-of-turn (post-discard) window, so the turn can actually end."
+  []
+  (close-phase-window! :post-discard))
 
 (defn indicate-action!
   "Signal you want to use a paid ability (pauses game for priority window)"

--- a/dev/src/clj/ai_card_actions.clj
+++ b/dev/src/clj/ai_card_actions.clj
@@ -689,10 +689,7 @@
           (do (println (str "❌ ICE not found installed: " ice-name))
               (core/with-cursor {:status :error :reason "ICE not found"}))
           (let [gameid (:gameid client-state)
-                card-ref {:cid (:cid card)
-                         :zone (:zone card)
-                         :side (:side card)
-                         :type (:type card)}
+                card-ref (core/create-card-ref card)
                 old-cursor (state/get-cursor)
                 old-prompt (state/get-prompt)
                 old-log-count (count (get-in client-state [:game-state :log]))]
@@ -760,10 +757,7 @@
             ;; Proceed with advance
             :else
             (let [gameid (:gameid client-state)
-                  card-ref {:cid (:cid card)
-                           :zone (:zone card)
-                           :side (:side card)
-                           :type (:type card)}
+                  card-ref (core/create-card-ref card)
                   ;; Capture log size AND prompt BEFORE sending to avoid race conditions (#105)
                   initial-log-size (core/get-log-size)
                   pre-prompt (state/get-prompt)]

--- a/dev/src/clj/ai_core.clj
+++ b/dev/src/clj/ai_core.clj
@@ -840,11 +840,19 @@
       :else nil)))
 
 (defn create-card-ref
-  "Create minimal card reference for server commands"
+  "Create minimal card reference for server commands.
+
+   Mirrors the reference client's single narrowing point
+   (`nr.gameboard.actions/send-command`: `[:cid :zone :side :host :type]`).
+   `:host` is load-bearing, not decoration: the engine's `get-card` uses it to
+   decide whether to walk a host's `:hosted` collection, and a hosted card's zone
+   is `[:onhost]` — not a real zone — so without `:host` the lookup returns nil
+   and the action is silently discarded. `:title` is ours, for logging."
   [card]
   {:cid (:cid card)
    :zone (:zone card)
    :side (:side card)
+   :host (:host card)
    :type (:type card)
    :title (:title card)})
 

--- a/dev/src/clj/ai_prompts.clj
+++ b/dev/src/clj/ai_prompts.clj
@@ -123,7 +123,12 @@
     (ws/send-message! :game/action
                       {:gameid gameid
                        :command "choice"
-                       :args {:choice {:uuid (:uuid choice)}}})
+                       ;; :eid names the prompt we are answering. Without it the
+                       ;; engine's resolve-prompt falls back to the HEAD of the
+                       ;; prompt queue, which is not necessarily the one we
+                       ;; rendered. The reference client always sends it.
+                       :args {:choice {:uuid (:uuid choice)}
+                              :eid old-eid}})
     ;; Report what actually happened, not what we attempted (#75): a choice the
     ;; engine rejects (e.g. an unpayable cost) or silently swallows leaves the
     ;; prompt unchanged — that must NOT read as success, and the success line

--- a/dev/src/clj/ai_runs.clj
+++ b/dev/src/clj/ai_runs.clj
@@ -1001,12 +1001,16 @@
 
 (defn- send-choice!
   "Helper to send choice command and return action-taken result.
-   Waits briefly for state to sync via WebSocket."
-  [gameid choice-uuid choice-value]
+   Waits briefly for state to sync via WebSocket.
+
+   `prompt-eid` names the prompt being answered: without it the engine resolves
+   whatever is at the HEAD of the prompt queue, not necessarily what we saw."
+  [gameid choice-uuid choice-value prompt-eid]
   (ws/send-message! :game/action
                    {:gameid gameid
                     :command "choice"
-                    :args {:choice {:uuid choice-uuid}}})
+                    :args {:choice {:uuid choice-uuid}
+                           :eid prompt-eid}})
   ;; Brief wait for WebSocket state update to arrive
   (Thread/sleep 100)
   {:status :action-taken
@@ -1131,7 +1135,7 @@
         (core/show-card-on-first-sight! card-title))
       ;; All single-choice prompts auto-continue (2+ choice access handled by handle-real-decision)
       (println (format "   → Auto-choosing: %s" choice-value))
-      (send-choice! gameid choice-uuid choice-value))))
+      (send-choice! gameid choice-uuid choice-value (:eid my-prompt)))))
 
 (defn handle-recently-passed-in-log
   "Priority 5.5: Detect when we've passed via game log (backup for :no-action).

--- a/dev/src/clj/ai_websocket_client_v2.clj
+++ b/dev/src/clj/ai_websocket_client_v2.clj
@@ -1,6 +1,7 @@
 (ns ai-websocket-client-v2
   "WebSocket client using gniazdo (JVM WebSocket library)"
   (:require
+   [ai-core :as core]
    [ai-debug :as debug]
    [ai-state :as state]
    [ai-hud-utils :as hud]
@@ -528,27 +529,30 @@
     (send-action! command args)))
 
 (defn choose!
-  "Make a choice from a prompt by index or UUID"
+  "Make a choice from a prompt by index or UUID.
+
+   Always names the prompt via :eid, as the reference client does. Without it the
+   engine's resolve-prompt falls back to the HEAD of the prompt queue, which is
+   not necessarily the prompt the seat was shown."
   [choice]
   (if (number? choice)
     ;; Choice by index
     (let [prompt (state/get-prompt)
           uuid (get-in prompt [:choices choice :uuid])]
       (when uuid
-        (safe-action! "choice" {:choice {:uuid uuid}})))
+        (safe-action! "choice" {:choice {:uuid uuid} :eid (:eid prompt)})))
     ;; Choice by UUID string
-    (safe-action! "choice" {:choice {:uuid choice}})))
+    (safe-action! "choice" {:choice {:uuid choice} :eid (:eid (state/get-prompt))})))
 
 (defn select-card!
   "Select a card for prompts like discard.
    Takes a card object and prompt eid.
-   Card should have :cid, :zone, :side, :type fields."
+   The card is narrowed by `ai-core/create-card-ref`, which mirrors the reference
+   client's key list — including `:host`, without which a hosted card cannot be
+   resolved server-side and the select is silently swallowed."
   [card eid]
   (safe-action! "select"
-                {:card {:cid (:cid card)
-                        :zone (:zone card)
-                        :side (:side card)
-                        :type (:type card)}
+                {:card (core/create-card-ref card)
                  :eid eid
                  :shift-key-held false}))
 

--- a/dev/test/ai_phase_window_test.clj
+++ b/dev/test/ai_phase_window_test.clj
@@ -1,0 +1,125 @@
+(ns ai-phase-window-test
+  "The seat's two phase-window commands.
+
+   Which wire command closes a window is not a free choice — it mirrors the
+   reference client's button exactly (`board.cljs/basic-actions`):
+
+     active player, no consent needed -> \"end-phase-12\" / \"end-post-discard\"
+     consent needed (either seat)     -> the \"…-pass-priority\" variant
+
+   Getting this wrong is silent: the engine accepts an unknown command by doing
+   nothing (`process-action` returns nil for a miss), so a seat would sit in a
+   window it believed it had closed. Hence assertions on the exact command sent.
+
+   The engine side — that these windows never close on their own — is pinned in
+   game.ai-phase-windows-test."
+  (:require [clojure.test :refer :all]
+            [test-helpers :refer :all]
+            [ai-state :as state]
+            [ai-basic-actions :as basic]
+            [ai-websocket-client-v2 :as ws]))
+
+(defn- state-with
+  "Client state for `side` with the given phase-window keys set on game-state."
+  [side window-keys]
+  {:connected true
+   :side side
+   :gameid (java.util.UUID/fromString "00000000-0000-0000-0000-000000000001")
+   :game-state (merge {:corp {} :runner {}} window-keys)})
+
+(defn- capture
+  "Run f with the wire stubbed; return the sent command name (nil if nothing sent)."
+  [client-state f]
+  (let [sent (atom nil)
+        original @state/client-state]
+    (try
+      (reset! state/client-state client-state)
+      (with-redefs [ws/send-message! (fn [_ data] (reset! sent (:command data)) true)]
+        (let [result (f)]
+          {:command @sent :result result}))
+      (finally (reset! state/client-state original)))))
+
+(deftest end-phase-12-mirrors-the-button
+  (testing "active player, window is theirs alone -> end-phase-12"
+    (let [{:keys [command result]}
+          (capture (state-with "corp" {:corp-phase-12 {:active true}})
+                   basic/end-phase-12!)]
+      (is (= "end-phase-12" command))
+      ;; nothing cleared the window in the stub, so the seat is told so honestly
+      (is (= :error (:status result)))
+      (is (= :window-still-open (:reason result)))))
+
+  (testing "active player, consent required -> pass-priority, not the plain end"
+    (let [{:keys [command]}
+          (capture (state-with "corp" {:corp-phase-12 {:active true :requires-consent true}})
+                   basic/end-phase-12!)]
+      (is (= "phase-12-pass-priority" command)
+          "the plain end-phase-12 would be ignored by the engine here")))
+
+  (testing "opponent's window, consent required -> we can and must pass too"
+    (let [{:keys [command]}
+          (capture (state-with "runner" {:corp-phase-12 {:active true :requires-consent true}})
+                   basic/end-phase-12!)]
+      (is (= "phase-12-pass-priority" command))))
+
+  (testing "opponent's window, no consent required -> not ours to close"
+    (let [{:keys [command result]}
+          (capture (state-with "runner" {:corp-phase-12 {:active true}})
+                   basic/end-phase-12!)]
+      (is (nil? command) "nothing is sent")
+      (is (= :not-my-window (:reason result)))))
+
+  (testing "already passed -> waiting on the opponent, not an error and not a resend"
+    (let [{:keys [command result]}
+          (capture (state-with "corp" {:corp-phase-12 {:active true :requires-consent true :corp true}})
+                   basic/end-phase-12!)]
+      (is (nil? command))
+      (is (= :waiting-input (:status result)))
+      (is (= :already-passed (:reason result)))))
+
+  (testing "no window open -> says so instead of sending a command into the void"
+    (let [{:keys [command result]}
+          (capture (state-with "corp" {}) basic/end-phase-12!)]
+      (is (nil? command))
+      (is (= :no-window-open (:reason result)))))
+
+  (testing "an inactive window is not an open one"
+    (let [{:keys [command result]}
+          (capture (state-with "corp" {:corp-phase-12 {:active false}}) basic/end-phase-12!)]
+      (is (nil? command))
+      (is (= :no-window-open (:reason result))))))
+
+(deftest end-post-discard-mirrors-the-button
+  (testing "active player, no consent -> end-post-discard"
+    (let [{:keys [command]}
+          (capture (state-with "corp" {:corp-post-discard {:active true}})
+                   basic/end-post-discard!)]
+      (is (= "end-post-discard" command))))
+
+  (testing "consent required -> post-discard-pass-priority, from either seat"
+    (is (= "post-discard-pass-priority"
+           (:command (capture (state-with "corp" {:corp-post-discard {:active true :requires-consent true}})
+                              basic/end-post-discard!))))
+    (is (= "post-discard-pass-priority"
+           (:command (capture (state-with "runner" {:corp-post-discard {:active true :requires-consent true}})
+                              basic/end-post-discard!)))))
+
+  (testing "the two windows are not confused for each other"
+    (is (nil? (:command (capture (state-with "corp" {:corp-phase-12 {:active true}})
+                                 basic/end-post-discard!)))
+        "end-post-discard does not close a phase-1.2 window")
+    (is (nil? (:command (capture (state-with "corp" {:corp-post-discard {:active true}})
+                                 basic/end-phase-12!)))
+        "and vice versa")))
+
+(deftest open-phase-window-reports-what-the-seat-needs
+  (testing "owner, consent and our own pass state are all reported"
+    (let [original @state/client-state]
+      (try
+        (reset! state/client-state
+                (state-with "runner" {:corp-phase-12 {:active true :requires-consent true :runner true}}))
+        (let [w (basic/open-phase-window :phase-12)]
+          (is (= :corp (:owner w)))
+          (is (:requires-consent? w))
+          (is (:i-passed? w) "our own pass is read from our own side key"))
+        (finally (reset! state/client-state original))))))

--- a/dev/test/ai_prompts_test.clj
+++ b/dev/test/ai_prompts_test.clj
@@ -88,8 +88,10 @@
     (let [{:keys [sent out]} (capture-choose-value "Done")]
       (is (= "choice" (:command sent))
           (str "expected a choice command, got: " sent))
-      (is (= {:choice {:uuid "done-uuid"}} (:args sent))
-          (str "expected Done's uuid in args, got: " sent))
+      ;; :eid is not decoration — resolve-prompt falls back to the HEAD of the
+      ;; prompt queue without it, so a stacked prompt would eat this press.
+      (is (= {:choice {:uuid "done-uuid"} :eid "sel-1"} (:args sent))
+          (str "expected Done's uuid AND the prompt's eid in args, got: " sent))
       (is (str/includes? out "Done")))))
 
 (deftest choose-by-value-no-match-on-select-does-not-send
@@ -443,9 +445,12 @@
 
 (deftest keep-hand-absorbs-post-bounce-sync-race
   (testing "keep-hand waits for a late-arriving mulligan prompt instead of false-negating"
-    (let [mull (make-prompt :prompt-type "mulligan"
-                            :choices [{:value "Keep" :uuid "keep-uuid"}
-                                      {:value "Mulligan" :uuid "mull-uuid"}])
+    (let [mull (assoc (make-prompt :prompt-type "mulligan"
+                                   :choices [{:value "Keep" :uuid "keep-uuid"}
+                                             {:value "Mulligan" :uuid "mull-uuid"}])
+                      ;; the fixture must carry an :eid — the payload names the
+                      ;; prompt it answers, and an eid-less mock hides that
+                      :eid "mull-eid-1")
           sent (atom nil)]
       ;; Cache starts with NO prompt (sync hasn't landed yet).
       (with-mock-state (mock-client-state :side "runner" :prompt nil)
@@ -464,7 +469,7 @@
                         (is (= :success (:status r))
                             (str "expected success after sync race, got: " r))))]
             ;; Pressed the Keep button (option 0), not bailed.
-            (is (= {:choice {:uuid "keep-uuid"}} (:args @sent)))
+            (is (= {:choice {:uuid "keep-uuid"} :eid "mull-eid-1"} (:args @sent)))
             (is (not (str/includes? out "No mulligan prompt active")))))))))
 
 (deftest keep-hand-still-errors-when-truly-no-prompt
@@ -504,9 +509,12 @@
 
 (deftest mulligan-absorbs-post-bounce-sync-race
   (testing "mulligan waits for a late-arriving prompt instead of false-negating"
-    (let [mull (make-prompt :prompt-type "mulligan"
-                            :choices [{:value "Keep" :uuid "keep-uuid"}
-                                      {:value "Mulligan" :uuid "mull-uuid"}])
+    (let [mull (assoc (make-prompt :prompt-type "mulligan"
+                                   :choices [{:value "Keep" :uuid "keep-uuid"}
+                                             {:value "Mulligan" :uuid "mull-uuid"}])
+                      ;; the fixture must carry an :eid — the payload names the
+                      ;; prompt it answers, and an eid-less mock hides that
+                      :eid "mull-eid-1")
           sent (atom nil)]
       (with-mock-state (mock-client-state :side "runner" :prompt nil)
         (with-redefs [core/wait-for-prompt
@@ -522,7 +530,7 @@
                         (is (= :success (:status r))
                             (str "expected success after sync race, got: " r))))]
             ;; Pressed the Mulligan button (option 1).
-            (is (= {:choice {:uuid "mull-uuid"}} (:args @sent)))
+            (is (= {:choice {:uuid "mull-uuid"} :eid "mull-eid-1"} (:args @sent)))
             (is (not (str/includes? out "No mulligan prompt active")))))))))
 
 ;; ============================================================================

--- a/dev/test/ai_wire_card_ref_test.clj
+++ b/dev/test/ai_wire_card_ref_test.clj
@@ -1,0 +1,108 @@
+(ns ai-wire-card-ref-test
+  "What our seat actually puts on the wire, checked against the reference client.
+
+   `nr.gameboard.actions/send-command` narrows every card to
+   `(select-keys card [:cid :zone :side :host :type])` — one narrowing point, one
+   key list. We had four copies of that list and every one of them was missing
+   `:host`, which `get-card` needs to resolve a hosted card at all
+   (see game.ai-hosted-card-ref-test for the engine side of this).
+
+   These tests assert the payload shape rather than any game outcome, because the
+   payload is the thing that drifted from the reference."
+  (:require [clojure.test :refer :all]
+            [test-helpers :refer :all]
+            [ai-core :as core]
+            [ai-runs]
+            [ai-websocket-client-v2 :as ws]))
+
+(def board-card-keys
+  "The key set nr.gameboard.actions/send-command puts on the wire."
+  #{:cid :zone :side :host :type})
+
+(def our-card-keys
+  "Ours is the reference set plus :title, which we carry for our own logging and
+   the engine ignores. Asserted EXACTLY, so any further drift in either direction
+   is a red test rather than a silent divergence."
+  (conj board-card-keys :title))
+
+(def ^:private hosted-card
+  "A Trojan hosted on a piece of ICE, shaped as it arrives in our game state."
+  {:cid "runner-cid-1"
+   :title "Botulus"
+   :type "Program"
+   :side "Runner"
+   :zone [:onhost]
+   :host {:cid "corp-cid-1"
+          :title "Ice Wall"
+          :type "ICE"
+          :side "Corp"
+          :zone [:servers :hq :ices]}})
+
+(defn- capture-action
+  "Run body with the wire stubbed; return the args map of the single action sent."
+  [f]
+  (let [sent (atom nil)]
+    (with-redefs [ws/ensure-connected! (constantly true)
+                  ws/send-action! (fn [command args] (reset! sent {:command command :args args}) true)]
+      (f))
+    @sent))
+
+(deftest create-card-ref-carries-host
+  (testing "the shared builder keeps every key the reference client sends"
+    (let [ref (core/create-card-ref hosted-card)]
+      (is (= (:host hosted-card) (:host ref))
+          ":host is what makes a hosted card resolvable server-side")
+      (is (= our-card-keys (set (keys ref)))
+          "no key the reference client sends may be dropped, and none added quietly")))
+  (testing "an unhosted card simply carries a nil :host, as in the reference client"
+    (let [ref (core/create-card-ref (dissoc hosted-card :host :zone))]
+      (is (contains? ref :host))
+      (is (nil? (:host ref))))))
+
+(deftest select-card-carries-host
+  (testing "select! sends the hosted card's :host"
+    (let [{:keys [command args]} (capture-action #(ws/select-card! hosted-card {:eid 42}))]
+      (is (= "select" command))
+      (is (= (:host hosted-card) (get-in args [:card :host])))
+      (is (= our-card-keys (set (keys (:card args)))))
+      (is (= {:eid 42} (:eid args)) "and still targets the prompt it was shown"))))
+
+(deftest choose-carries-prompt-eid
+  (testing "choose! names the prompt it is answering"
+    ;; Without :eid the engine falls back to the HEAD of the prompt queue
+    ;; (resolve-prompt, actions.clj:266) — which is not necessarily the prompt
+    ;; the seat was shown. The reference client always sends (prompt-eid side).
+    (let [prompt {:eid {:eid 99}
+                  :msg "Choose one"
+                  :choices [{:uuid "uuid-a" :value "A"} {:uuid "uuid-b" :value "B"}]}
+          by-index (with-redefs [ai-state/get-prompt (constantly prompt)]
+                     (capture-action #(ws/choose! 1)))]
+      (is (= "choice" (:command by-index)))
+      (is (= {:uuid "uuid-b"} (get-in by-index [:args :choice])))
+      (is (= {:eid 99} (get-in by-index [:args :eid]))
+          "the eid of the prompt we rendered, not whatever is at the head"))
+    (let [prompt {:eid {:eid 101} :msg "Choose one" :choices []}
+          by-uuid (with-redefs [ai-state/get-prompt (constantly prompt)]
+                    (capture-action #(ws/choose! "uuid-z")))]
+      (is (= {:uuid "uuid-z"} (get-in by-uuid [:args :choice])))
+      (is (= {:eid 101} (get-in by-uuid [:args :eid]))
+          "including when the caller passes a raw uuid"))))
+
+;; ============================================================================
+;; The other two "choice" senders. There are THREE in the client and the CLI's
+;; `choose`/`choose-value` path uses press-choice!, not ws/choose! — fixing one
+;; and testing that one is how this bug would have survived the round.
+;; (`press-choice!` is covered where it lives, in ai-prompts-test.)
+;; ============================================================================
+
+(deftest run-auto-choice-carries-prompt-eid
+  (testing "the run monitor's single-choice auto-press names its prompt too"
+    (let [sent (atom nil)
+          prompt {:eid {:eid 7}
+                  :msg "You accessed Hedge Fund"
+                  :choices [{:uuid "only-uuid" :value "No action"}]}]
+      (with-redefs [ws/send-message! (fn [_ data] (reset! sent data) true)]
+        (ai-runs/handle-auto-choice {:my-prompt prompt :gameid "game-1"}))
+      (is (= "choice" (:command @sent)))
+      (is (= {:uuid "only-uuid"} (get-in @sent [:args :choice])))
+      (is (= {:eid 7} (get-in @sent [:args :eid]))))))

--- a/test/clj/game/ai_hosted_card_ref_test.clj
+++ b/test/clj/game/ai_hosted_card_ref_test.clj
@@ -1,0 +1,106 @@
+(ns game.ai-hosted-card-ref-test
+  "Engine premise behind the AI seat's wire card-reference shape.
+
+   The reference client narrows a card to `(select-keys card [:cid :zone :side :host :type])`
+   before putting it on the wire (`nr.gameboard.actions/send-command`). Our seat builders
+   used the same list MINUS `:host`.
+
+   `get-card` (card.cljc) branches on `:host`: with it, it walks the host's `:hosted`
+   collection; without it, it looks the cid up in `(get-in @state [side zone])`. A hosted
+   card's zone is `[:onhost]`, which is not a real zone — so the lookup misses and the
+   action resolves against `nil`.
+
+   These tests pin what that costs, so the `:host` key can never be dropped again without
+   a red test: `select` silently no-ops and `ability` is refused."
+  (:require [game.core :as core]
+            [game.test-framework :refer :all]
+            [clojure.test :refer :all]))
+
+(defn- seat-ref
+  "The card reference our seat builders put on the wire."
+  [card]
+  (select-keys card [:cid :zone :side :host :type]))
+
+(defn- seat-ref-without-host
+  "The pre-fix reference: the same list with `:host` dropped."
+  [card]
+  (dissoc (seat-ref card) :host))
+
+(deftest hosted-card-zone-is-not-a-real-zone
+  (testing "a hosted card lives at [:onhost], so a cid+zone lookup cannot find it"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)] :hand ["Ice Wall"]}
+                 :runner {:credits 15 :hand ["Botulus"]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Botulus")
+      (click-card state :runner (get-ice state :hq 0))
+      (let [bot (first (:hosted (refresh (get-ice state :hq 0))))]
+        (is (= [:onhost] (vec (:zone bot))) "hosted cards are zoned :onhost")
+        (is (some? (:host bot)) "and carry a :host back-pointer")
+        (is (nil? (core/get-card state (seat-ref-without-host bot)))
+            "dropping :host makes the card unresolvable")
+        (is (= (:cid bot) (:cid (core/get-card state (seat-ref bot))))
+            "keeping :host resolves it — this is the only difference")))))
+
+(deftest hosted-card-ability-needs-host-on-the-wire
+  (testing "firing a hosted program's ability: refused without :host, works with it"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)] :hand ["Ice Wall"]}
+                 :runner {:credits 15 :hand ["Botulus"]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Botulus")
+      (click-card state :runner (get-ice state :hq 0))
+      (let [iw (get-ice state :hq 0)
+            bot (first (:hosted (refresh iw)))]
+        (run-on state :hq)
+        (rez state :corp iw)
+        (run-continue state)
+        ;; pre-fix payload: get-card returns nil, so (:abilities nil) is nil and
+        ;; play-ability bails before any prompt is made.
+        (core/process-action "ability" state :runner
+                             {:card (seat-ref-without-host bot) :ability 0})
+        (is (= :run (:prompt-type (get-prompt state :runner)))
+            "no :host => no break prompt; the seat is still just sitting in the run")
+        (is (= 1 (count (remove :broken (:subroutines (refresh iw)))))
+            "the subroutine is still unbroken")
+        ;; post-fix payload: identical but for :host.
+        (core/process-action "ability" state :runner
+                             {:card (seat-ref bot) :ability 0})
+        (click-prompt state :runner "End the run")
+        (is (zero? (count (remove :broken (:subroutines (refresh iw)))))
+            "with :host the ability fires and breaks the subroutine")))))
+
+(deftest hosted-card-select-needs-host-on-the-wire
+  (testing "selecting a hosted card at a select prompt: silent no-op without :host"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)] :hand ["Ice Wall"]}
+                 :runner {:credits 15 :hand ["Botulus" "Scavenge"]}})
+      (play-from-hand state :corp "Ice Wall" "HQ")
+      (take-credits state :corp)
+      (play-from-hand state :runner "Botulus")
+      (click-card state :runner (get-ice state :hq 0))
+      (let [bot (first (:hosted (refresh (get-ice state :hq 0))))
+            ;; NB: identity here is by title, not :cid. A card leaving play for
+            ;; deck/hand/discard is given a fresh cid (moving.clj:139), so the
+            ;; trashed copy is deliberately not the same object as `bot`.
+            still-hosted? (fn [] (some? (seq (:hosted (refresh (get-ice state :hq 0))))))
+            in-heap? (fn [] (some #(= "Botulus" (:title %)) (:discard (:runner @state))))]
+        (play-from-hand state :runner "Scavenge")
+        (is (= :select (:prompt-type (get-prompt state :runner)))
+            "Scavenge opens a select prompt over installed programs")
+        (let [eid (:eid (get-prompt state :runner))]
+          (core/process-action "select" state :runner
+                               {:card (seat-ref-without-host bot)
+                                :eid eid
+                                :shift-key-held false})
+          (is (still-hosted?) "no :host => the select is swallowed; nothing was trashed")
+          (is (= :select (:prompt-type (get-prompt state :runner)))
+              "and the same prompt is still up, with no refusal for the seat to read")
+          (core/process-action "select" state :runner
+                               {:card (seat-ref bot)
+                                :eid eid
+                                :shift-key-held false})
+          (is (not (still-hosted?)) "with :host the selection lands")
+          (is (in-heap?) "and Scavenge trashes the program"))))))

--- a/test/clj/game/ai_phase_windows_test.clj
+++ b/test/clj/game/ai_phase_windows_test.clj
@@ -1,0 +1,108 @@
+(ns game.ai-phase-windows-test
+  "Engine premise behind the AI seat's phase-1.2 and post-discard commands.
+
+   Both windows are opened by the engine at every turn boundary and closed again
+   immediately when nothing is holding them (turns.clj:136, :262). When a card IS
+   holding one, the only exit is an explicit command: `end-phase-12` /
+   `phase-12-pass-priority`, or `end-post-discard` /
+   `post-discard-pass-priority`. There is no timer and no implicit exit. The
+   reference client puts a button on each (`board.cljs/basic-actions`); our seat
+   had none of the four, and `start-turn` told the seat to \"wait\" for a pause
+   that nothing in its surface could clear.
+
+   These tests pin what the seat is up against: the window is real, it persists,
+   the whole start-of-turn (mandatory draw, every turn-begins trigger) is held
+   behind it while ordinary actions are NOT blocked, and the consent variant needs
+   BOTH sides. They are engine-level so they stay true if our client is rewritten."
+  (:require [game.core :as core]
+            [game.core.card :refer [get-counters]]
+            [game.test-framework :refer :all]
+            [clojure.string :as str]
+            [clojure.test :refer :all]))
+
+(deftest phase-12-window-persists-until-commanded
+  (testing "a rezzed start-of-turn card holds phase 1.2 open across the turn start"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)] :hand ["Anson Rose"]}})
+      (play-from-hand state :corp "Anson Rose" "New remote")
+      (rez state :corp (get-content state :remote1 0))
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (is (:corp-phase-12 @state) "the window is open at the start of the Corp turn")
+      (is (nil? (:requires-consent (:corp-phase-12 @state)))
+          "and with no opponent-forcing card it is the Corp's alone to close")
+      ;; The engine does not close it on its own: no amount of waiting helps.
+      (core/process-action "credit" state :corp nil)
+      (is (:corp-phase-12 @state) "still open after an unrelated action")
+      (core/process-action "end-phase-12" state :corp nil)
+      (is (nil? (:corp-phase-12 @state)) "only the command closes it"))))
+
+(deftest phase-12-holds-back-the-whole-turn-start
+  (testing "the mandatory draw AND every turn-begins trigger wait on the command"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)] :hand ["Anson Rose"]}})
+      (play-from-hand state :corp "Anson Rose" "New remote")
+      (rez state :corp (get-content state :remote1 0))
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (let [anson (get-content state :remote1 0)
+            hand-size (count (:hand (:corp @state)))
+            ;; log entries are {<log-side> {:user … :text …}}, not bare messages.
+            ;; Count rather than test for presence: turn 1's own mandatory draw is
+            ;; already in the log, so a substring check would always be true.
+            draw-lines (fn [] (count (filter #(when-let [t (get-in % [:public :text])]
+                                                (str/includes? t "mandatory start of turn draw"))
+                                             (:log @state))))
+            draws-before (atom nil)]
+        ;; The engine does NOT gate ordinary actions on the window — a seat can
+        ;; spend its whole turn here without noticing (this is the "engine trusts
+        ;; the client" seam; only board.cljs greys the buttons out).
+        (let [before (:credit (:corp @state))]
+          (core/process-action "credit" state :corp nil)
+          (is (= (inc before) (:credit (:corp @state)))
+              "the action itself goes through — the engine does not gate on the window")
+          (is (:corp-phase-12 @state) "and taking it does not close the window"))
+        ;; Meanwhile nothing that should happen at the start of a turn has.
+        (is (zero? (get-counters (refresh anson) :advancement))
+            "no :corp-turn-begins trigger has fired")
+        (is (= hand-size (count (:hand (:corp @state))))
+            "no mandatory draw")
+        (reset! draws-before (draw-lines))
+        (is (= @draws-before (draw-lines)) "and nothing new in the log says otherwise")
+        (core/process-action "end-phase-12" state :corp nil)
+        (is (= 1 (get-counters (refresh anson) :advancement))
+            "the command is what fires the turn-begins triggers")
+        (is (= (inc hand-size) (count (:hand (:corp @state))))
+            "and takes the mandatory draw")
+        (is (= (inc @draws-before) (draw-lines))
+            "and says so in the log — which is where our seat reads turn boundaries")))))
+
+(deftest phase-12-consent-needs-both-seats
+  (testing "a force-phase-12-opponent card needs a pass from each side"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)] :hand ["Anson Rose"]}})
+      (play-from-hand state :corp "Anson Rose" "New remote")
+      (rez state :corp (get-content state :remote1 0))
+      (swap! state assoc-in [:runner :properties :force-phase-12-opponent] true)
+      (take-credits state :corp)
+      (take-credits state :runner)
+      (is (:requires-consent (:corp-phase-12 @state))
+          "the window now requires consent")
+      (core/process-action "phase-12-pass-priority" state :corp nil)
+      (is (:corp-phase-12 @state) "one pass is not enough")
+      (core/process-action "phase-12-pass-priority" state :runner nil)
+      (is (nil? (:corp-phase-12 @state))
+          "the window closes only when both seats have passed — so the OPPONENT
+           needs this command too, not just the active player"))))
+
+(deftest post-discard-window-persists-until-commanded
+  (testing "a forced post-discard window holds the turn boundary open"
+    (do-game
+      (new-game {:corp {:deck [(qty "Hedge Fund" 5)] :hand ["Hedge Fund"]}})
+      (swap! state assoc-in [:corp :properties :force-post-discard-self] true)
+      (core/process-action "end-turn" state :corp nil)
+      (is (:corp-post-discard @state) "the turn has not actually ended")
+      (is (= :corp (:active-player @state)) "and it is still the Corp's turn")
+      (core/process-action "end-post-discard" state :corp nil)
+      (is (nil? (:corp-post-discard @state)) "only the command closes it")
+      (is (:end-turn @state) "and the turn then ends normally"))))


### PR DESCRIPTION
A diff of the human web UI's wire behaviour against every `:game/action` our seat
emits — the sweep Michael green-lit on the forum ([195]), off the back of #110 §2
turning out to be a hardcoded `:shift-key-held false` where `board.cljs` varies.
It was: there are more of those.

Suite **643/1723 → 657/1876**, 0 failures. Shell suites green.
The remaining half of the diff — commands the reference client sends that we
still cannot — is filed as #112 rather than silently dropped.

## §1 — every card reference dropped `:host`

`nr.gameboard.actions/send-command` narrows a card **once**, to
`[:cid :zone :side :host :type]`. We had four copies of that list and every one
omitted `:host`.

`get-card` (`card.cljc:449`) branches on it: with `:host` it walks the host's
`:hosted`; without, it looks the cid up in `(get-in @state [side zone])` — and a
hosted card's zone is `[:onhost]`, which is not a real zone. So the lookup
returns `nil`, `select` silently no-ops (`actions.clj:349`) and `play-ability`
refuses on `(:abilities nil)`. Trojans and anything hosted on an asset were
unaddressable from a seat.

Consolidated to one builder rather than adding the key in four places — four
copies is how it happened. It keeps `:title` (ours, ignored by the engine) and
the test now asserts the key set **exactly**, so drift in either direction is red.

## §2 — `choice` sent no `:eid`, and my first fix was on the wrong sender

`resolve-prompt` (`actions.clj:266`) falls back to the **head of the prompt
queue** when `:eid` is absent. We were answering whichever prompt was first
rather than the one the seat was shown.

I fixed `ws/choose!` and wrote a passing test for it. The off-vendor reviewer
pointed out that `choose` / `choose-value` do not go through `ws/choose!` at all —
they go through `ai-prompts/press-choice!`, which still sent the eid-less payload.
There were **three** senders; the fix and its test had both landed on the one the
CLI does not call. All three now send it.

Two existing tests asserted the eid-less payload by exact equality and so pinned
the bug. Their fixtures carried no `:eid` at all, which is why it read as correct —
the same "the fixture omitted the field the bug lives in" shape as #31.

## §3 — the four phase-window commands did not exist

`end-phase-12`, `phase-12-pass-priority`, `end-post-discard` and
`post-discard-pass-priority` are all in the engine's command table with buttons in
`board.cljs/basic-actions`. None was in `send_command`.

The engine opens both windows at every turn boundary and closes them again in the
same breath when nothing is holding them (`turns.clj:136`) — which is exactly why
tutorial decks never showed this. When a card **does** hold one, `end-phase-12` is
what fires every `:corp-turn-begins` trigger and takes the Corp's mandatory draw.
Until it is sent, none of that has happened. **105 card defs carry the flag,
identities included** — so this is latent for every real-deck game.

And `start-turn` was printing *"Use 'wait' until the post-discard pause clears"*
for a window with no timer. That is the deadlock shape we keep re-finding: a
handler returning a pause-for-human status that nothing in the surface can convert
into an action.

Adds `end-phase-12` and `end-post-discard`, each choosing the pass-priority
variant exactly when the button does (active player + consent, or the opponent's
consent seat). `start-turn` now names the command and reports an open 1.2 window
instead of half-starting in silence.

### Design note

I built these as **explicit** commands rather than auto-passing. The window is a
priority window — auto-passing it would silently spend the seat's chance to use
start-of-turn paid abilities. A seat that ignores the pause still stalls, but now
has a way out and is told about it. Happy to add an auto-pass-when-nothing-to-use
mode if that is the call.

## Tests

Engine premises are pinned **separately from** client behaviour, so they stay true
if the client is rewritten:

- `game.ai-hosted-card-ref-test` — the same payload with and without `:host`:
  unresolvable vs resolvable, select swallowed vs landing, ability refused vs
  firing. (Identity here is by title, not `:cid`: a card leaving play for
  deck/hand/discard is given a fresh cid at `moving.clj:139`, which cost me a
  false positive first.)
- `game.ai-phase-windows-test` — the window persists, ordinary actions are *not*
  blocked by it (the engine does not gate on it — only `board.cljs` greys the
  buttons out), the whole start-of-turn waits on the command, and the consent
  variant needs both seats.
- `ai-phase-window-test` — which wire command we send in each of the six
  situations, since sending the wrong one fails **silently**: `process-action`
  returns nil for an unknown command, so a seat would sit in a window it believed
  it had closed.

## Review

Off-vendor panel (GPT-5.6 via `codex exec`) on the full diff, with my load-bearing
assumptions stated in the prompt so a shared-premise error had something to catch.
It confirmed three of my four assumptions, corrected the fourth ("closed ONLY by an
explicit command" over-claims — the engine auto-closes an unheld window), and
found the §2 CRITICAL. Five findings, all taken:

1. **CRITICAL** — the CLI's `choice` path was untouched by my fix (above).
2. **MAJOR** — the sweep owed a complete inventory, not just the parts I fixed → #112.
3. **MINOR** — the "no timer" claim over-stated; wording corrected in code and tests.
4. **MINOR** — `every? contains?` would pass with arbitrary extra keys → exact key set.
5. **MINOR** — the engine test never asserted the credit action itself worked → it does now.
