### PR TITLE
fix(#115): decode the my-run-window wake, and stop steering a passed seat to 'continue'

### DIFF
--- a/dev/seat-corp-devin.md
+++ b/dev/seat-corp-devin.md
@@ -42,6 +42,12 @@ of ICE, not the presence of an agenda, that makes a hand a throw.
    `start-turn`); it is NOT a stall. Reason `my-turn` (with clicks) means act now.
    A `wait` that wakes because **a run started** means **defend it now** (see the
    ⚠️ box below).
+   Reason `my-run-window` means **a run is stopped on YOU**: you owe the
+   `continue` at the current run window. It fires on every run. At an ICE
+   *approach* that continue is also your rez window (`continue --rez <ice>` to
+   rez first, `--no-rez` to decline); at movement there is nothing to rez, just
+   pass. Another `wait` cannot advance it, and an empty game log under it means
+   the Runner is already waiting on you — do not read it as nothing-happened.
 
 2a. **OPENING MULLIGAN RACE — do NOT give up if `start-turn` is refused.** You
    keep your hand first, but the Runner may not have finished its mulligan yet. If

--- a/dev/seat-corp.md
+++ b/dev/seat-corp.md
@@ -69,6 +69,12 @@ hand + recent log + cursor in ONE call):
    Do this every turn before acting. A `wait` at a turn boundary wakes with reason
    `my-turn-start` (and prints a 👉 start-turn reminder) — that means start your
    turn, it is NOT a stall. Reason `my-turn` (with clicks) means act now.
+   Reason `my-run-window` means **a run is stopped on YOU**: you owe the
+   `continue` at the current run window. It fires on every run. At an ICE
+   *approach* that continue is also your rez window (`continue --rez <ice>` to
+   rez first, `--no-rez` to decline); at movement there is nothing to rez, just
+   pass. Another `wait` cannot advance it, and an empty game log under it means
+   the Runner is already waiting on you — do not read it as nothing-happened.
 1. **See state:** `./dev/send_command corp snapshot`
    **Don't guess what a card does — look it up:** `card-text "<name>"` gives any
    card's type/cost/text; `abilities "<name>"` lists an installed card's numbered

--- a/dev/seat-runner-devin.md
+++ b/dev/seat-runner-devin.md
@@ -27,6 +27,12 @@ already kept its hand. You take the Runner seat.
    ```
    A `wait` that wakes with reason `my-turn-start` means **start your turn** (run
    `start-turn`); it is NOT a stall. Reason `my-turn` (with clicks) means act now.
+   Reason `my-run-window` means **a run is stopped on YOU**: you owe the
+   `continue` at the current run window (an ICE approach, or movement past one).
+   It fires on every run. Another `wait` cannot advance it, and an empty game log
+   under it means the opponent is already waiting on you — do not read it as
+   nothing-happened. (A break/`tank` decision is a different wake:
+   `encounter-decision`.)
 
    **Do NOT give up just because a `wait` times out empty.** A `wait` return now
    ends with a peer-liveness line — and you can check any time with

--- a/dev/seat-runner-sol.md
+++ b/dev/seat-runner-sol.md
@@ -27,6 +27,12 @@ already kept its hand. You take the Runner seat.
    ```
    A `wait` that wakes with reason `my-turn-start` means **start your turn** (run
    `start-turn`); it is NOT a stall. Reason `my-turn` (with clicks) means act now.
+   Reason `my-run-window` means **a run is stopped on YOU**: you owe the
+   `continue` at the current run window (an ICE approach, or movement past one).
+   It fires on every run. Another `wait` cannot advance it, and an empty game log
+   under it means the opponent is already waiting on you — do not read it as
+   nothing-happened. (A break/`tank` decision is a different wake:
+   `encounter-decision`.)
 
    **Do NOT give up just because a `wait` times out empty.** A `wait` return now
    ends with a peer-liveness line — and you can check any time with

