### PR TITLE
fix(#117): the turn boundary is the engine's :end-turn latch, not a click count

### DIFF
--- a/dev/src/clj/ai_core.clj
+++ b/dev/src/clj/ai_core.clj
@@ -1397,70 +1397,28 @@
 
 (defn my-turn-to-act?
   "Check if it's our turn to act (need to start-turn or have clicks).
-   Handles Netrunner priority system where active-player doesn't flip until start-turn.
+   The authoritative 'whose move is it' predicate — see ai-state for the full
+   contract and the wake conditions it deliberately excludes.
 
-   Wake conditions (any one is sufficient):
-     - I am the active player AND I have clicks remaining
-     - opponent set the :end-turn flag and active-player is still them
-       (engine in transition; my turn is up next)
-     - turn 0, Corp side, 0 clicks (post-mulligan: Corp goes first)
-
-   Crucially NOT a wake condition: 'both players at 0 clicks'. That
-   scenario fires every time the Runner spends their last click on a run
-   (Runner=0, Corp=0, but Runner is still resolving the run). An earlier
-   duplicate predicate had that bug and woke spuriously on every
-   opponent run-transition; this predicate is the authoritative source
-   of truth for the `wait` command (via `relevance-reason`).
-
-   Also NOT a wake condition: the opening-mulligan boundary. While our own prompt
-   is the 'waiting for opponent to keep hand or mulligan' window, start-turn is
-   refused (:opponent-mulligan), so reporting 'your move' here is a lie that
-   returns instantly and repeatedly — #87. The guard is checked FIRST so this
-   predicate agrees with can-start-turn? by construction."
+   Moved DOWN to ai-state for #117 so `get-turn-status` (which backs every
+   seat-facing turn surface) answers from this predicate instead of its own
+   click-count heuristic. Same `defn` delegation as opponent-mulligan-pending?
+   above, and deliberately not `(def x state/x)`: the latter captures the
+   function VALUE, so with-redefs in tests silently misses it and a REPL
+   :reload of the owning namespace leaves this bound to the stale fn."
   [state side]
-  ;; nil-safe on side: in the lobby / pre-game the seat may have no :side yet,
-  ;; and `(name nil)` would NPE (#46). No side => not our turn.
-  (when-let [my-side (keyword side)]
-   (let [active-player (get-in state [:game-state :active-player])
-        my-clicks (get-in state [:game-state my-side :click] 0)
-        end-turn (get-in state [:game-state :end-turn])
-        turn-number (get-in state [:game-state :turn] 0)]
-    (and
-     ;; #87: never claim it's our move while the opponent's opening mulligan is
-     ;; unresolved — start-turn will refuse, and `wait` would spin on the lie.
-     (not (opponent-mulligan-pending? state))
-     (or
-      ;; My turn and I have clicks
-      (and (= (name my-side) active-player) (> my-clicks 0))
-      ;; Opponent ended turn, waiting for me to start
-      ;; (active-player = opponent because end-turn was called, I'm next)
-      (and end-turn (not= (name my-side) active-player))
-      ;; Turn 0 with 0 clicks = post-mulligan, Corp needs to start
-      ;; (Corp always goes first)
-      (and (= 0 turn-number) (= 0 my-clicks) (= my-side :corp)))))))
+  (state/my-turn-to-act? state side))
 
 (defn- turn-awaiting-start?
   "True when it's our turn at a boundary but the turn has NOT been started yet
    (we hold 0 clicks). The seat must call `start-turn` before it can act.
 
-   This is the subset of `my-turn-to-act?` that is a turn boundary rather than a
-   live, actionable turn. It lets `relevance-reason` wake with the distinct
-   reason :my-turn-start instead of :my-turn, so the seat isn't misled into
-   trying to act before starting (and so a boundary doesn't read like a stall).
-   Both seats hit this confusion in the first rung-2 game (laundry-list #1)."
+   Lets `relevance-reason` wake with the distinct reason :my-turn-start instead
+   of :my-turn, so the seat isn't misled into trying to act before starting (and
+   so a boundary doesn't read like a stall). Both seats hit this confusion in the
+   first rung-2 game (laundry-list #1). Delegates to ai-state — see there."
   [state side]
-  ;; nil-safe on side (see my-turn-to-act?): no side => no pending turn start.
-  (when-let [my-side (keyword side)]
-   (let [active-player (get-in state [:game-state :active-player])
-        my-clicks (get-in state [:game-state my-side :click] 0)
-        end-turn (get-in state [:game-state :end-turn])
-        turn-number (get-in state [:game-state :turn] 0)]
-    (and (= 0 my-clicks)
-         (or
-           ;; Opponent ended their turn; active-player is still them until I start
-           (and end-turn (not= (name my-side) active-player))
-           ;; Post-mulligan turn 0: Corp goes first but hasn't started
-           (and (= 0 turn-number) (= my-side :corp)))))))
+  (state/turn-awaiting-start? state side))
 
 (defn- ping-message?
   "Check if a log entry is a 'ping' wake signal.

--- a/dev/src/clj/ai_display.clj
+++ b/dev/src/clj/ai_display.clj
@@ -163,12 +163,13 @@
             run-state (get-in gs [:run])
             runner-clicks (get-in gs [:runner :click])
             corp-clicks (get-in gs [:corp :click])
-            both-zero-clicks (and (= 0 runner-clicks) (= 0 corp-clicks))
-            next-player (cond
-                         (= turn-num 0) "corp"
-                         (= active-side "corp") "runner"
-                         (= active-side "runner") "corp"
-                         :else "unknown")
+            ;; #117: `status` used to re-derive the turn boundary from its own
+            ;; `both-zero-clicks` copy, so it could contradict game-over-status,
+            ;; `prompt`, AND itself ("Turn: 10 - corp" over "🟢 Waiting to start
+            ;; runner turn", same output block). One predicate, one answer.
+            turn-status (state/get-turn-status)
+            at-boundary (:waiting-to-start? turn-status)
+            next-player (:next-player turn-status)
             runner-missing? (and gs (nil? (get-in gs [:runner :user])))
             corp-missing? (and gs (nil? (get-in gs [:corp :user])))]
 
@@ -213,8 +214,8 @@
               (and end-turn (= my-side active-side))
               (println "Status: ⏳ Waiting for" (if (= active-side "corp") "runner" "corp") "to start turn")
 
-              ;; Both players have 0 clicks but end-turn not called yet
-              both-zero-clicks
+              ;; A boundary the two end-turn branches above didn't catch
+              at-boundary
               (println "Status: 🟢 Waiting to start" next-player "turn (use 'start-turn' command)")
 
               ;; Waiting for opponent
@@ -224,6 +225,15 @@
               ;; Waiting prompt
               (state/waiting-prompt-type? prompt-type)
               (println "Status: ⏳" (:msg prompt))
+
+              ;; My turn, not a boundary, nothing blocking — and no clicks. The
+              ;; orphaned turn (#114/#117): the only move is end-turn. This used
+              ;; to be swallowed by the both-zero-clicks branch above and read as
+              ;; "waiting to start the OPPONENT's turn".
+              (and (= 0 (get-in gs [(keyword (str/lower-case (or my-side "corp"))) :click])))
+              (do
+                (println "Status: ⚠️  Your turn — 0 clicks left")
+                (println "💡 Use 'end-turn' to finish your turn"))
 
               ;; My turn and active
               :else
@@ -270,7 +280,7 @@
                                         (:sources hosted)))))
                 (println "Credits:" (state/runner-credits))))
             (let [clicks runner-clicks]
-              (if (and (= "runner" active-side) (zero? clicks) (not end-turn) (not both-zero-clicks))
+              (if (and (= "runner" active-side) (zero? clicks) (not end-turn) (not at-boundary))
                 (do
                   (println "Clicks:" clicks "(End of Turn)")
                   (println "💡 Use 'end-turn' to finish your turn"))
@@ -333,7 +343,7 @@
             (println "\n--- CORP ---")
             (println "Credits:" (state/corp-credits))
             (let [clicks corp-clicks]
-              (if (and (= "corp" active-side) (zero? clicks) (not end-turn) (not both-zero-clicks))
+              (if (and (= "corp" active-side) (zero? clicks) (not end-turn) (not at-boundary))
                 (do
                   (println "Clicks:" clicks "(End of Turn)")
                   (println "💡 Use 'end-turn' to finish your turn"))

--- a/dev/src/clj/ai_state.clj
+++ b/dev/src/clj/ai_state.clj
@@ -304,6 +304,86 @@
          ;; Engine says they've resolved => not pending, whatever our prompt says.
          (not opp-keep))))
 
+(defn my-turn-to-act?
+  "Check if it's our turn to act (need to start-turn or have clicks).
+   Handles Netrunner priority system where active-player doesn't flip until start-turn.
+
+   Wake conditions (any one is sufficient):
+     - I am the active player AND I have clicks remaining
+     - opponent set the :end-turn flag and active-player is still them
+       (engine in transition; my turn is up next)
+     - turn 0, Corp side, 0 clicks (post-mulligan: Corp goes first)
+
+   Crucially NOT a wake condition: 'both players at 0 clicks'. That
+   scenario fires every time the Runner spends their last click on a run
+   (Runner=0, Corp=0, but Runner is still resolving the run). An earlier
+   duplicate predicate had that bug and woke spuriously on every
+   opponent run-transition; this predicate is the authoritative source
+   of truth for the `wait` command (via `relevance-reason`).
+
+   Also NOT a wake condition: the opening-mulligan boundary. While our own prompt
+   is the 'waiting for opponent to keep hand or mulligan' window, start-turn is
+   refused (:opponent-mulligan), so reporting 'your move' here is a lie that
+   returns instantly and repeatedly — #87. The guard is checked FIRST so this
+   predicate agrees with can-start-turn? by construction.
+
+   Lives HERE, at the bottom of the stack, for the same reason
+   `opponent-mulligan-pending?` does: get-turn-status (below) backs every
+   seat-facing turn surface and MUST give this predicate's answer rather than
+   re-deriving one. ai-core re-exports it via a delegating `defn`."
+  [client-state side]
+  ;; nil-safe on side: in the lobby / pre-game the seat may have no :side yet,
+  ;; and `(name nil)` would NPE (#46). No side => not our turn.
+  (when-let [my-side (keyword side)]
+    (let [active-player (get-in client-state [:game-state :active-player])
+          my-clicks (get-in client-state [:game-state my-side :click] 0)
+          end-turn (get-in client-state [:game-state :end-turn])
+          turn-number (get-in client-state [:game-state :turn] 0)]
+      (and
+       ;; #87: never claim it's our move while the opponent's opening mulligan is
+       ;; unresolved — start-turn will refuse, and `wait` would spin on the lie.
+       (not (opponent-mulligan-pending? client-state))
+       (or
+        ;; My turn and I have clicks
+        (and (= (name my-side) active-player) (> my-clicks 0))
+        ;; Opponent ended turn, waiting for me to start
+        ;; (active-player = opponent because end-turn was called, I'm next)
+        (and end-turn (not= (name my-side) active-player))
+        ;; Turn 0 with 0 clicks = post-mulligan, Corp needs to start
+        ;; (Corp always goes first)
+        (and (= 0 turn-number) (= 0 my-clicks) (= my-side :corp)))))))
+
+(defn turn-awaiting-start?
+  "True when it's SIDE's turn at a boundary but the turn has NOT been started yet
+   (they hold 0 clicks). That side must call `start-turn` before it can act.
+
+   This is the subset of `my-turn-to-act?` that is a turn boundary rather than a
+   live, actionable turn. `relevance-reason` uses it to wake with the distinct
+   reason :my-turn-start instead of :my-turn; get-turn-status uses it to decide
+   :waiting-to-start? / :next-player.
+
+   Note it takes an arbitrary side, not just ours: whose-turn is a property of
+   the shared game state, so the boundary question is answerable for either
+   seat from the same wire fields (:end-turn, :active-player, per-side :click).
+
+   The engine makes :end-turn a LATCH, not a transient: `new-state` starts it
+   true, `start-turn` clears it, `end-turn-continue` sets it. So 'a turn has
+   ended and the next has not begun' is exactly `:end-turn`, and 'both sides
+   hold 0 clicks' is NOT a boundary — see the #117 note on get-turn-status."
+  [client-state side]
+  ;; nil-safe on side (see my-turn-to-act?): no side => no pending turn start.
+  (when-let [my-side (keyword side)]
+    (let [active-player (get-in client-state [:game-state :active-player])
+          my-clicks (get-in client-state [:game-state my-side :click] 0)
+          end-turn (get-in client-state [:game-state :end-turn])
+          turn-number (get-in client-state [:game-state :turn] 0)]
+      (and (= 0 my-clicks)
+           (or
+             ;; Opponent ended their turn; active-player is still them until I start
+             (and end-turn (not= (name my-side) active-player))
+             ;; Post-mulligan turn 0: Corp goes first but hasn't started
+             (and (= 0 turn-number) (= my-side :corp)))))))
+
 (defn get-prompt
   "Get current prompt for our side, if any"
   []
@@ -336,25 +416,54 @@
         run-state (get-in gs [:run])
         runner-clicks (get-in gs [:runner :click])
         corp-clicks (get-in gs [:corp :click])
-        both-zero-clicks (and (= 0 runner-clicks) (= 0 corp-clicks))
+        my-clicks (when my-side
+                    (get-in gs [(keyword (clojure.string/lower-case my-side)) :click]))
         ;; Compare case-insensitively since my-side is "Corp"/"Runner" but active-side is "corp"/"runner"
         my-turn (and my-side active-side
                      (= (clojure.string/lower-case my-side)
                         (clojure.string/lower-case active-side)))
-        ;; When both have 0 clicks, determine who should go next
-        ;; At turn 0: Corp goes first
-        ;; Otherwise: opposite of whoever is currently active
+
+        ;; #117: whose move it is comes from ONE predicate. This used to be
+        ;; derived here from `both-zero-clicks`, which is not a turn boundary —
+        ;; :end-turn is an engine LATCH, so a turn ORPHANED at 0 clicks (last
+        ;; click handed the opponent a decision, auto-end-turn declined, nothing
+        ;; re-ran the check — #114) looks identical to a real boundary by click
+        ;; count alone. In that state every surface here pointed at the wrong
+        ;; player while the action belonged to the active one, and the "(End of
+        ;; Turn) → use 'end-turn'" hint in `status` — the exact recovery — was
+        ;; suppressed by the same flag. Third time this class has bitten
+        ;; (#31, #68, #114): the boundary is NOT derivable from click counts.
+        client @client-state
+        ;; The opening mulligan is NOT a turn boundary, however the click counts
+        ;; and the :end-turn latch read (#87). `new-state` ships :end-turn true
+        ;; at turn 0, so every click-or-latch derivation — the old one included —
+        ;; called this a boundary and published AWAITING-START next-player=corp
+        ;; while start-turn refused (:opponent-mulligan). my-turn-to-act? guards
+        ;; on this FIRST, so the boundary must too, or "derives from the
+        ;; authoritative predicate" is only half true. Guest-panel catch: it made
+        ;; get-turn-status contradict its OWN :status-text, which already said
+        ;; "waiting for opponent to finish their opening mulligan".
+        mulligan-pending (opponent-mulligan-pending? client)
+        i-await-start (boolean (and (not mulligan-pending)
+                                    (turn-awaiting-start? client my-side)))
+        opp-side (when my-side
+                   (if (= "corp" (clojure.string/lower-case my-side)) "runner" "corp"))
+        opp-awaits-start (boolean (and (not mulligan-pending)
+                                       (turn-awaiting-start? client opp-side)))
+        at-boundary (or i-await-start opp-awaits-start)
+        ;; Name the side the boundary is actually waiting on. Only meaningful
+        ;; when at-boundary; the positional fallback keeps the field populated
+        ;; for the non-boundary callers that still read it.
         next-player (cond
-                     (= turn-num 0) "corp"
-                     (= active-side "corp") "runner"
-                     (= active-side "runner") "corp"
-                     :else "unknown")
+                      i-await-start (clojure.string/lower-case my-side)
+                      opp-awaits-start opp-side
+                      (= turn-num 0) "corp"
+                      (= active-side "corp") "runner"
+                      (= active-side "runner") "corp"
+                      :else "unknown")
 
         ;; Determine status
-        ;; Check if I'm the next player (for both-zero-clicks case)
-        i-am-next (and both-zero-clicks
-                       my-side
-                       (= (clojure.string/lower-case my-side) next-player))
+        i-am-next i-await-start
 
         [emoji text can-act]
         (cond
@@ -375,8 +484,8 @@
           (opponent-mulligan-pending? @client-state)
           ["⏳" "Waiting for opponent to finish their opening mulligan" false]
 
-          ;; Both at 0 clicks - it's the next player's turn to start
-          both-zero-clicks
+          ;; A real turn boundary: someone owes a `start-turn`.
+          at-boundary
           (if i-am-next
             ["🟢" "Ready to start your turn" true]
             ["⏳" (str "Waiting for " next-player " to start") false])
@@ -389,6 +498,19 @@
 
           (waiting-prompt-type? prompt-type)
           ["⏳" (or (:msg prompt) "Waiting...") false]
+
+          ;; My turn, no boundary, no blocking prompt — and no clicks left. The
+          ;; ORPHANED-turn shape (#114/#117). The only move is `end-turn`, and
+          ;; saying "Your turn to act" here sent a seat hunting for a playable
+          ;; it does not have. Not a run: a last-click run is still resolving.
+          ;;
+          ;; :can-act? is FALSE deliberately, so this row agrees with
+          ;; my-turn-to-act? (which requires clicks > 0) — the single-source rule
+          ;; the whole fix exists to restore. It only drives presentation:
+          ;; show-turn-indicator uses it to decide whether to append
+          ;; "- N clicks remaining", which is exactly the claim we must not make.
+          (and (not run-state) (= 0 my-clicks))
+          ["⚠️" "Your turn — 0 clicks left, use 'end-turn'" false]
 
           :else
           ["✅" "Your turn to act" true])]
@@ -413,16 +535,18 @@
      ;; game-over first, lobby-gone second.
      :in-game? (boolean (and (or gs (:lobby-state @client-state))
                              (not (lobby-gone? @client-state))))
-     ;; A clean turn boundary (a player ended their turn, or both sides are at
-     ;; 0 clicks) is "next player to start", NOT a stall. Tooling uses this to
-     ;; avoid false-positive stall detection while a slow opponent thinks about
-     ;; its turn start. game-over takes precedence. An ACTIVE run is excluded:
-     ;; a run started with the last click leaves both sides at 0 clicks but is
-     ;; mid-resolution, not a turn boundary — a wedged run there must keep the
-     ;; tight mid-turn stall budget, not the patient boundary one.
+     ;; A clean turn boundary — a player has ended their turn and the next one
+     ;; owes a `start-turn` — is "next player to start", NOT a stall. Tooling
+     ;; uses this to avoid false-positive stall detection while a slow opponent
+     ;; thinks about its turn start. game-over takes precedence. An ACTIVE run
+     ;; is excluded: a run started with the last click leaves both sides at 0
+     ;; clicks but is mid-resolution, not a turn boundary — a wedged run there
+     ;; must keep the tight mid-turn stall budget, not the patient boundary one.
+     ;; (turn-awaiting-start? already rejects that shape; the guard is kept
+     ;; because a run can also be live across a genuinely latched :end-turn.)
      :waiting-to-start? (boolean (and (not game-over?)
                                       (not run-state)
-                                      (or end-turn both-zero-clicks)))
+                                      at-boundary))
      :my-turn? my-turn
      :turn-number turn-num
      :can-act? can-act

--- a/dev/test/ai_display_test.clj
+++ b/dev/test/ai_display_test.clj
@@ -132,13 +132,14 @@
              (str/trim (with-out-str (display/game-over-status))))))))
 
 (deftest test-game-over-status-awaiting-start
-  ;; At a clean turn boundary (a player has ended their turn, or both sides are
-  ;; at 0 clicks) the active-player wire field still names the player who just
-  ;; finished. Reporting `IN-PROGRESS whose-turn=corp clicks=0` there is
+  ;; At a clean turn boundary the active-player wire field still names the player
+  ;; who just finished. Reporting `IN-PROGRESS whose-turn=corp clicks=0` there is
   ;; indistinguishable from a corp stall, so the umpire's stall detector can
   ;; false-positive while a slow opponent is thinking about its turn start.
   ;; A distinct AWAITING-START token names who acts next so tooling can apply a
   ;; patient boundary budget instead of the tight mid-turn stall threshold.
+  ;;
+  ;; The boundary is the engine's :end-turn latch, NOT a click count — see #117.
   (testing "corp ended turn -> AWAITING-START next-player=runner"
     (with-mock-state (mock-client-state
                       :side "corp"
@@ -148,12 +149,17 @@
       (is (= "AWAITING-START turn=5 next-player=runner"
              (str/trim (with-out-str (display/game-over-status)))))))
 
-  (testing "both sides at 0 clicks (no end-turn flag yet) -> AWAITING-START"
+  ;; #117: this case used to assert AWAITING-START. It is the shape of an
+  ;; ORPHANED turn (#114) — the active player is out of clicks but has not
+  ;; latched :end-turn — and calling it a boundary is what made every seat-facing
+  ;; surface point at the wrong player. The clicks=0 in IN-PROGRESS is the honest
+  ;; signal: the runner's turn is open and going nowhere.
+  (testing "#117: both sides at 0 clicks with no end-turn latch -> IN-PROGRESS"
     (with-mock-state (mock-client-state
                       :side "corp"
                       :game-state {:active-player "runner" :turn 6
                                    :corp {:click 0} :runner {:click 0}})
-      (is (= "AWAITING-START turn=6 next-player=corp"
+      (is (= "IN-PROGRESS turn=6 whose-turn=runner clicks=0"
              (str/trim (with-out-str (display/game-over-status)))))))
 
   ;; #104: a boundary with our own prompt still open (end-of-turn discard) read
@@ -1976,3 +1982,163 @@
           (str "the Corp has no self-advance path, got:\n" out))
       (is (not (str/includes? out "abandoned"))
           (str "must not promise the Corp a recovery it does not have, got:\n" out)))))
+
+;; ============================================================================
+;; #117 — the three turn-boundary surfaces must AGREE
+;; ============================================================================
+;; Ground truth from the Luna-vs-Luna game (gameid d840fc14): a Corp turn was
+;; ORPHANED at 0 clicks — `active-player=corp, end-turn=false, corp clicks=0` —
+;; because the last click handed the Runner a decision and auto-end-turn declined
+;; (#114). Every seat-facing surface then pointed at the RUNNER:
+;;
+;;   game-over-status  AWAITING-START turn=10 next-player=runner
+;;   Runner `prompt`   🟢 It's YOUR turn but it hasn't started yet
+;;   Corp   `prompt`   ⏳ Waiting for runner to start their turn
+;;   Corp   `status`   "Turn: 10 - corp" AND "🟢 Waiting to start runner turn"
+;;
+;; The umpire read the Runner's `prompt`, believed it, and issued a wrong
+;; instruction. No test constructed this state, so all three surfaces stayed
+;; green through it. Each surface derives from get-turn-status, which derived
+;; the boundary from `both-zero-clicks` — a heuristic, not the engine's rule.
+
+(defn- orphaned-turn-state
+  "The #117 shape, viewed from SIDE. Corp is active with 0 clicks and has NOT
+   latched :end-turn; the Runner also holds 0 (it is not their turn)."
+  [side]
+  (mock-client-state
+   :side side
+   :active-player "corp"
+   :game-state {:active-player "corp"
+                :turn 10
+                :end-turn false
+                :corp {:click 0 :credit 3 :hand-count 5 :deck-count 30
+                       :user {:username "ai-corp"}}
+                :runner {:click 0 :credit 5 :hand-count 5 :deck-count 30
+                         :user {:username "ai-runner"}}}))
+
+(deftest test-orphaned-turn-surfaces-agree
+  (testing "#117: game-over-status does not call an orphaned turn a boundary"
+    (with-mock-state (orphaned-turn-state "corp")
+      (let [out (with-out-str (display/game-over-status))]
+        (is (not (str/includes? out "AWAITING-START"))
+            (str "no :end-turn latch => no boundary; got:\n" out))
+        (is (str/includes? out "IN-PROGRESS")
+            (str "the corp's turn is still open; got:\n" out))
+        (is (str/includes? out "whose-turn=corp")
+            (str "and it belongs to the CORP, not the runner; got:\n" out)))))
+
+  (testing "#117: the Runner's prompt does not claim the turn is theirs"
+    (with-mock-state (orphaned-turn-state "runner")
+      (let [out (with-out-str (display/show-prompt-detailed))]
+        (is (not (str/includes? out "It's YOUR turn"))
+            (str "this is the line the umpire believed; got:\n" out))
+        (is (str/includes? out "corp")
+            (str "it must name the corp as the side to act; got:\n" out)))))
+
+  (testing "#117: the Corp's prompt points at the Corp, not at the runner"
+    (with-mock-state (orphaned-turn-state "corp")
+      (let [out (with-out-str (display/show-prompt-detailed))]
+        (is (not (str/includes? out "Waiting for runner to start"))
+            (str "the runner owes nothing here; got:\n" out))
+        (is (str/includes? out "end-turn")
+            (str "end-turn is the only legal move; got:\n" out)))))
+
+  (testing "#117: the Corp's status block does not contradict itself"
+    (with-mock-state (orphaned-turn-state "corp")
+      (let [out (with-out-str (display/show-status))]
+        (is (str/includes? out "Turn: 10 - corp")
+            (str "ground truth line; got:\n" out))
+        (is (not (str/includes? out "Waiting to start runner turn"))
+            (str "…which the status line used to contradict; got:\n" out))
+        (is (str/includes? out "end-turn")
+            (str "the recovery hint the both-zero-clicks guard suppressed;
+                  got:\n" out)))))
+
+  (testing "#117: all three surfaces name the same side"
+    (doseq [side ["corp" "runner"]]
+      (with-mock-state (orphaned-turn-state side)
+        (let [ts (ai-state/get-turn-status)]
+          (is (false? (:waiting-to-start? ts))
+              (str side ": not a boundary"))
+          (is (= "corp" (:whose-turn ts))
+              (str side ": the corp is the active player"))
+          ;; The single-source rule (#31/#68/#114): the surfaces above all read
+          ;; get-turn-status, and it must not claim an ability to act that
+          ;; my-turn-to-act? — the predicate backing `wait` — denies. Asserted
+          ;; directionally rather than as an equality, because an equality here
+          ;; is satisfied by false=false and would go on passing if BOTH sides
+          ;; of it regressed together.
+          (is (false? (boolean (core/my-turn-to-act? @ai-state/client-state side)))
+              (str side ": nobody has clicks, so the predicate denies acting"))
+          (is (false? (:can-act? ts))
+              (str side ": …and get-turn-status must not claim otherwise")))))))
+
+(deftest test-real-boundary-still-reads-as-a-boundary
+  (testing "#117 regression guard: a LATCHED end-turn is still AWAITING-START"
+    (with-mock-state (mock-client-state
+                      :side "runner"
+                      :active-player "corp"
+                      :game-state {:active-player "corp"
+                                   :turn 10
+                                   :end-turn true
+                                   :corp {:click 0 :user {:username "ai-corp"}}
+                                   :runner {:click 0 :user {:username "ai-runner"}}})
+      (let [out (with-out-str (display/game-over-status))]
+        (is (str/includes? out "AWAITING-START turn=10 next-player=runner")
+            (str "the patient boundary stall budget must still be reachable;
+                  got:\n" out)))))
+
+  (testing "#117 regression guard: post-mulligan turn 0 is the Corp's to start"
+    (with-mock-state (mock-client-state
+                      :side "corp"
+                      :active-player "runner"
+                      :game-state {:active-player "runner"
+                                   :turn 0
+                                   :end-turn true
+                                   :corp {:click 0 :keep true :user {:username "ai-corp"}}
+                                   :runner {:click 0 :keep true :user {:username "ai-runner"}}})
+      (let [out (with-out-str (display/game-over-status))]
+        (is (str/includes? out "AWAITING-START turn=0 next-player=corp")
+            (str "corp goes first; got:\n" out))))))
+
+(deftest test-opening-mulligan-is-not-a-turn-boundary
+  ;; #117 (guest-panel catch), continuing #87. `new-state` ships :end-turn TRUE
+  ;; at turn 0, so the mulligan window satisfies every click-or-latch reading of
+  ;; "turn boundary" — the pre-#117 `(or end-turn both-zero-clicks)` included.
+  ;; get-turn-status therefore published AWAITING-START next-player=corp (and
+  ;; `prompt` said "It's YOUR turn ... use 'start-turn'") while start-turn
+  ;; refused with :opponent-mulligan, and while get-turn-status's OWN
+  ;; :status-text said we were waiting on the opponent's mulligan.
+  ;; my-turn-to-act? guards on the mulligan first; the boundary must too.
+  (let [mulligan-state
+        (mock-client-state
+         :side "corp"
+         :active-player "runner"
+         :game-state {:active-player "runner"
+                      :turn 0
+                      :end-turn true
+                      :corp {:click 0
+                             :prompt-state {:prompt-type "waiting"
+                                            :msg "Waiting for Runner to keep hand or mulligan"}}
+                      :runner {:click 0}})]
+    (testing "the predicate and the boundary agree that we cannot start yet"
+      (with-mock-state mulligan-state
+        (is (true? (ai-state/opponent-mulligan-pending? @ai-state/client-state))
+            "precondition: this IS the mulligan window")
+        (is (false? (boolean (core/my-turn-to-act? @ai-state/client-state "corp")))
+            "the authoritative predicate says no (#87)")
+        (is (false? (:waiting-to-start? (ai-state/get-turn-status)))
+            "so the boundary must say no as well")))
+
+    (testing "game-over-status does not advertise a start the engine will refuse"
+      (with-mock-state mulligan-state
+        (let [out (with-out-str (display/game-over-status))]
+          (is (not (str/includes? out "AWAITING-START"))
+              (str "tooling would apply boundary semantics to a refused start;
+                    got:\n" out)))))
+
+    (testing "prompt does not tell the seat to start-turn"
+      (with-mock-state mulligan-state
+        (let [out (with-out-str (display/show-prompt-detailed))]
+          (is (not (str/includes? out "start-turn"))
+              (str "the #87 lie, relocated to the prompt surface; got:\n" out)))))))

--- a/dev/test/ai_state_test.clj
+++ b/dev/test/ai_state_test.clj
@@ -263,7 +263,27 @@
         (is (true? (:waiting-to-start? status)))
         (is (= "runner" (:next-player status))))))
 
-  (testing "both at 0 clicks -> waiting-to-start?, next-player=corp"
+  (testing "runner ended turn -> waiting-to-start?, next-player=corp"
+    (with-mock-state (mock-client-state
+                      :side "corp"
+                      :active-player "runner"
+                      :game-state {:active-player "runner"
+                                   :turn 6
+                                   :end-turn true
+                                   :corp {:click 0}
+                                   :runner {:click 0}})
+      (let [status (state/get-turn-status)]
+        (is (true? (:waiting-to-start? status)))
+        (is (= "corp" (:next-player status))))))
+
+  ;; #117: this case used to assert the OPPOSITE — "both at 0 clicks" was read
+  ;; as a boundary with no :end-turn in sight. It is not one. The engine makes
+  ;; :end-turn a latch (new-state true / start-turn false / end-turn-continue
+  ;; true), so 0-clicks-without-:end-turn means the active player's turn is
+  ;; still open — orphaned at 0 clicks (#114). The test was green through the
+  ;; whole life of the bug because it encoded the heuristic rather than the
+  ;; engine's rule. Deriving from turn-awaiting-start? kills the class.
+  (testing "#117: both at 0 clicks WITHOUT end-turn is NOT a boundary"
     (with-mock-state (mock-client-state
                       :side "corp"
                       :active-player "runner"
@@ -272,8 +292,9 @@
                                    :corp {:click 0}
                                    :runner {:click 0}})
       (let [status (state/get-turn-status)]
-        (is (true? (:waiting-to-start? status)))
-        (is (= "corp" (:next-player status))))))
+        (is (false? (:waiting-to-start? status))
+            "no :end-turn latch => the runner's turn is still open")
+        (is (= "runner" (:whose-turn status))))))
 
   (testing "mid-turn (active player has clicks) -> not waiting-to-start?"
     (with-mock-state (mock-client-state


### PR DESCRIPTION
Closes #117.

## The bug

Every seat-facing turn surface derived "is this a turn boundary" from
`both-zero-clicks`. It isn't one. The engine writes `:end-turn` in exactly three places —
`new-state` (true), `start-turn` (false), `end-turn-continue` (true) — so it is a **latch**,
and "a turn ended and the next hasn't started" is precisely that flag. Zero clicks without
it means the active player's turn is still open.

That state is reachable for real (#114): the last click hands the opponent a decision,
auto-end-turn declines, nothing re-runs the check. Ground truth
`active-player=corp, end-turn=false, corp clicks=0` — and every surface pointed at the Runner:

| Surface | Before | After |
|---|---|---|
| `game-over-status` | `AWAITING-START turn=10 next-player=runner` | `IN-PROGRESS turn=10 whose-turn=corp clicks=0` |
| Runner `prompt` | `🟢 It's YOUR turn but it hasn't started yet` | `⏳ It's corp's turn, not yours → use 'wait'` |
| Corp `prompt` | `⏳ Waiting for runner to start their turn` | `ℹ️ ⚠️ Your turn — 0 clicks left, use 'end-turn'` |
| Corp `status` | `Turn: 10 - corp` **and** `🟢 Waiting to start runner turn` | `Turn: 10 - corp` + `⚠️ Your turn — 0 clicks left` + `💡 Use 'end-turn'` |

The umpire read the Runner's `prompt`, believed it, and issued a wrong instruction. The same
flag also suppressed the Corp's `(End of Turn) → use 'end-turn'` hint — the exact recovery.

## Changes

- `my-turn-to-act?` / `turn-awaiting-start?` move **down** to `ai-state` (the
  `opponent-mulligan-pending?` precedent) so `get-turn-status` answers from the authoritative
  predicate instead of a private heuristic. `ai-core` re-exports via delegating `defn`s.
- `get-turn-status` derives `:waiting-to-start?` / `:next-player` from `turn-awaiting-start?`
  per side, and gains an orphaned-turn branch naming `end-turn` as the only move.
  `:can-act?` is false there, agreeing with `my-turn-to-act?`.
- `show-status` drops its own duplicate copy of the heuristic.

## Guest panel (GPT-5.6, read-only)

Two CRITICAL findings; both confirmed against the engine, one fixed here, one split out.

**Confirmed + fixed — the opening mulligan was the same bug, pre-existing.** `new-state`
ships `:end-turn true` at turn 0, so the mulligan window satisfied the *old*
`(or end-turn both-zero-clicks)` as well. Verified live:

```
opponent-mulligan-pending? = true
my-turn-to-act? corp       = false
waiting-to-start?          = true      <-- disagrees
status-text                = Waiting for opponent to finish their opening mulligan
game-over-status           => AWAITING-START turn=0 next-player=corp
```

`get-turn-status` was contradicting its **own** `:status-text`, and advertising a
`start-turn` the engine refuses with `:opponent-mulligan` (#87). The boundary now applies
the mulligan guard `my-turn-to-act?` already applied.

**Confirmed, split out as #120 — the wake half.** `my-turn-to-act?` still denies the Corp's
`end-turn` obligation, so `relevance-reason` is nil on *both* seats and neither `wait` can
wake. Verified:

```
corp   | my-turn-to-act? = false | relevance-reason = nil
runner | my-turn-to-act? = false | relevance-reason = nil
```

Not fixed here: the naive patch re-introduces the exact wake condition
`my-turn-to-act?`'s docstring forbids ("NOT a wake condition: both players at 0 clicks —
fires every time the Runner spends their last click on a run"), and it touches the wake
ladder that #31/#68/#91 all live in. #117 is explicitly scoped to the display layer.

The guest also verified the two load-bearing assumptions I put in the review prompt: the
`:end-turn` latch reading, and that `:click` is in `diffs/player-keys` for both sides
(so `turn-awaiting-start?` is safe to ask about the opponent). It rejected my fourth
question — `Turn: 10 - corp` is correct ground truth, left unchanged.

## Tests

**681 tests / 1874 assertions / 0 failures** (678/1847 before).

Two existing tests *asserted the bug* (`both-zero-clicks` ⇒ boundary) and were green
through its entire life — the fixture encoded the heuristic instead of the engine's rule.
Both inverted here with the rule spelled out. New coverage builds the orphaned state, which
no test constructed, and asserts the three surfaces agree; plus guards for a real latched
boundary, post-mulligan turn 0, and the mulligan window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)