### PR TITLE
fix(#114): the orphaned turn — an opponent-owed prompt must not stop the turn ending

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ check-full:
 # Run unit tests
 test:
 	@echo "Running unit tests..."
-	lein test ai-actions-test ai-actions-sad-path-test ai-basic-actions-test ai-connection-test ai-heuristic-corp-test ai-heuristic-runner-test ai-runs-test ai-run-corp-decisions-test ai-stall-test ai-websocket-diff-test ai-websocket-error-recovery-test ai-display-test ai-state-test ai-prompts-test ai-pure-functions-test ai-turn-validation-test ai-wait-test continue-run-rez-test run-window-selfadvance-test game.ai-upgrade-rez-timing-test game.ai-duplicate-continue-test web.lobby-disconnect-test
+	lein test ai-actions-test ai-actions-sad-path-test ai-basic-actions-test ai-connection-test ai-heuristic-corp-test ai-heuristic-runner-test ai-runs-test ai-run-corp-decisions-test ai-stall-test ai-websocket-diff-test ai-websocket-error-recovery-test ai-display-test ai-state-test ai-prompts-test ai-pure-functions-test ai-turn-validation-test ai-wait-test continue-run-rez-test run-window-selfadvance-test game.ai-upgrade-rez-timing-test game.ai-duplicate-continue-test game.ai-waiting-prompt-test web.lobby-disconnect-test
 
 # Run shell-level tests (fast, no REPL/server needed) — e.g. send_command output filters
 test-shell:

--- a/dev/src/clj/ai_basic_actions.clj
+++ b/dev/src/clj/ai_basic_actions.clj
@@ -790,6 +790,25 @@
         (core/show-turn-indicator)
         (core/with-cursor {:status :success})))))
 
+(defn- arm-for
+  "Build a deferred auto-end arm for CLIENT-STATE.
+
+   Pinned to (gameid, turn, side) so a stale arm expires instead of firing an
+   end-turn into somebody else's turn, plus a unique :token so that two arms for
+   the SAME turn are never `=` — that token is what makes claim-deferred-arm!
+   exclusive rather than ABA-vulnerable."
+  [client-state side]
+  {:turn (get-in client-state [:game-state :turn])
+   :side side
+   :gameid (:gameid client-state)
+   :token (str (java.util.UUID/randomUUID))})
+
+(defn- opponent-label
+  "Human name of the other seat, for messages that must say WHO owes a decision.
+   A message that only says 'a prompt is active' is what made #114 unreadable."
+  [side]
+  (if (= (keyword side) :corp) "Runner" "Corp"))
+
 (defn check-auto-end-turn!
   "Proactively check if turn should auto-end after an action.
    Called automatically after clicks-consuming actions.
@@ -860,6 +879,33 @@
         (println "💡 Review agendas and score if able, then manually end turn")
         (flush))
 
+      ;; #114: the prompt is the OPPONENT's decision, not ours. A last click spent
+      ;; on a card that hands the other seat a choice (Public Trail, tag punishment)
+      ;; leaves us holding a :waiting pseudo-prompt with NO choices. The old code
+      ;; lumped it in with real prompts and told us to `choose` — advice with no
+      ;; referent, which sent the seat hunting and then into a wait loop.
+      ;;
+      ;; We still don't end the turn here: board.cljs' button-pane renders the
+      ;; prompt div instead of basic-actions whenever a prompt is up, so a human
+      ;; Corp in this spot has no End Turn button either. Instead ARM the re-check
+      ;; — resume-deferred-auto-end! fires it off the diff that clears the prompt.
+      ;; Without that arm the turn is orphaned at 0 clicks forever (Luna-vs-Luna
+      ;; d840fc14 turn 10: both seats deadlocked until an umpire intervened).
+      (and (= clicks 0)
+           prompt
+           (state/waiting-prompt-type? (:prompt-type prompt))
+           (not already-ended?))
+      (do
+        (swap! state/client-state assoc :auto-end-deferred (arm-for client-state side))
+        (println "")
+        (println (format "⏸️  Turn not ended yet — the %s owes a decision (you are at 0 clicks)."
+                         (opponent-label side)))
+        (println (format "   Prompt: %s" (:msg prompt)))
+        (println "   Nothing for you to do: you have no choices in this prompt.")
+        (println "   Your turn will end automatically as soon as they resolve it.")
+        (flush)
+        (core/with-cursor {:status :waiting-for-opponent :prompt prompt}))
+
       ;; Has prompt blocking - notify user
       (and (= clicks 0)
            prompt
@@ -912,6 +958,92 @@
           (println "💡 Auto-ending turn (0 clicks, nothing pending)"))
         (flush)
         (end-turn!)))))