--- a/dev/seat-runner-terra.md
+++ b/dev/seat-runner-terra.md
@@ -27,6 +27,12 @@ already kept its hand. You take the Runner seat.
    ```
    A `wait` that wakes with reason `my-turn-start` means **start your turn** (run
    `start-turn`); it is NOT a stall. Reason `my-turn` (with clicks) means act now.
+   Reason `my-run-window` means **a run is stopped on YOU**: you owe the
+   `continue` at the current run window (an ICE approach, or movement past one).
+   It fires on every run. Another `wait` cannot advance it, and an empty game log
+   under it means the opponent is already waiting on you — do not read it as
+   nothing-happened. (A break/`tank` decision is a different wake:
+   `encounter-decision`.)
 
    **Do NOT give up just because a `wait` times out empty.** A `wait` return now
    ends with a peer-liveness line — and you can check any time with

--- a/dev/seat-runner.md
+++ b/dev/seat-runner.md
@@ -54,6 +54,12 @@ You have 4 clicks. A turn auto-ends when clicks hit 0. A rough loop:
    acting. A `wait` at a turn boundary wakes with reason `my-turn-start` (and
    prints a 👉 start-turn reminder) — that means start your turn, it is NOT a
    stall. Reason `my-turn` (with clicks) means act now.
+   Reason `my-run-window` means **a run is stopped on YOU**: you owe the
+   `continue` at the current run window (an ICE approach, or movement past one).
+   It fires on every run. Another `wait` cannot advance it, and an empty game log
+   under it means the opponent is already waiting on you — do not read it as
+   nothing-happened. (A break/`tank` decision is a different wake:
+   `encounter-decision`.)
 1. **See state** (use the compact forms to save tokens):
    `status-compact`, `board-compact`, `hand`, `list-playables`.
    **Don't guess what a card does — look it up:** `card-text "<name>"` gives any

--- a/dev/src/clj/ai_core.clj
+++ b/dev/src/clj/ai_core.clj
@@ -1533,6 +1533,37 @@
   [phase]
   (contains? #{"approach-ice" "movement"} phase))
 
+(defn ice-pass-index
+  "Convert the run's `position` COUNTDOWN into the 1-based order the Runner meets
+   the ICE — position = ice-count is the outermost ICE, i.e. ICE 1 of N. Returns
+   nil when the inputs can't support an honest index (no count, past all ICE, or
+   a position out of range — the wire is the volatile coupling, so drop the index
+   rather than print a bogus one).
+
+   Single source for the convention (#115): the run ladder printed 'ICE 1 of 2'
+   while the approach handler printed 'position 2/2' two lines above it — the same
+   ICE under two conventions that read as a contradiction."
+  [position ice-count]
+  (when (and ice-count position (pos? position) (<= position ice-count))
+    (inc (- ice-count position))))
+
+(defn describe-approached-ice
+  "One line naming the ICE the Runner is approaching, in the ladder's convention.
+
+   Renders the fog of war honestly instead of as breakage: an unrezzed ICE has no
+   title on the Runner's wire, and the old format string put the literal default
+   through %s to print `ICE: ICE` (#115), which reads as a display bug rather than
+   as 'you are not allowed to know yet'."
+  [ice-title position ice-count]
+  (let [idx   (ice-pass-index position ice-count)
+        where (if idx
+                (format "ICE %d of %d (outermost first)" idx ice-count)
+                "ICE")
+        named (when (and ice-title (not= ice-title "ICE")) ice-title)]
+    (if named
+      (format "%s: %s — unrezzed" where named)
+      (format "%s — unrezzed, identity hidden until the Corp rezzes it" where))))
+
 (defn- run-window-owner
   "Who owns the FIRST un-passed pass at the current run pass-window, or nil when it
    is not a pass window or both seats have already passed. Ownership is read from
@@ -1740,6 +1771,57 @@
        ;; Nothing relevant
        :else nil))))
 
+(defn wake-reason-guidance-lines
+  "Lines that decode a wake `reason` into the action it demands, printed under the
+   `⚡ Woke up: <reason>` line. `state` is the full client-state (only :game-state
+   is read, for the winner). Pure; returns a (possibly empty) vector of strings.
+
+   Why this is a function and not two inline conds (#115): the reason token is
+   emitted from TWO places — the fast :already-advanced path and the polling
+   loop — and only the polling copy had grown guidance. A seat whose cursor had
+   already advanced got the bare token for every reason but :my-turn-start, so
+   :game-over / :game-gone / :encounter-decision arrived undecoded there. Same
+   shape as send-continue!'s three copies (#75/#77) and the prompt :eid fix that
+   landed on the wrong sender (#113): N emitters, one contract. Both call here.
+   (The fast path cannot currently report :my-run-window itself — it passes
+   initial-run-active? false, so a live run always resolves to :run-started
+   first — but that is a property of the caller, not something to encode twice.)
+
+   :my-run-window in particular shipped with NO decoding anywhere — not here, not
+   in a single seat brief — and two Luna seats independently read
+   `⚡ Woke up: my-run-window` + `(no new entries)` as nothing-happened and
+   re-blocked while owing the pass that advances the run (#115)."
+  [reason state]
+  (case reason
+    :my-turn-start
+    ["   👉 Turn boundary: call `start-turn` before acting (0 clicks until you do)"]
+
+    ;; The seat OWNS the un-passed pass at an active run window (my-run-window?
+    ;; = run-window-owner names us at approach-ice / movement). The run cannot
+    ;; advance until we send it, so another `wait` returns here unchanged — the
+    ;; precise trap this guidance exists to break.
+    :my-run-window
+    ["   👉 The run is stopped on YOU: you owe the pass at this run window."
+     "      Act — `prompt` shows the window; the verb is usually `continue`"
+     "      (Corp at an ICE approach: `continue --rez <ice>` to rez first)."
+     "      Another `wait` cannot advance it, and an empty game log here means the"
+     "      opponent is already waiting on you."]
+
+    :encounter-decision
+    ;; NOT jack-out: it is movement-window only, so at an encounter it is both
+    ;; illegal and a subroutine-skip. `jack-out` refuses here with the same steer.
+    ["   👉 ICE encounter with unbroken subs: `continue` to see options, then break / tank"]
+
+    :game-over
+    (let [winner (get-in state [:game-state :winner])]
+      [(format "   🏁 Game over%s — stop acting; call `game-over-status` for the result, then tear down."
+               (if winner (str " — " (clojure.string/capitalize (name winner)) " wins") ""))])
+
+    :game-gone
+    ["   🏚️  The server closed this game's lobby — the game is GONE, not paused. Stop acting; `game-over-status` will confirm (GAME-GONE)."]
+
+    []))
+
 (defn wait-for-relevant-diff
   "Block until something we care about happens, then return.
 
@@ -1841,8 +1923,8 @@
          (when (:verbose opts)
            (println (format "⚡ Cursor advanced (%d → %d), %s — returning immediately"
                            since-cursor current-cursor (name since-reason)))
-           (when (= since-reason :my-turn-start)
-             (println "   👉 Turn boundary: call `start-turn` before acting (0 clicks until you do)")))
+           (doseq [line (wake-reason-guidance-lines since-reason current-state)]
+             (println line)))
          {:status :already-advanced
           :reason since-reason
           :cursor current-cursor
@@ -1887,19 +1969,8 @@
                  (do
                    (when (:verbose opts)
                      (println (format "⚡ Woke up: %s" (name reason)))
-                     (when (= reason :my-turn-start)
-                       (println "   👉 Turn boundary: call `start-turn` before acting (0 clicks until you do)"))
-                     (when (= reason :encounter-decision)
-                       ;; NOT jack-out: it is movement-window only, so at an
-                       ;; encounter it is both illegal and a subroutine-skip.
-                       ;; `jack-out` refuses here with the same steer.
-                       (println "   👉 ICE encounter with unbroken subs: `continue` to see options, then break / tank"))
-                     (when (= reason :game-over)
-                       (let [winner (get-in current-state [:game-state :winner])]
-                         (println (format "   🏁 Game over%s — stop acting; call `game-over-status` for the result, then tear down."
-                                          (if winner (str " — " (clojure.string/capitalize (name winner)) " wins") "")))))
-                     (when (= reason :game-gone)
-                       (println "   🏚️  The server closed this game's lobby — the game is GONE, not paused. Stop acting; `game-over-status` will confirm (GAME-GONE)."))
+                     (doseq [line (wake-reason-guidance-lines reason current-state)]
+                       (println line))
                      (println "")
                      (println "📜 Game log while you were waiting:")
                      (if (seq entries-since-start)

--- a/dev/src/clj/ai_display.clj
+++ b/dev/src/clj/ai_display.clj
@@ -1081,6 +1081,29 @@
       (seq k) (str "the " k " server")
       :else "the server")))
 
+(defn both-pass-window?
+  "True when `run-phase` is a window `my-side` advances by PASSING PRIORITY, and
+   whose pass the engine records in [:run :no-action] — i.e. one that must route
+   through run-priority-hint-lines so an already-passed seat is not told to
+   `continue` at a window it cannot advance.
+
+   The Runner owns a sub-step at initiation, approach-ice and movement/
+   approach-server; the Corp's initiation and approach-ice sub-steps carry a rez /
+   paid-ability decision, so those two keep their own richer steer and are not
+   listed here. encounter-ice is deliberately absent: its passer lives on
+   [:encounters :no-action], and the Runner's decision there is break/tank, not a
+   pass (#92).
+
+   Single source (#115): this set was inlined in BOTH print-run-window-priority!
+   and diagnose-blocker, so adding approach-ice to one left the other — the
+   surface a stuck seat actually reaches for — printing the same steer that
+   provably cannot act. Same N-emitters shape as #75/#77/#113."
+  [run-phase my-side]
+  (contains? (if (= my-side "runner")
+               #{"initiation" "approach-ice" "movement" "approach-server"}
+               #{"movement" "approach-server"})
+             run-phase))
+
 (defn run-priority-hint-lines
   "Side-aware hint lines for a run priority window (movement / approach-server).
 
@@ -1107,18 +1130,39 @@
         ;; so we encode that directly rather than trusting the volatile
         ;; :active-player wire field. Render: Runner = first sub-step, Corp = second.
         i-am-active? (= my-side "runner")
-        ;; What the Runner specifically gains by continuing this window.
+        ;; What the Runner specifically gains by continuing this window. Phase
+        ;; matters: at approach-ice the Runner is already AT the ICE, so passing
+        ;; resolves THIS ICE (encounter it, or walk past it if the Corp declined
+        ;; the rez) — "approach the next ICE" is only true of the windows BEFORE
+        ;; an approach (initiation, and movement with ICE still to come).
         gain      (when (= my-side "runner")
-                    (if past-ice?
-                      (str "breach " server " and access cards")
-                      (str "approach the next ICE on " server)))]
+                    (cond
+                      past-ice? (str "breach " server " and access cards")
+                      (= "approach-ice" (:phase run))
+                      "resolve this ICE (encounter it if the Corp rezzes, otherwise walk past it)"
+                      :else (str "approach the next ICE on " server)))]
     (cond
       ;; I have already passed — waiting on the opponent; no action from me.
       (= na my-side)
       (into
         [(str "    ⏸️  You have already passed priority here — waiting for " opp
               " to pass before the run advances.")
-         (str "      (No action needed from you; use 'wait'. Re-sending 'continue' does nothing.)")]
+         ;; "Re-sending does nothing" is true of a MANUAL repeat — send-continue!'s
+         ;; #98 guard suppresses it — but it is NOT true of the Runner's run loop.
+         ;; handle-stalled-window-self-advance (ai-runs) deliberately sends a
+         ;; SECOND pass once a decision-free window has gone unanswered for
+         ;; self-advance-grace-ms, because the engine's advance branch has no
+         ;; side-check (game.core.runs `continue`), and that is the sanctioned #31
+         ;; recovery. Telling the Runner a repeat is futile therefore steered it
+         ;; past its own recovery and into an umpire ping — the exact escalation
+         ;; this block exists to prevent. Guest panel caught it (#115); the Corp
+         ;; keeps the flat line because self-advance is Runner-side only.
+         (if (= my-side "runner")
+           (str "      (Nothing to send right now; use 'wait'. A repeat 'continue' is suppressed "
+                "while the window is live — but if the Corp has no decision to make here, "
+                "re-issuing 'continue' after ~5s lets the run loop advance the abandoned "
+                "window itself (#31). Try that BEFORE escalating.)")
+           (str "      (No action needed from you; use 'wait'. Re-sending 'continue' does nothing.)"))]
         ;; Stall recovery (issue #31). We used to tell the Runner that 'jack-out
         ;; ends the run to recover' here. That advice LOST marquee d6962df4:
         ;; GPT-5.5 followed it 5 times, once abandoning a Brân it had just broken
@@ -1268,21 +1312,44 @@
    encounter ICE's subs); `run` is [:game-state :run]; `run-phase` is
    (:phase run); `my-side` is \"runner\"/\"corp\". Returns nil.
 
-   The both-must-pass windows (initiation for the Runner, movement/approach-server
-   for both) route through run-priority-hint-lines, which disambiguates the two
-   sub-steps and warns about the #31 stall. A Runner mid-encounter with UNBROKEN
-   subs it is not breaking routes through runner-encounter-decline-hint-lines:
-   `continue` is refused there, so steering to it is the #92 lie. Other windows
-   get the terse decline/continue guidance — spelled out for the Corp (continue
-   here DECLINES an action, e.g. an ICE rez, rather than being forced)."
+   The both-must-pass windows (initiation and approach-ice for the Runner,
+   movement/approach-server for both) route through run-priority-hint-lines, which
+   disambiguates the two sub-steps and warns about the #31 stall. A Runner
+   mid-encounter with UNBROKEN subs it is not breaking routes through
+   runner-encounter-decline-hint-lines: `continue` is refused there, so steering to
+   it is the #92 lie. Other windows get the terse decline/continue guidance —
+   spelled out for the Corp (continue here DECLINES an action, e.g. an ICE rez,
+   rather than being forced).
+
+   approach-ice is a both-must-pass window for the Runner too (#115). The engine's
+   `continue :approach-ice` records the first passer in [:run :no-action] exactly
+   as movement does (game.core.runs), so a Runner that has already passed cannot
+   advance it — yet this printed the terse 'use continue to pass priority' at a
+   seat that provably could not act, with none of the already-passed / do-not-
+   jack-out / escalate guidance the identical situation gets at #1 Run begins. Two
+   Luna seats re-sent continue and then pinged the umpire."
   [state run run-phase my-side]
   (let [runner-unbroken (when (and (= my-side "runner") (= run-phase "encounter-ice"))
-                          (runner-encounter-unbroken-count state))]
+                          (runner-encounter-unbroken-count state))
+        ;; A Corp that has already passed this window is in the SAME position the
+        ;; Runner's already-passed branch describes: `continue` is a no-op and the
+        ;; opponent owes the move. The Corp's rez guidance below is correct only
+        ;; while it still owns the window.
+        ;;
+        ;; Scoped to the run-level windows that reach the Corp branch at all:
+        ;; movement/approach-server already route through the hint lines above,
+        ;; and at encounter-ice the passer lives on [:encounters :no-action] while
+        ;; run-priority-hint-lines reads [:run :no-action] — routing there would
+        ;; hand it a stale nil and print fresh-window text. Same source as the fn
+        ;; we delegate to, or not at all.
+        corp-already-passed? (and (= my-side "corp")
+                                  (contains? #{"initiation" "approach-ice"} run-phase)
+                                  (= my-side (let [v (:no-action run)]
+                                               (cond (keyword? v) (name v)
+                                                     (string? v) v
+                                                     :else nil))))]
     (cond
-      (contains? (if (= my-side "runner")
-                   #{"initiation" "movement" "approach-server"}
-                   #{"movement" "approach-server"})
-                 run-phase)
+      (both-pass-window? run-phase my-side)
       (doseq [line (run-priority-hint-lines run my-side)]
         (println line))
 
@@ -1291,6 +1358,12 @@
       (and runner-unbroken (pos? runner-unbroken))
       (doseq [line (runner-encounter-decline-hint-lines
                     (:title (core/current-run-ice state) "this ICE") runner-unbroken)]
+        (println line))
+
+      ;; Corp at approach-ice having already declined/passed: don't offer it a rez
+      ;; it can no longer take, and don't call a no-op a priority pass (#115).
+      corp-already-passed?
+      (doseq [line (run-priority-hint-lines run my-side)]
         (println line))
 
       (= my-side "corp")
@@ -1342,12 +1415,10 @@
     (when cur
       (let [srv      (or server-name "the server")
             ;; Pass order: the Runner meets the OUTERMOST ICE (position = ice-count)
-            ;; first, so pass-index counts up as position counts down. Guard the
-            ;; upper bound too: a position > ice-count (shouldn't happen, but the
-            ;; wire is the volatile coupling) would otherwise print a bogus
-            ;; "ICE 0 of N" / negative index — drop the index rather than lie.
-            pass-idx (when (and ice-count position (pos? position) (<= position ice-count))
-                       (inc (- ice-count position)))
+            ;; first, so pass-index counts up as position counts down. Shared with
+            ;; the approach handler's ICE line (core/ice-pass-index) so the two
+            ;; can't drift into contradicting conventions on adjacent lines (#115).
+            pass-idx (core/ice-pass-index position ice-count)
             ice-of   (if (and pass-idx ice-count) (format " %d of %d" pass-idx ice-count) "")
             ice-tag  (if ice-name (format " [%s]" ice-name) "")
             label    {:begin           "#1 Run begins"
@@ -2128,12 +2199,12 @@
         ;; needs BOTH sides), but only the Runner gets the already-passed-aware hint
         ;; here — once it has passed, "use continue" is a no-op loop (issue #31 / g3).
         ;; The Corp keeps the generic continue/monitor-run steer at initiation (it
-        ;; may still want to rez/fire a paid ability there).
+        ;; may still want to rez/fire a paid ability there). Membership comes from
+        ;; both-pass-window?, shared with print-run-window-priority! — this copy of
+        ;; the set was the one left behind when approach-ice was added (#115), and
+        ;; `diagnose` is exactly the surface a stuck seat reaches for.
         (cond
-          (contains? (if (= my-side-lc "runner")
-                       #{"initiation" "movement" "approach-server"}
-                       #{"movement" "approach-server"})
-                     run-phase)
+          (both-pass-window? run-phase my-side-lc)
           (do
             (println "   → Owner: this is a both-must-pass priority window, not a choose prompt.")
             (doseq [line (run-priority-hint-lines run my-side-lc)]

--- a/dev/src/clj/ai_run_runner_handlers.clj
+++ b/dev/src/clj/ai_run_runner_handlers.clj
@@ -171,7 +171,8 @@
           (when-not already-printed?
             (reset! last-waiting-status status-key)
             (println "⏸️  Waiting for corp rez decision")
-            (println (format "   ICE: %s (position %d/%d, unrezzed)" ice-title position ice-count)))
+            (println (format "   %s"
+                             (core/describe-approached-ice ice-title position ice-count))))
           {:status :waiting-for-corp-rez
            :wake-reason :rez-decision
            :message (format "Waiting for corp to decide: rez %s or continue" ice-title)

--- a/dev/test/ai_display_test.clj
+++ b/dev/test/ai_display_test.clj
@@ -9,6 +9,7 @@
             [clojure.string :as str]
             [test-helpers :refer [mock-client-state with-mock-state]]
             [ai-state :as ai-state]
+            [ai-core :as core]
             [ai-display :as display]))
 
 ;; ============================================================================
@@ -702,13 +703,19 @@
       (is (not (str/includes? out "access cards"))))))
 
 (deftest test-priority-hint-i-already-passed-waits
-  (testing "Side that already passed is told to wait, not re-continue"
+  ;; This test used to assert the Runner is told "Re-sending 'continue' does
+  ;; nothing". A guest panel on #115 showed that sentence is false on this side:
+  ;; the run loop's own #31 recovery IS a re-issued continue. The test had pinned
+  ;; the bug. What must hold is that the seat is not steered back into an
+  ;; immediate manual repeat as if the window were still its move.
+  (testing "Side that already passed is told to wait, not that it's still its move"
     (let [out (str/join "\n" (display/run-priority-hint-lines
                               {:phase "movement" :position 0 :server ["hq"] :no-action "runner"}
                               "runner"))]
       (is (str/includes? out "already passed priority"))
       (is (str/includes? out "waiting for Corp"))
-      (is (str/includes? out "Re-sending 'continue' does nothing")))))
+      (is (str/includes? out "use 'wait'"))
+      (is (not (str/includes? out "It's YOUR move"))))))
 
 (deftest test-priority-hint-opponent-passed-my-move
   (testing "When opponent already passed, it's my move to advance"
@@ -1780,3 +1787,192 @@
             "fixture sanity: this state is the one #93 calls GAME-GONE")
         (is (false? (:in-game? (ai-state/get-turn-status)))
             "a GAME-GONE state is not a game we are in")))))
+
+;; ============================================================================
+;; #115: approach-ice is a both-must-pass window for the Runner too.
+;;
+;; game.core.runs `continue :approach-ice` records the first passer in
+;; [:run :no-action] exactly as movement does, so a Runner that has already
+;; passed cannot advance it. This surface printed the terse "use 'continue' to
+;; pass priority (advance the run)" at that seat — with none of the
+;; already-passed / don't-jack-out / escalate guidance the identical situation
+;; gets at #1 Run begins. Two Luna seats re-sent continue and then pinged the
+;; umpire.
+;; ============================================================================
+
+(deftest test-approach-ice-runner-already-passed-gets-the-run-begins-guidance
+  (testing "#115: a Runner that has passed approach-ice is told it has passed, that
+            re-sending does nothing, and how to escalate — not to 'continue'"
+    (let [run {:server ["rd"] :phase "approach-ice" :position 2 :no-action "runner"}
+          out (with-out-str
+                (display/print-run-window-priority!
+                 {:game-state {:run run}} run "approach-ice" "runner"))]
+      (is (str/includes? out "already passed priority")
+          (str "the seat must learn its pass is already recorded, got:\n" out))
+      (is (str/includes? out "use 'wait'")
+          (str "and steered to wait rather than an immediate manual repeat, got:\n" out))
+      (is (str/includes? out "umpire-ping")
+          (str "and be given the sanctioned escalation instead of inventing one, got:\n" out))
+      (is (not (re-find #"→ Use 'continue' to pass priority" out))
+          (str "the terse steer that provably cannot act must be gone, got:\n" out)))))
+
+(deftest test-approach-ice-runner-fresh-window-names-what-passing-buys
+  (testing "#115: at a fresh approach-ice window the Runner is the first sub-step,
+            and passing resolves THIS ICE — not 'the next ICE', which is the
+            movement-window outcome"
+    (let [run {:server ["rd"] :phase "approach-ice" :position 2 :no-action false}
+          out (with-out-str
+                (display/print-run-window-priority!
+                 {:game-state {:run run}} run "approach-ice" "runner"))]
+      (is (str/includes? out "active player goes first")
+          (str "expected the sub-step framing, got:\n" out))
+      (is (str/includes? out "resolve this ICE")
+          (str "passing an approach resolves the ICE in front of you, got:\n" out))
+      (is (not (str/includes? out "approach the next ICE"))
+          (str "the movement-window outcome must not be claimed here, got:\n" out))
+      (is (not (str/includes? out "ICE rez window"))
+          (str "the rez verb is the Corp's, not the Runner's, got:\n" out)))))
+
+(deftest test-approach-ice-runner-corp-passed-is-my-move
+  (testing "#115: Corp has passed approach-ice — the Runner's continue advances it"
+    (let [run {:server ["rd"] :phase "approach-ice" :position 2 :no-action "corp"}
+          out (with-out-str
+                (display/print-run-window-priority!
+                 {:game-state {:run run}} run "approach-ice" "runner"))]
+      (is (str/includes? out "It's YOUR move")
+          (str "expected the opponent-has-passed branch, got:\n" out))
+      (is (not (str/includes? out "already passed priority here"))
+          (str "the Runner has NOT passed — must not read as its own pass, got:\n" out)))))
+
+(deftest test-approach-ice-corp-already-passed-loses-the-rez-offer
+  (testing "#115: a Corp that has already declined this window must not be offered
+            a rez it can no longer take, nor told 'continue' passes priority"
+    (let [run {:server ["rd"] :phase "approach-ice" :position 2 :no-action "corp"}
+          out (with-out-str
+                (display/print-run-window-priority!
+                 {:game-state {:run run}} run "approach-ice" "corp"))]
+      (is (str/includes? out "already passed priority")
+          (str "the Corp's own pass is recorded; say so, got:\n" out))
+      (is (not (str/includes? out "ICE rez window"))
+          (str "the rez window is closed to a Corp that passed it, got:\n" out))
+      (is (not (str/includes? out "DECLINE"))
+          (str "it has already declined — offering the decline again is the lie, got:\n" out)))))
+
+(deftest test-approach-ice-corp-owning-window-keeps-its-rez-guidance
+  (testing "#115 regression guard: a Corp that still owns the window keeps the rez
+            options — the fix must not cost the Corp its rez steer"
+    (let [run {:server ["rd"] :phase "approach-ice" :position 2 :no-action false}
+          out (with-out-str
+                (display/print-run-window-priority!
+                 {:game-state {:run run}} run "approach-ice" "corp"))]
+      (is (str/includes? out "ICE rez window"))
+      (is (str/includes? out "--no-rez"))
+      (is (str/includes? out "DECLINE")))))
+
+;; ============================================================================
+;; #115 cosmetics: one indexing convention, and fog of war that reads as fog.
+;; ============================================================================
+
+(deftest test-ice-pass-index-counts-up-as-position-counts-down
+  (testing "position is a countdown; the Runner meets position=ice-count FIRST"
+    (is (= 1 (core/ice-pass-index 2 2)) "outermost ICE is 'ICE 1 of 2'")
+    (is (= 2 (core/ice-pass-index 1 2)) "innermost ICE is 'ICE 2 of 2'"))
+  (testing "no honest index available -> nil, never a bogus one"
+    (is (nil? (core/ice-pass-index 0 2)) "past all ICE")
+    (is (nil? (core/ice-pass-index nil 2)))
+    (is (nil? (core/ice-pass-index 2 nil)) "unknown ICE count")
+    (is (nil? (core/ice-pass-index 3 2)) "position out of range (wire drift)")))
+
+(deftest test-describe-approached-ice-renders-fog-not-breakage
+  (testing "#115: an unrezzed ICE has no title on the Runner's wire — the old
+            format printed the literal default and read as 'ICE: ICE'"
+    (let [line (core/describe-approached-ice "ICE" 2 2)]
+      (is (not (str/includes? line "ICE: ICE"))
+          (str "the placeholder-as-name rendering is gone, got: " line))
+      (is (str/includes? line "hidden")
+          (str "say WHY there is no name, got: " line))))
+  (testing "the line uses the ladder's convention, not the raw countdown"
+    (let [line (core/describe-approached-ice "ICE" 2 2)]
+      (is (str/includes? line "ICE 1 of 2")
+          (str "outermost ICE with 2 ICE = 'ICE 1 of 2', matching the run ladder, got: " line))
+      (is (not (str/includes? line "position 2/2"))
+          (str "the contradicting second convention is gone, got: " line))))
+  (testing "a known title is still named"
+    (is (str/includes? (core/describe-approached-ice "Whitespace" 2 2) "Whitespace"))))
+
+;; The same lie lived in a SECOND emitter. `diagnose` is the surface a stuck seat
+;; reaches for, and it carried its own inline copy of the both-pass phase set —
+;; so fixing print-run-window-priority! alone would have left the seat that had
+;; actually noticed it was stuck reading "Use: continue" at a window it had
+;; already passed. Both now read the membership from both-pass-window?.
+
+(deftest test-diagnose-approach-ice-runner-already-passed-agrees-with-prompt
+  (testing "#115: diagnose at an approach-ice window the Runner has passed gives the
+            already-passed guidance, not the generic continue steer"
+    (with-mock-state (mock-client-state
+                      :side "runner"
+                      :game-state {:active-player "runner" :turn 4
+                                   :run {:phase "approach-ice" :position 2
+                                         :server ["rd"] :no-action "runner"}
+                                   :runner {:click 2 :credit 5 :hand []
+                                            :prompt-state {:msg "Waiting for Corp to rez"
+                                                           :prompt-type "run"}}
+                                   :corp {:click 0 :credit 5 :hand []
+                                          :servers {:rd {:ices [{:title "Whitespace"}
+                                                                {:title "Diviner"}]}}}})
+      (let [out (with-out-str (display/show-blocker-diagnosis))]
+        (is (str/includes? out "already passed priority")
+            (str "diagnose must agree with prompt/status that the pass is spent, got:\n" out))
+        (is (not (re-find #"(?i)use: continue \(to pass priority\)" out))
+            (str "the generic steer that cannot act must be gone from diagnose too, got:\n" out))))))
+
+(deftest test-both-pass-window-membership
+  (testing "#115: the Runner's pass windows include approach-ice — the engine's
+            continue :approach-ice records [:run :no-action] exactly as movement does"
+    (is (display/both-pass-window? "approach-ice" "runner"))
+    (is (display/both-pass-window? "initiation" "runner"))
+    (is (display/both-pass-window? "movement" "runner")))
+  (testing "encounter-ice is NOT one: its passer lives on [:encounters :no-action]
+            and the Runner's decision there is break/tank, not a pass (#92)"
+    (is (not (display/both-pass-window? "encounter-ice" "runner")))
+    (is (not (display/both-pass-window? "encounter-ice" "corp"))))
+  (testing "the Corp keeps its own richer steer at the windows carrying a rez decision"
+    (is (not (display/both-pass-window? "approach-ice" "corp")))
+    (is (not (display/both-pass-window? "initiation" "corp")))
+    (is (display/both-pass-window? "movement" "corp"))))
+
+;; Guest-panel catch on the #115 fix: the already-passed block told the Runner
+;; "Re-sending 'continue' does nothing" and then, two lines later, to escalate to
+;; an umpire. Both cannot be right. The engine's advance branch has no side-check
+;; (game.core.runs `continue`), and handle-stalled-window-self-advance uses that
+;; deliberately — a re-issued `continue` after the grace period IS the sanctioned
+;; #31 recovery for a decision-free abandoned window. The old wording steered the
+;; Runner straight past its own recovery into the ping this block exists to avoid.
+
+(deftest test-already-passed-runner-is-told-about-self-advance-before-escalating
+  (testing "#115/panel: the Runner's already-passed guidance must not call a repeat
+            continue futile — it is the #31 recovery — and must order it before the
+            umpire escalation"
+    (let [run {:server ["rd"] :phase "approach-ice" :position 2 :no-action "runner"}
+          out (with-out-str
+                (display/print-run-window-priority!
+                 {:game-state {:run run}} run "approach-ice" "runner"))]
+      (is (not (str/includes? out "Re-sending 'continue' does nothing"))
+          (str "flatly false for the Runner: the run loop self-advances an abandoned
+                window with a second pass, got:\n" out))
+      (is (re-find #"(?i)re-issuing 'continue'.*self|advance the abandoned" out)
+          (str "the seat must learn the recovery exists, got:\n" out))
+      (is (< (.indexOf out "BEFORE escalating") (.indexOf out "umpire-ping"))
+          (str "and must be told to try it BEFORE the umpire, got:\n" out)))))
+
+(deftest test-already-passed-corp-keeps-the-flat-no-op-line
+  (testing "#115/panel: self-advance is Runner-side only, so the Corp's repeat
+            continue really is a no-op — it must not be told otherwise"
+    (let [run {:server ["rd"] :phase "movement" :position 1 :no-action "corp"}
+          out (with-out-str
+                (display/print-run-window-priority!
+                 {:game-state {:run run}} run "movement" "corp"))]
+      (is (str/includes? out "Re-sending 'continue' does nothing")
+          (str "the Corp has no self-advance path, got:\n" out))
+      (is (not (str/includes? out "abandoned"))
+          (str "must not promise the Corp a recovery it does not have, got:\n" out)))))

--- a/dev/test/ai_runs_test.clj
+++ b/dev/test/ai_runs_test.clj
@@ -1378,3 +1378,34 @@
   ;; Run from main
   (-main)
   )
+
+;; ============================================================================
+;; #115: the ICE line a Runner actually sees at approach-ice.
+;;
+;; Pinning core/describe-approached-ice alone would not have caught this — the
+;; handler is the surface the seat reaches, and the previous round's lesson was
+;; exactly that (a fix and its green test both landed on a sender the CLI never
+;; calls, #113). Drive the handler.
+;; ============================================================================
+
+(deftest test-approach-ice-handler-ice-line-is-readable
+  (testing "#115: unrezzed ICE renders as fog, in the run ladder's index convention
+            — not as the literal 'ICE: ICE (position 2/2, unrezzed)'"
+    (runner-handlers/reset-state!)
+    (let [state {:side "runner"
+                 :game-state {:run {:phase "approach-ice" :position 2
+                                    :server ["rd"] :no-action false}
+                              :corp {:servers {:rd {:ices [{:title nil :rezzed false}
+                                                           {:title nil :rezzed false}]}}}}}
+          out (with-out-str
+                (runner-handlers/handle-runner-approach-ice
+                 {:side "runner" :run-phase "approach-ice" :state state}))]
+      (is (clojure.string/includes? out "Waiting for corp rez decision")
+          (str "fixture sanity: this is the approach-ice wait, got:\n" out))
+      (is (not (clojure.string/includes? out "ICE: ICE"))
+          (str "the placeholder-as-name rendering is gone, got:\n" out))
+      (is (not (clojure.string/includes? out "position 2/2"))
+          (str "the countdown convention contradicted the ladder's 'ICE 1 of 2'
+                two lines below it, got:\n" out))
+      (is (clojure.string/includes? out "ICE 1 of 2")
+          (str "outermost of two ICE, in the ladder's convention, got:\n" out)))))

--- a/dev/test/ai_wait_test.clj
+++ b/dev/test/ai_wait_test.clj
@@ -483,3 +483,79 @@
           "engine says the Runner resolved — a leftover prompt must not deadlock us")
       (is (true? (:can-act? (state/get-turn-status)))
           "and the status surface must agree"))))
+
+;; ---------------------------------------------------------------------------
+;; #115: the wake REASON must decode itself.
+;;
+;; :my-run-window fires on every run and was documented nowhere — not in the
+;; emitted output, not in any of the 13 seat briefs. Two Luna seats read
+;;   ⚡ Woke up: my-run-window
+;;   📜 Game log while you were waiting:
+;;     (no new entries)
+;; as "nothing happened", re-blocked, and sat on the pass that advances the run
+;; until the umpire told them what the token meant. Every ping in the first half
+;; of that game traced to this; they stopped completely after the explanation.
+;;
+;; These assert the FRAMING (does the seat learn it owes a move?), never that a
+;; particular token appears — a green "the string is present" test is what let
+;; the bare token ship in the first place.
+;; ---------------------------------------------------------------------------
+
+(deftest test-my-run-window-wake-tells-the-seat-it-owes-the-move
+  (testing "#115: waking on an owned run window says the run is stopped on US and
+            names an action — a bare reason token is not decodable by a seat"
+    (with-redefs [state/get-cursor (fn [] 10)]
+      (with-mock-state (mock-game "runner" approach-server-game-state)
+        (let [out (with-out-str
+                    (core/wait-for-relevant-diff {:timeout 0 :verbose true}))]
+          (is (str/includes? out "my-run-window")
+              (str "fixture sanity: this is the my-run-window wake, got:\n" out))
+          (is (re-find #"(?i)you owe|stopped on you" out)
+              (str "the seat must learn the move is OWED BY IT, got:\n" out))
+          (is (str/includes? out "continue")
+              (str "and must be pointed at the verb that advances the window, got:\n" out))
+          (is (re-find #"(?i)another `?wait`? (cannot|can't)" out)
+              (str "and must be told that re-blocking does not advance it — the exact
+                    loop two seats fell into, got:\n" out)))))))
+
+(deftest test-my-run-window-guidance-defuses-the-empty-log
+  (testing "#115: an owned window with no new log entries is the trap shape —
+            'no new entries' must not be the last word the seat reads"
+    (with-redefs [state/get-cursor (fn [] 10)]
+      (with-mock-state (mock-game "runner" approach-server-game-state)
+        (let [out (with-out-str
+                    (core/wait-for-relevant-diff {:timeout 0 :verbose true}))]
+          (is (str/includes? out "(no new entries)")
+              (str "fixture sanity: the empty-log rendering, got:\n" out))
+          (is (re-find #"(?i)empty game log|no new entries.*waiting on you|waiting on you" out)
+              (str "an empty log at an owned window means the OPPONENT is waiting on
+                    us; say so rather than leaving 'no new entries' to be read as
+                    'nothing happened', got:\n" out)))))))
+
+;; The same reason token is printed from TWO places — the polling loop above and
+;; the :since fast path. Only the polling copy had grown guidance, so every
+;; reason but :my-turn-start arrived undecoded on the fast path. One contract,
+;; both emitters (the #75/#77/#113 "N senders" shape).
+
+(deftest test-fast-path-decodes-its-wake-reason-too
+  (testing "#115: the :already-advanced fast path carries the same guidance as the
+            polling loop — a GAME-GONE wake there must still say the game is gone"
+    (with-redefs [state/get-cursor (fn [] 10)]
+      (with-mock-state (assoc (mock-game "corp"
+                                         {:active-player "corp" :turn 5
+                                          :corp {:click 3} :runner {:click 0}})
+                              :lobby-gone? true)
+        (let [out (with-out-str
+                    (core/wait-for-relevant-diff {:since 5 :timeout 0 :verbose true}))]
+          (is (str/includes? out "returning immediately")
+              (str "fixture sanity: this is the fast path, got:\n" out))
+          (is (re-find #"(?i)gone, not paused|game is GONE" out)
+              (str "the fast path must decode the reason, not print a bare token, got:\n" out)))))))
+
+(deftest test-wake-guidance-is-silent-for-reasons-with-nothing-to-add
+  (testing "#115: guidance is per-reason, not a blanket paragraph — reasons that
+            speak for themselves add no lines"
+    (is (empty? (core/wake-reason-guidance-lines :run-started {}))
+        "a run starting needs no decoding")
+    (is (empty? (core/wake-reason-guidance-lines :has-prompt {}))
+        "a prompt is self-describing — the prompt itself is the guidance")))


### PR DESCRIPTION
Fixes #115.

## What was broken

`:my-run-window` fires on **every run** and was decoded nowhere — not in the emitted output, not in any of the seat briefs. Two Luna seats independently read

```
⚡ Woke up: my-run-window

📜 Game log while you were waiting:
  (no new entries)
```

as *nothing happened*, re-blocked, and sat on the pass that advances the run. Every umpire ping in the first half of that game traced to it; they stopped completely once each seat was told what the token meant.

## The fix

**Client side — the durable half.** Briefs drift (see `player-packets-location-and-drift`); the emitted line does not.

- `wake-reason-guidance-lines` decodes each reason into the action it demands, and **both** emitters call it. Only the polling loop had grown guidance, so a seat whose cursor had already advanced got a bare token for every reason but `:my-turn-start` — `:game-over` / `:game-gone` / `:encounter-decision` arrived undecoded there. Same N-emitters shape as #75/#77/#113.
- **approach-ice is a both-must-pass window for the Runner too.** `continue :approach-ice` records the first passer in `[:run :no-action]` exactly as movement does, so a Runner that had already passed was told to "use continue to pass priority" at a window it provably could not advance — with none of the already-passed / escalate guidance the identical state gets at `#1 Run begins`. Membership now lives in one predicate, `both-pass-window?`: the phase set was inlined in **both** `print-run-window-priority!` and `diagnose-blocker`, and `diagnose` is the surface a stuck seat actually reaches for.
- A Corp that has already declined an approach no longer gets offered the rez it can no longer take.
- Passing an approach resolves **this** ICE — "approach the next ICE" is the movement outcome.
- Cosmetics from the same output block: `ICE: ICE` (a format default printed as a name) now reads as fog of war, and the ICE line uses the ladder's `ICE 1 of 2` rather than contradicting it with `position 2/2` two lines above.