+
+(defn- claim-deferred-arm!
+  "Atomically take ARMED off the client state. Returns true for the ONE caller
+   that actually removed it, false for everyone else.
+
+   This is the duplicate-end-turn interlock, and it has to be a claim rather than
+   a check-then-clear. Diffs arrive in bursts and each armed one spawns a resume;
+   two of them can read the same arm before either clears it, and both would then
+   pass every downstream guard (the already-ended? log line has not come back yet)
+   and send end-turn — which this codebase treats as unrecoverable engine
+   corruption. Only the winner of this claim may proceed.
+
+   Comparing against ARMED (rather than a blind dissoc) also stops a late thread
+   from deleting a NEWER arm belonging to a later turn, which would silently
+   re-open the very deadlock this fixes. Both failure modes were guest-panel
+   CRITICALs on the first cut.
+
+   The comparison relies on every arm carrying a unique :token — see arm-for.
+   Without it the claim has an ABA hole: (gameid, turn, side) can be re-armed
+   identically on the same turn (a card that hands the opponent two decisions in
+   a row), so a second caller could match the re-armed value and win a claim the
+   first caller had already taken."
+  [armed]
+  (let [[old _new] (swap-vals! state/client-state
+                               (fn [s] (if (= (:auto-end-deferred s) armed)
+                                         (dissoc s :auto-end-deferred)
+                                         s)))]
+    (= (:auto-end-deferred old) armed)))
+
+(defn resume-deferred-auto-end!
+  "#114 second half: re-run the auto-end check once the OPPONENT's decision clears.
+
+   check-auto-end-turn! arms `:auto-end-deferred` when it declines to end over a
+   :waiting pseudo-prompt. Nothing else re-evaluates that turn — maybe-auto-end-
+   turn-after-prompt! only fires for the side that resolved a prompt, and the side
+   that resolved this one is the opponent. So the orphaned turn needs a hook on
+   incoming state: this is called from the :game/diff and :game/resync handlers.
+
+   Safe to call on every state update: no arm means no work. The arm is pinned to
+   the (gameid, turn, side) it was created for, so a stale one expires instead of
+   firing an end-turn into somebody else's turn — the one unrecoverable mistake at
+   this boundary (see end-turn!'s off-turn guard).
+
+   The end-turn is gated on WINNING claim-deferred-arm!, not merely on having
+   seen an arm — see that fn for why a check-then-clear is not enough."
+  []
+  ;; Read the arm fresh: never act on a value captured before we could have been
+  ;; descheduled.
+  (when-let [armed (:auto-end-deferred @state/client-state)]
+    (let [client-state @state/client-state
+          side (keyword (:side client-state))
+          gameid (:gameid client-state)
+          turn (get-in client-state [:game-state :turn])
+          active-player (get-in client-state [:game-state :active-player])
+          my-turn? (boolean (and active-player
+                                 side
+                                 (= (str/lower-case (name side))
+                                    (str/lower-case active-player))))
+          prompt (get-in client-state [:game-state side :prompt-state])
+          still-waiting? (boolean (and prompt
+                                       (state/waiting-prompt-type? (:prompt-type prompt))))]
+      (cond
+        ;; Stale: the world moved on (different game, turn advanced, seat
+        ;; changed, or it is no longer our turn). Drop the arm — never act on it.
+        ;; The gameid pin matters because the arm now survives clear-game-state!:
+        ;; turn numbers repeat across games, so (turn, side) alone would let an
+        ;; arm from a dead game fire into a fresh one.
+        (or (not= (:side armed) side)
+            (not= (:turn armed) turn)
+            (not= (:gameid armed) gameid)
+            (not my-turn?))
+        (do (claim-deferred-arm! armed)
+            nil)
+
+        ;; They haven't decided yet. Stay armed; most diffs in this window are
+        ;; the opponent thinking out loud.
+        still-waiting?
+        nil
+
+        ;; The block cleared. Only the thread that CLAIMS the arm may end the
+        ;; turn; the losers of a concurrent burst fall out here having done
+        ;; nothing. The winner then lets check-auto-end-turn! re-apply every
+        ;; other guard (scorable agendas, paid window, already-ended) afresh.
+        :else
+        (when (claim-deferred-arm! armed)
+          (check-auto-end-turn!))))))
 
 (defn smart-end-turn!
   "Smart end-turn that checks if it's safe to end turn automatically.
@@ -1011,6 +1143,20 @@
         (println "⚠️  Cannot auto-end: you still have clicks")
         (println (format "   %d click(s) remaining - use them or end-turn --force" clicks))
         (core/with-cursor {:status :clicks-remaining :clicks clicks}))
+
+      ;; #114: opponent-owed prompt. "Resolve the prompt first" is false here —
+      ;; there is nothing we can resolve. Arm the deferred re-check (a seat that
+      ;; reaches this by typing end-turn explicitly, e.g. after a reconnect that
+      ;; skipped the automatic hook, must still get the resume) and say who we
+      ;; are actually waiting on.
+      (and has-prompt? (state/waiting-prompt-type? (:prompt-type prompt)))
+      (do
+        (swap! state/client-state assoc :auto-end-deferred (arm-for client-state side))
+        (println (format "⏸️  Cannot end yet — the %s owes a decision." (opponent-label side)))
+        (println (format "   Prompt: %s" (:msg prompt)))
+        (println "   You have no choices here. The turn ends automatically once they resolve it;")
+        (println "   do NOT re-send end-turn.")
+        (core/with-cursor {:status :waiting-for-opponent :prompt prompt}))
 
       ;; Pause: active prompt (discard, choices, etc.)
       has-prompt?

--- a/dev/src/clj/ai_state.clj
+++ b/dev/src/clj/ai_state.clj
@@ -881,7 +881,16 @@
    Call this BEFORE requesting a resync to ensure clean state."
   []
   (let [preserved-keys [:connected :socket :uid :session-token :username :csrf-token
-                        :client-id :side :gameid :spectator :spectator-perspective]]
+                        :client-id :side :gameid :spectator :spectator-perspective
+                        ;; #114: the deferred auto-end arm records that OUR turn is
+                        ;; orphaned at 0 clicks behind an opponent-owed decision.
+                        ;; Dropping it here made the resync hook dead on the only
+                        ;; path that actually runs it (guest-panel CRITICAL #3):
+                        ;; the seat came back, the arm was gone, and the turn stayed
+                        ;; orphaned with no further diff coming. It is safe to keep:
+                        ;; the arm is pinned to (gameid, turn, side) and re-validated
+                        ;; against live state before it can fire.
+                        :auto-end-deferred]]
     ;; Clear game-specific state
     (swap! client-state
            (fn [s]

--- a/dev/src/clj/ai_websocket_client_v2.clj
+++ b/dev/src/clj/ai_websocket_client_v2.clj
@@ -17,6 +17,29 @@
 
 (declare ensure-connected! send-message!)
 
+;; #114: the deferred auto-end resume lives in ai-basic-actions, which requires
+;; THIS namespace — so it can only be reached by late var lookup (same pattern as
+;; ai-prompts' maybe-auto-end-turn-after-prompt!). Held in a delay so the lookup
+;; happens once, at the first diff, long after both namespaces have loaded.
+;; requiring-resolve returns the Var, so calls still see with-redefs in tests.
+(def ^:private resume-deferred-auto-end-var
+  (delay (requiring-resolve 'ai-basic-actions/resume-deferred-auto-end!)))
+
+(defn- resume-deferred-auto-end-async!
+  "Fire the #114 deferred auto-end check off an incoming diff, if one is armed.
+
+   Off-thread deliberately: this runs on the websocket RECEIVE thread, and
+   end-turn! sleeps a full standard-delay (1s) before reading state back. Doing
+   that inline would stall every message behind it — including the diff that
+   confirms the end-turn we just sent."
+  []
+  (when (:auto-end-deferred @state/client-state)
+    (future
+      (try
+        (@resume-deferred-auto-end-var)
+        (catch Throwable t
+          (debug/debug "WARN" (str "deferred auto-end resume failed: " t)))))))
+
 ;; ============================================================================
 ;; Action Synchronization
 ;; ============================================================================
@@ -150,6 +173,9 @@
           (hud/write-game-log-to-hud 30)
           ;; Bump cursor for wait synchronization
           (state/bump-cursor!)
+          ;; #114: if our turn is orphaned behind an opponent-owed decision, this
+          ;; is the only event that can tell us it cleared.
+          (resume-deferred-auto-end-async!)
           (println "   ✓ Diff applied successfully"))
         ;; Diff doesn't match our game - we might be stale
         (do
@@ -163,7 +189,12 @@
       (println "🔄 Game resync")
       (state/set-full-state! state)
       ;; Bump cursor for wait synchronization
-      (state/bump-cursor!))
+      (state/bump-cursor!)
+      ;; #114: the arm lives in the client atom, so it survives a reconnect. A
+      ;; resync can be the state update that reveals the block cleared, and if we
+      ;; only listened for diffs there might not be another one — the game would
+      ;; be waiting on the very end-turn we're sitting on.
+      (resume-deferred-auto-end-async!))
 
     :game/error
     (do

--- a/dev/test/ai_basic_actions_test.clj
+++ b/dev/test/ai_basic_actions_test.clj
@@ -683,3 +683,263 @@
                 (str "no side = no seat = nothing to end, got: " @result))
             (is (empty? @sent)
                 "must not send end-turn without knowing which seat we are")))))))