**Briefs.** `my-run-window` documented in all 6 seat briefs that decode wake reasons. (The issue's "0 of 13 / 7 document them" predates some renames — current counts are 6 of 11, all patched.)

## What the guest panel found

GPT-5.6 via codex, given the verbatim issue plus my stated assumptions. It found one real defect — in text the fix *inherited* rather than introduced:

> "Re-sending 'continue' does nothing" is false when the ICE is already rezzed and no Corp decision exists.

Confirmed, and it sharpens: the engine's advance branch has **no side-check** (`game.core.runs` `continue` records the first caller, the second advances, regardless of side), and `handle-stalled-window-self-advance` uses that deliberately — a re-issued `continue` after `self-advance-grace-ms` **is** the sanctioned #31 recovery for an abandoned, decision-free window. So the line steered the Runner past its own recovery and into an umpire ping, which is exactly what that block exists to prevent. The Runner now gets the accurate version, ordered before the escalation; the Corp keeps the flat wording, since self-advance is Runner-side only.

A pre-existing test had **pinned that false sentence**. It now asserts what is actually true on that side.

It also filed two others: a seventh brief at `dev/seat-runner-luna.md` (**rejected** — no such file; the 6 that decode wake reasons are all patched), and `--rez` being illegal at movement in the Corp brief text (**confirmed**, qualified to the approach window).

## Verification

- Suite **662 → 678** tests / 1790 → 1847 assertions, 0 failures.
- **9 mutation reverts, 9 reds** — every non-obvious guard, including the `diagnose-blocker` copy on its own (reverting only that call site turns the diagnose test red with the exact stuck-seat output), and the handler wiring separately from the pure helper it calls.

## Not asked for

- `both-pass-window?` extraction — the issue asked to port guidance to approach-ice; doing that in one of two inlined copies would have left `diagnose` printing the same lie.
- Shared `wake-reason-guidance-lines` rather than adding one `when` to each emitter — same reason. Side effect: the fast path gained the `:game-over` / `:game-gone` / `:encounter-decision` guidance it never had.
- The self-advance wording correction — a confirmed panel finding in text this PR was already editing, not in the issue.
- `core/ice-pass-index` extraction, used by the run ladder as well as the new ICE line — the cosmetic complaint was that the two conventions contradict, which one shared helper prevents structurally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)