+
+;; ============================================================================
+;; #114: a turn whose last click hands the OPPONENT a decision must still end
+;; ============================================================================
+;; Luna-vs-Luna d840fc14 turn 10: the Corp spent its last click on Public Trail,
+;; which gives the RUNNER the choice (take a tag or pay 8). The engine hands the
+;; Corp a :waiting pseudo-prompt; check-auto-end-turn! read "prompt is non-nil"
+;; as "blocking" and declined to end. When the Runner took the tag, nothing
+;; re-ran the check — the turn was orphaned at 0 clicks and both seats deadlocked
+;; until an umpire with eval access intervened.
+;;
+;; Two defects, two fixes:
+;;   1. the guidance ("use 'choose' to respond") is unactionable — the Corp has
+;;      no choices. Engine-pinned in game.ai-waiting-prompt-test: the prompt
+;;      carries :prompt-type :waiting and an empty :choices.
+;;   2. nothing re-checked when the block cleared. The turn is ARMED here and
+;;      resumed by resume-deferred-auto-end! off the next diff.
+;;
+;; We do NOT simply end the turn over the waiting prompt (the issue's first
+;; suggested bullet). board.cljs' button-pane renders the prompt div instead of
+;; basic-actions whenever a prompt is up, so a HUMAN Corp holding this prompt has
+;; no End Turn button at all — ending anyway would send what the reference client
+;; cannot. Deferring and re-checking gets the same outcome inside the wire spec.
+
+(defn- corp-waiting-on-runner-state
+  "Corp at 0 clicks holding the 'Waiting for Runner to make a decision' prompt.
+   PROMPT-TYPE defaults to the live wire form (the JSON string), not the keyword."
+  [& {:keys [prompt-type turn] :or {prompt-type "waiting" turn 10}}]
+  {:corp {:click 0 :credit 3 :hand [] :hand-count 3
+          :hand-size {:total 5} :installed {} :servers {}
+          :prompt-state {:msg "Waiting for Runner to make a decision"
+                         :prompt-type prompt-type
+                         :eid {:eid 4242}}}
+   :runner {:click 0 :credit 5 :hand []}
+   :turn turn
+   :active-player "corp"
+   :log []})
+
+(deftest test-auto-end-waiting-prompt-does-not-coach-choose
+  (testing "#114: an opponent-owed prompt must not be described as ours to resolve"
+    (let [sent (atom [])]
+      (with-mock-state (mock-client-state :side "corp"
+                                          :game-state (corp-waiting-on-runner-state))
+        (with-redefs [ws/send-message! (mock-websocket-send! sent)
+                      basic/turn-started-since-last-opp-end? (fn [] true)]
+          (let [out (with-out-str (basic/check-auto-end-turn!))]
+            (is (not (re-find #"'choose'" out))
+                (str "must not tell a seat with no choices to 'choose', got: " out))
+            (is (not (re-find #"Active prompt must be resolved first" out))
+                (str "we cannot resolve the opponent's decision, got: " out))
+            (is (re-find #"(?i)runner" out)
+                (str "must name who actually owes the decision, got: " out))
+            (is (re-find #"(?i)automatic" out)
+                (str "must promise the re-check so the seat doesn't hunt, got: " out))
+            (is (empty? @sent)
+                "must not end the turn while the reference client shows no End Turn button")))))))
+
+(deftest test-auto-end-waiting-prompt-arms-the-recheck
+  (testing "#114: deferring records enough to validate the resume later"
+    (with-mock-state (mock-client-state :side "corp"
+                                        :game-state (corp-waiting-on-runner-state))
+      (with-redefs [ws/send-message! (fn [& _] nil)
+                    basic/turn-started-since-last-opp-end? (fn [] true)]
+        (with-out-str (basic/check-auto-end-turn!))
+        (let [armed (:auto-end-deferred @state/client-state)]
+          (is (some? armed) "the waiting branch must arm the deferred re-check")
+          (is (= 10 (:turn armed)) "pinned to the turn it was armed on")
+          (is (= :corp (:side armed)) "and to the seat that owes the end-turn"))))))
+
+(deftest test-auto-end-waiting-prompt-arms-on-keyword-prompt-type
+  (testing "#114: fixture/keyword :waiting is recognised too, not just the wire string"
+    (with-mock-state (mock-client-state
+                       :side "corp"
+                       :game-state (corp-waiting-on-runner-state :prompt-type :waiting))
+      (with-redefs [ws/send-message! (fn [& _] nil)
+                    basic/turn-started-since-last-opp-end? (fn [] true)]
+        (with-out-str (basic/check-auto-end-turn!))
+        (is (some? (:auto-end-deferred @state/client-state)))))))
+
+(deftest test-real-prompt-still-blocks-and-does-not-arm
+  (testing "#114 no over-reach: a prompt WE owe keeps the original blocking behaviour"
+    (let [sent (atom [])
+          gs (assoc-in (corp-waiting-on-runner-state)
+                       [:corp :prompt-state]
+                       {:msg "Choose a card to discard" :prompt-type "select"
+                        :choices [{:value "x"}] :eid {:eid 1}})]
+      (with-mock-state (mock-client-state :side "corp" :game-state gs)
+        (with-redefs [ws/send-message! (mock-websocket-send! sent)
+                      basic/turn-started-since-last-opp-end? (fn [] true)]
+          (let [out (with-out-str (basic/check-auto-end-turn!))]
+            (is (re-find #"Active prompt must be resolved first" out)
+                (str "an actionable prompt must still block loudly, got: " out))
+            (is (nil? (:auto-end-deferred @state/client-state))
+                "and must NOT arm a deferred end — we owe this one")
+            (is (empty? @sent))))))))
+
+;; --- the resume half -------------------------------------------------------
+
+(defn- armed-state
+  "Client state armed for a deferred auto-end, with GAME-STATE as the world now.
+   The arm's :gameid is taken from the state being built, exactly as
+   check-auto-end-turn! writes it — a hand-written gameid here would drift from
+   the code and turn every one of these into a vacuous 'stale arm' pass."
+  [game-state & {:keys [turn side] :or {turn 10 side :corp}}]
+  (let [cs (mock-client-state :side (name side) :game-state game-state)]
+    (assoc cs :auto-end-deferred {:turn turn :side side :gameid (:gameid cs)})))
+
+(deftest test-resume-deferred-ends-turn-once-opponent-resolves
+  (testing "#114: the waiting prompt clearing is what ends the orphaned turn"
+    (let [sent (atom [])
+          ;; exactly the post-resolution state pinned by game.ai-waiting-prompt-test:
+          ;; prompt gone, 0 clicks, turn still open
+          gs (assoc-in (corp-waiting-on-runner-state) [:corp :prompt-state] nil)]
+      (with-mock-state (armed-state gs)
+        (with-redefs [ws/send-message! (mock-websocket-send! sent)
+                      basic/turn-started-since-last-opp-end? (fn [] true)]
+          (with-out-str (basic/resume-deferred-auto-end!))
+          (is (some #(= "end-turn" (get-in % [:data :command])) @sent)
+              (str "the deadlocked turn must end itself, sent: " @sent))
+          (is (nil? (:auto-end-deferred @state/client-state))
+              "and disarm, so a later diff can't re-send end-turn"))))))
+
+(deftest test-resume-deferred-noop-while-opponent-still-deciding
+  (testing "#114: every other diff in the window must be a no-op"
+    (let [sent (atom [])]
+      (with-mock-state (armed-state (corp-waiting-on-runner-state))
+        (with-redefs [ws/send-message! (mock-websocket-send! sent)
+                      basic/turn-started-since-last-opp-end? (fn [] true)]
+          (with-out-str (basic/resume-deferred-auto-end!))
+          (is (empty? @sent) "waiting prompt still up — nothing to do")
+          (is (some? (:auto-end-deferred @state/client-state))
+              "and stay armed for the diff that does clear it"))))))
+
+(deftest test-resume-deferred-noop-when-not-armed
+  (testing "#114: an unarmed client must not auto-end off arbitrary diffs"
+    (let [sent (atom [])
+          gs (assoc-in (corp-waiting-on-runner-state) [:corp :prompt-state] nil)]
+      (with-mock-state (mock-client-state :side "corp" :game-state gs)
+        (with-redefs [ws/send-message! (mock-websocket-send! sent)
+                      basic/turn-started-since-last-opp-end? (fn [] true)]
+          (with-out-str (basic/resume-deferred-auto-end!))
+          (is (empty? @sent)
+              "no arm = no end-turn: diffs arrive constantly, including on the opponent's turn"))))))
+
+(deftest test-resume-deferred-expires-on-a-later-turn
+  (testing "#114: a stale arm must never fire into a turn it wasn't armed for"
+    (let [sent (atom [])
+          ;; turn moved on and it's the Runner's turn now — the arm is garbage
+          gs (-> (corp-waiting-on-runner-state :turn 11)
+                 (assoc-in [:corp :prompt-state] nil)
+                 (assoc :active-player "runner"))]
+      (with-mock-state (armed-state gs :turn 10)
+        (with-redefs [ws/send-message! (mock-websocket-send! sent)
+                      basic/turn-started-since-last-opp-end? (fn [] true)]
+          (with-out-str (basic/resume-deferred-auto-end!))
+          (is (empty? @sent) "must not end-turn off a stale arm")
+          (is (nil? (:auto-end-deferred @state/client-state))
+              "and must clear the stale arm rather than carry it forward"))))))
+
+(deftest test-smart-end-turn-waiting-prompt-guidance
+  (testing "#114: the explicit command must also not blame us for the opponent's prompt"
+    (with-mock-state (mock-client-state :side "corp"
+                                        :game-state (corp-waiting-on-runner-state))
+      (with-redefs [ws/send-message! (fn [& _] nil)
+                    basic/turn-started-since-last-opp-end? (fn [] true)]
+        (let [out (with-out-str (basic/smart-end-turn!))]
+          (is (not (re-find #"Resolve the prompt first" out))
+              (str "there is no prompt we can resolve, got: " out))
+          (is (re-find #"(?i)runner" out)
+              (str "must name who owes the decision, got: " out)))))))
+
+;; --- guest-panel CRITICALs on the first cut of the #114 fix ----------------
+;; All three were real. Recorded as tests because none of them is visible from
+;; the happy path: the fix worked perfectly in every single-threaded run.
+
+;; The interlock is claim-deferred-arm!: end-turn is gated on WINNING it, not on
+;; having seen an arm. Tested as an invariant rather than by racing threads — a
+;; race test here does NOT discriminate (verified by mutation: with the interlock
+;; removed, 8 concurrent resumes still produced one end-turn, because the window
+;; between reading the arm and clearing it is shorter than future-spawn overhead).
+;; A test that cannot fail against the broken code is not a regression pin.
+(def ^:private claim-arm! #'basic/claim-deferred-arm!)
+
+(deftest test-arm-claim-is-exclusive
+  (testing "#114 CRITICAL: exactly one caller may take the arm"
+    (let [arm {:turn 10 :side :corp :gameid "g1"}]
+      (with-mock-state (assoc (mock-client-state :side "corp") :auto-end-deferred arm)
+        (is (true? (claim-arm! arm)) "first caller takes it")
+        (is (false? (claim-arm! arm))
+            "second caller must LOSE — if it proceeded we would send a duplicate end-turn")
+        (is (nil? (:auto-end-deferred @state/client-state)))))))
+
+(deftest test-two-arms-for-the-same-turn-are-distinguishable
+  (testing "#114 CRITICAL: the claim must not be ABA-vulnerable"
+    ;; A card can hand the opponent two decisions in a row, so the SAME
+    ;; (gameid, turn, side) gets armed twice. If those two arms compare equal, a
+    ;; caller whose claim was already consumed can match the re-armed value and
+    ;; win a second claim — two end-turns, which is unrecoverable here.
+    (let [gs (corp-waiting-on-runner-state)
+          arm-twice (fn []
+                      (with-mock-state (mock-client-state :side "corp" :game-state gs)
+                        (with-redefs [ws/send-message! (fn [& _] nil)
+                                      basic/turn-started-since-last-opp-end? (fn [] true)]
+                          (with-out-str (basic/check-auto-end-turn!))
+                          (let [first-arm (:auto-end-deferred @state/client-state)]
+                            (with-out-str (basic/check-auto-end-turn!))
+                            [first-arm (:auto-end-deferred @state/client-state)]))))
+          [a b] (arm-twice)]
+      (is (some? a))
+      (is (some? b))
+      (is (not= a b)
+          "re-arming the same turn must produce a DISTINCT arm, or the claim can be won twice")
+      (is (= (dissoc a :token) (dissoc b :token))
+          "…distinct only by token: the (gameid, turn, side) pin must still match"))))
+
+(deftest test-arm-claim-refuses-a-different-arm
+  (testing "#114 CRITICAL: claiming is compare-and-clear, so it cannot eat a newer arm"
+    (let [live {:turn 12 :side :corp :gameid "g1"}
+          stale {:turn 10 :side :corp :gameid "g1"}]
+      (with-mock-state (assoc (mock-client-state :side "corp") :auto-end-deferred live)
+        (is (false? (claim-arm! stale)) "a late thread's stale arm must not win")
+        (is (= live (:auto-end-deferred @state/client-state))
+            "and turn 12's arm must survive — it is the only thing that will end turn 12")))))
+
+(deftest test-concurrent-resumes-send-at-most-one-end-turn
+  (testing "#114: stress check (not a regression pin — see comment above)"
+    (let [sent (atom [])
+          gs (assoc-in (corp-waiting-on-runner-state) [:corp :prompt-state] nil)]
+      (with-mock-state (armed-state gs)
+        (with-redefs [ws/send-message! (mock-websocket-send! sent)
+                      basic/turn-started-since-last-opp-end? (fn [] true)]
+          (let [threads (mapv (fn [_] (future (with-out-str (basic/resume-deferred-auto-end!))))
+                              (range 8))]
+            (doseq [t threads] (deref t 10000 :timeout))
+            (is (= 1 (count (filter #(= "end-turn" (get-in % [:data :command])) @sent)))
+                (str "exactly one end-turn must reach the wire, sent: " @sent))))))))
+
+(deftest test-arm-from-a-different-game-never-fires
+  (testing "#114 CRITICAL: the arm now survives clear-game-state!, so it must be game-pinned"
+    (let [sent (atom [])
+          gs (assoc-in (corp-waiting-on-runner-state) [:corp :prompt-state] nil)]
+      (with-mock-state (assoc (mock-client-state :side "corp" :game-state gs)
+                              :auto-end-deferred
+                              {:turn 10 :side :corp
+                               :gameid (java.util.UUID/fromString
+                                         "ffffffff-ffff-ffff-ffff-ffffffffffff")})
+        (with-redefs [ws/send-message! (mock-websocket-send! sent)
+                      basic/turn-started-since-last-opp-end? (fn [] true)]
+          (with-out-str (basic/resume-deferred-auto-end!))
+          (is (empty? @sent)
+              "turn numbers repeat across games — an arm from a dead game must not end a live turn")
+          (is (nil? (:auto-end-deferred @state/client-state))))))))
+
+(deftest test-arm-survives-clear-game-state
+  (testing "#114 CRITICAL: a resync must not forget that our turn is orphaned"
+    (with-mock-state (assoc (mock-client-state :side "corp")
+                            :auto-end-deferred {:turn 10 :side :corp :gameid "g1"})
+      (with-out-str (state/clear-game-state!))
+      (is (= {:turn 10 :side :corp :gameid "g1"} (:auto-end-deferred @state/client-state))
+          "cleared with the rest of game state, the resync hook has nothing to act on"))))

--- a/dev/test/ai_websocket_error_recovery_test.clj
+++ b/dev/test/ai_websocket_error_recovery_test.clj
@@ -8,7 +8,8 @@
   (:require [clojure.test :refer :all]
             [test-helpers :refer [mock-client-state with-mock-state mock-websocket-send!]]
             [ai-websocket-client-v2 :as ws]
-            [ai-state :as state]))
+            [ai-state :as state]
+            [ai-basic-actions]))
 
 (deftest test-game-error-triggers-resync
   (testing "receiving :game/error requests a full resync for the current game"
@@ -93,3 +94,50 @@
                           :data {:gameid "00000000-0000-0000-0000-000000000002"}})
       (is (not (state/lobby-gone?))
           "being seated in a lobby again must retract the gone verdict"))))
+
+;; ============================================================================
+;; #114: the deferred auto-end resume must be ON the live state-update path
+;; ============================================================================
+;; The resume logic itself is unit-tested in ai-basic-actions-test. What that
+;; can't show is whether anything ever CALLS it in a real game — and a resume
+;; nobody calls leaves the turn orphaned exactly as before. These pin the two
+;; message types that carry new state to a seat sitting at 0 clicks behind an
+;; opponent-owed decision.
+
+(defn- await-resume-call
+  "Run BODY and return true if the deferred resume fired within 2s.
+   The hook runs on a future (the diff handler is the websocket receive thread
+   and end-turn! sleeps a full second), so this can't be a bare assertion."
+  [body-fn]
+  (let [called (promise)]
+    (with-redefs [ai-basic-actions/resume-deferred-auto-end! (fn [] (deliver called true))]
+      (body-fn)
+      (= true (deref called 2000 :timeout)))))
+
+(deftest test-game-diff-fires-deferred-auto-end-resume
+  (testing "#114: an incoming diff re-checks an armed turn"
+    (with-mock-state (assoc (mock-client-state :side "corp")
+                            :auto-end-deferred {:turn 10 :side :corp})
+      (let [gameid (:gameid @state/client-state)]
+        (is (await-resume-call
+              #(ws/handle-message {:type :game/diff
+                                   :data {:gameid gameid :diff [{} {}]}}))
+            "the diff that clears the opponent's prompt is the ONLY event that can end this turn")))))
+
+(deftest test-game-resync-fires-deferred-auto-end-resume
+  (testing "#114: a resync counts too — the arm survives a reconnect"
+    (with-mock-state (assoc (mock-client-state :side "corp")
+                            :auto-end-deferred {:turn 10 :side :corp})
+      (is (await-resume-call
+            #(ws/handle-message {:type :game/resync
+                                 :data {:turn 10 :active-player "corp"}}))
+          "otherwise a seat that reconnected waits for a diff the game may never send"))))
+
+(deftest test-game-diff-does-not-fire-resume-when-unarmed
+  (testing "#114: no arm, no thread — diffs arrive constantly all game"
+    (with-mock-state (mock-client-state :side "corp")
+      (let [gameid (:gameid @state/client-state)]
+        (is (not (await-resume-call
+                   #(ws/handle-message {:type :game/diff
+                                        :data {:gameid gameid :diff [{} {}]}})))
+            "unarmed clients must not spawn a resume on every diff")))))

--- a/test/clj/game/ai_waiting_prompt_test.clj
+++ b/test/clj/game/ai_waiting_prompt_test.clj
@@ -1,0 +1,84 @@
+(ns game.ai-waiting-prompt-test
+  "Issue #114: a Corp turn whose LAST click hands the Runner a decision never ends.
+
+   The client's auto-end guard treats any non-nil :prompt-state as blocking, so the
+   Corp-side 'Waiting for Runner to make a decision' pseudo-prompt stops the turn
+   from ending — and nothing re-runs the check once the Runner resolves it. Both
+   seats then deadlock permanently (Luna-vs-Luna game d840fc14, turn 10).
+
+   This namespace pins the two ENGINE facts the client fix depends on, so the unit
+   fixtures in ai-basic-actions-test can't drift away from the wire:
+
+   1. The pseudo-prompt the Corp holds really does carry :prompt-type :waiting —
+      i.e. `state/waiting-prompt-type?` is the right discriminator, not a message
+      regex. (The #109 lesson: copying a predicate isn't inheriting its authority.)
+   2. It really does clear on its own when the Runner resolves, leaving the Corp
+      at 0 clicks with NO prompt — the state the deferred re-check must act on."
+  (:require [game.core :as core]
+            [game.core.diffs :as diffs]
+            [game.test-framework :refer :all]
+            [cheshire.core :as json]
+            [ai-state]
+            [clojure.test :refer :all]))
+
+(defn- corp-prompt
+  "The Corp's :prompt-state as the server privatizes it — still Clojure values."
+  [state]
+  (get-in (diffs/public-states state) [:corp-state :corp :prompt-state]))
+
+(defn- over-the-wire
+  "Round-trip through the client's actual transport encoding.
+
+   public-states alone stops short of the boundary that matters: the diff is
+   JSON-encoded on the way out and parsed with keywordized keys on the way in, so
+   the server's KEYWORD :waiting reaches the seat as the STRING \"waiting\". A test
+   that asserts the keyword and stops has not pinned what the client sees — it
+   would stay green while the live seat fell through to the actionable-prompt
+   branch. (Guest-panel MINOR on the first cut of this file.)"
+  [x]
+  (json/parse-string (json/generate-string x) true))
+
+(deftest corp-last-click-opponent-decision-leaves-a-waiting-prompt
+  (testing "#114: Public Trail on the last click -> Corp holds a :waiting pseudo-prompt at 0 clicks"
+    (do-game
+      (new-game {:corp {:hand ["Public Trail"]}
+                 :runner {:hand ["Sure Gamble"]}})
+      ;; Public Trail requires the Runner to have made a successful run last turn.
+      (take-credits state :corp)
+      (run-empty-server state "Archives")
+      (take-credits state :runner)
+      ;; Burn down to a single click, then spend it on the card that hands the
+      ;; Runner the decision — the exact shape from the seat log.
+      (core/gain state :corp :credit 10)
+      (click-credit state :corp)
+      (click-credit state :corp)
+      (play-from-hand state :corp "Public Trail")
+
+      (is (zero? (get-in @state [:corp :click]))
+          "precondition: the last click is spent")
+      (is (not (:end-turn @state))
+          "precondition: the turn has not ended")
+
+      (let [prompt (corp-prompt state)
+            wire (over-the-wire prompt)]
+        (is (some? prompt)
+            "Corp holds a prompt — this is what blocks the client's auto-end")
+        (is (= :waiting (:prompt-type prompt))
+            (str "server-side, the blocking prompt must be tagged :waiting, got: " (pr-str prompt)))
+        ;; The assertion that actually protects the fix: the discriminator the
+        ;; client keys on must accept the value the client RECEIVES, after JSON.
+        (is (ai-state/waiting-prompt-type? (:prompt-type wire))
+            (str "waiting-prompt-type? must recognise the post-JSON value, got: "
+                 (pr-str (:prompt-type wire))))
+        (is (re-find #"(?i)waiting for" (str (:msg wire)))
+            "and it reads as a waiting message")
+        (is (empty? (:choices wire))
+            "the Corp has NO choices here — 'use choose to respond' is unactionable advice"))
+
+      (testing "the Runner resolving it clears the Corp's prompt, with the turn still open"
+        (click-prompt state :runner "Take 1 tag")
+        (is (nil? (corp-prompt state))
+            "Corp's waiting prompt clears on its own — nothing left to resolve")
+        (is (zero? (get-in @state [:corp :click])))
+        (is (not (:end-turn @state))
+            "but the turn is STILL not ended: this is the orphaned state a re-check must catch")))))


### PR DESCRIPTION
Closes the first three bullets of #114. Fourth bullet split to #117.

## The bug

A Corp turn whose last click hands the Runner a decision never ended. The engine
gives the Corp a `:waiting` pseudo-prompt; `check-auto-end-turn!` classified any
non-nil prompt as blocking, and nothing re-ran the check when the Runner
resolved. Both seats deadlocked permanently — a seat without an umpire holding
`eval` has no recovery path at all.

## The fix

- **Guidance**: the waiting case is split out in `check-auto-end-turn!` and
  `smart-end-turn!`. It names who owes the decision and stops telling a seat with
  no choices to `choose`.
- **Re-check**: `check-auto-end-turn!` arms `:auto-end-deferred`;
  `resume-deferred-auto-end!` fires from `:game/diff` and `:game/resync`, off the
  websocket receive thread (`end-turn!` sleeps 1s — inline would stall every
  message behind it, including the diff confirming our own end-turn).

**Not** the issue's first suggested bullet ("end the turn over the waiting
prompt"). `board.cljs`' `button-pane` renders the prompt div instead of
`basic-actions` whenever a prompt is up, so a human Corp here has no End Turn
button; deferring reaches the same outcome inside the wire spec. Noted in #114
that the engine *would* have accepted it — this is a self-imposed constraint.

## Review

Guest panel (GPT-5.6 via codex) found three CRITICALs in the first cut, all
confirmed and fixed, plus an ABA hole in the fix for the first one on a second
pass. All concern the arm's concurrency and lifecycle; none was visible from the
happy path. Detail in the #114 comment.

## Tests

662 (was 643), green. New `game.ai-waiting-prompt-test` pins the engine facts the
client rests on — including that the prompt-type survives JSON as something
`waiting-prompt-type?` accepts, which is the assertion that would have caught a
wire-shape drift. Every non-obvious guard mutation-tested. The 8-thread stress
test does not discriminate and says so in its own name and comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)