### PR TITLE
DRAFT fix(#116): ability legality from the engine's :playable — COLLIDES with in-flight work in netrunner-116

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ check-full:
 # Run unit tests
 test:
 	@echo "Running unit tests..."
-	lein test ai-actions-test ai-actions-sad-path-test ai-basic-actions-test ai-connection-test ai-heuristic-corp-test ai-heuristic-runner-test ai-runs-test ai-run-corp-decisions-test ai-stall-test ai-websocket-diff-test ai-websocket-error-recovery-test ai-display-test ai-state-test ai-prompts-test ai-pure-functions-test ai-turn-validation-test ai-wait-test continue-run-rez-test run-window-selfadvance-test game.ai-upgrade-rez-timing-test game.ai-duplicate-continue-test game.ai-waiting-prompt-test web.lobby-disconnect-test
+	lein test ai-actions-test ai-actions-sad-path-test ai-basic-actions-test ai-connection-test ai-heuristic-corp-test ai-heuristic-runner-test ai-runs-test ai-run-corp-decisions-test ai-stall-test ai-websocket-diff-test ai-websocket-error-recovery-test ai-display-test ai-state-test ai-prompts-test ai-pure-functions-test ai-turn-validation-test ai-wait-test continue-run-rez-test run-window-selfadvance-test game.ai-upgrade-rez-timing-test game.ai-duplicate-continue-test game.ai-waiting-prompt-test game.ai-ability-legality-test web.lobby-disconnect-test
 
 # Run shell-level tests (fast, no REPL/server needed) — e.g. send_command output filters
 test-shell:

--- a/dev/src/clj/ai_card_actions.clj
+++ b/dev/src/clj/ai_card_actions.clj
@@ -340,6 +340,192 @@
       (flush)
       {:status :error :reason (str "Card not found: " card-name)})))
 
+(defn- break-ability?
+  "Does this ability's label read as a subroutine-break?
+
+   Used ONLY to pick which hint to print after the engine has already ruled the
+   ability unplayable — never to decide legality itself. The engine's own
+   `:playable` flag is the authority (see unplayable-ability-error), so a false
+   positive here costs a slightly-off suggestion, not a wrong verdict.
+
+   `:dynamic :auto-pump-and-break` is the encounter-only compound ability the
+   engine SYNTHESISES during an encounter; the plain 'Break N ... subroutine'
+   label is the printed one, which is what a seat reaches for at approach."
+  [ability]
+  (boolean
+    (or (= :auto-pump-and-break (:dynamic ability))
+        (when-let [label (:label ability)]
+          (re-find #"(?i)\bbreak\b.*\bsubroutine" label)))))
+
+(defn- unplayable-ability-error
+  "Explain an ability the engine has marked NOT playable, and DON'T send it.
+
+   Why this gate exists (#116). `use-ability` used to send unconditionally and
+   then infer failure from the absence of a log entry, reporting
+   `Ability not confirmed in game log (timeout)`. That sentence describes a
+   HARNESS fault — a lost message, a slow server, a desync — and invites a retry.
+   The actual condition is usually a rules one, and retrying an illegal ability
+   is the duplicate-send pattern that mints phantom prompts (#75/#77).
+
+   The engine already tells us. `game.core.diffs/ability-playable?` runs
+   can-pay? + can-trigger? (which for a break ability includes the encounter
+   requirement) and assoc's `:playable true` only when the ability is legal
+   RIGHT NOW; the summary reaches us over the wire on every card. board.cljs
+   renders an ability without it as `[:li.disabled label]` — no click handler at
+   all — so the human UI physically cannot send what we were sending. Mirroring
+   that enable condition is the same lesson as [[board-cljs-is-the-wire-spec]]:
+   the UI is the rules layer, and anything its buttons refuse to send, we must
+   refuse too.
+
+   Verified against the engine (game.ai-ability-legality-test): a Corroder at
+   `approach-ice` reports NO :playable on 'Break 1 Barrier subroutine' while
+   'Add 1 strength' keeps it. So this is per-ability, not per-phase — a blanket
+   'nothing works at approach' would wrongly block the pump."
+  [card-name ability-index ability]
+  (let [run (get-in @state/client-state [:game-state :run])
+        phase (:phase run)
+        encountering? (= "encounter-ice" phase)
+        label (:label ability)
+        breaking? (and run (break-ability? ability) (not encountering?))
+        ;; Only at APPROACH is the encounter still ahead of us. The other
+        ;; non-encounter phases are real and reachable — the engine's run ladder
+        ;; is approach-ice / encounter-ice / movement / pass-ice / success — and
+        ;; at movement or success the ICE is already behind the Runner, so
+        ;; "continue to enter the encounter" would push them FURTHER from the
+        ;; recovery. Guest-panel MAJOR: the first cut printed it at every
+        ;; non-encounter phase. Guidance text that asserts engine behaviour is
+        ;; code, and this project has been bitten by exactly this before (#115).
+        encounter-ahead? (and breaking? (= "approach-ice" phase))]
+    (println (format "❌ %s ability %d%s is not usable right now — NOT sent."
+                     card-name ability-index
+                     (if label (str " (\"" label "\")") "")))
+    (println "   The game reports this ability as unavailable in the current state;")
+    (println "   this is a rules/timing condition, not a lost message — retrying as-is will fail again.")
+    (cond
+      encounter-ahead?
+      (do
+        (println (format "   You are at run phase '%s' — you have not reached the ICE yet." phase))
+        (println "   → Subroutines can only be broken during the ENCOUNTER.")
+        (println "     Use 'continue' to enter the encounter, then retry this ability."))
+
+      breaking?
+      (do
+        (println (format "   You are at run phase '%s', not encountering an ICE." phase))
+        (println "   → Subroutines can only be broken during an ENCOUNTER.")
+        (println (if (= "success" phase)
+                   "     This run has passed the ICE — there is nothing left to break."
+                   "     'board' / 'status' to see where in the run you are.")))
+
+      :else
+      (do
+        (println "   Common causes: not enough credits, once-per-turn already used,")
+        (println "   a condition on the card that isn't met, or the wrong game phase.")
+        (when run
+          (println (format "   (You are in a run, phase '%s'.)" phase)))
+        ;; Real command spellings — `send_command` has card-text and abilities;
+        ;; there is no `show-card`. (Guest-panel MINOR, and the same class as the
+        ;; line above: an invented command name reads as authoritative.)
+        (println (format "   → 'abilities \"%s\"' for the indexed menu, 'card-text \"%s\"' for the card,"
+                         card-name card-name))
+        (println "     or 'list-playables' for what IS usable right now.")))
+    (flush)
+    {:status :error
+     :reason (if breaking?
+               (format "Ability not legal at run phase %s (subroutines break during the encounter)" phase)
+               "Ability not currently playable (engine reports it unavailable)")
+     :card-name card-name
+     :unplayable true}))
+
+(def ^:private playable-settle-ms
+  "How long to let an in-flight diff land before trusting a NEGATIVE :playable.
+
+   Our flag is a CACHED negative — whatever the last applied diff said. board.cljs
+   disables its button off the same cached field, so the gate is no staler than
+   the human UI; but a human re-reads a greyed button while a seat treats a hard
+   error as final. The dangerous window is `continue` immediately followed by
+   `use-ability`: if the encounter diff hasn't applied, the pre-send gate would
+   refuse an action that is about to be legal (guest-panel CRITICAL).
+
+   Polling costs nothing in the case the gate exists for — a genuinely illegal
+   ability never gains the flag, so we always pay the full wait and then refuse.
+   It is still an order of magnitude under the 3s log timeout it replaces."
+  600)
+
+(defn- settle-ability
+  "Re-read the ability at INDEX, giving an in-flight diff up to
+   `playable-settle-ms` to make it playable. Returns [abilities ability] as of
+   the freshest read. `get-abilities` re-looks-up the card each poll, so a diff
+   that replaces the whole card map is picked up too.
+
+   Returns immediately once the ability is playable; only a refusal pays the wait."
+  [get-abilities ability-index]
+  (let [deadline (+ (System/currentTimeMillis) playable-settle-ms)]
+    (loop []
+      (let [abilities (get-abilities)
+            ability (when (and abilities (< ability-index (count abilities)))
+                      (nth abilities ability-index))]
+        (if (or (:playable ability)
+                (>= (System/currentTimeMillis) deadline))
+          [abilities ability]
+          (do (Thread/sleep core/polling-delay)
+              (recur)))))))
+
+(defn- ability-blocked
+  "Return an error map when the request can be refused BEFORE sending, else nil.
+
+   `unplayable-ability-error` is shared with `use-runner-ability!`, which does
+   the same two checks in its own `cond`. Both senders must agree: this codebase
+   keeps paying for per-sender copies of a shared rule (#75/#77 three
+   send-continue! copies, #113 the sender the CLI never calls, #115 the inlined
+   phase set).
+
+   Two refusable conditions, both knowable from state we already hold:
+   - the index addresses no ability (the seat guessed, or is reaching for the
+     encounter-only dynamic 'Fully break X' that the engine has not synthesised
+     yet — it appears in the list ONLY during an encounter);
+   - the ability exists but the engine has not marked it :playable.
+
+   Both are re-checked against settled state first (see `settle-ability`) so an
+   unapplied diff can't produce a false refusal. With no abilities vector at all
+   we know nothing, so we send and let the existing verification path answer."
+  [card-name ability-index get-abilities]
+  (let [[abilities ability] (settle-ability get-abilities ability-index)]
+   (cond
+    (and (seq abilities) (>= ability-index (count abilities)))
+    (do
+      (println (format "❌ %s has no ability %d — it has %d (0-%d). NOT sent."
+                       card-name ability-index (count abilities) (dec (count abilities))))
+      (doseq [[i a] (map-indexed vector abilities)]
+        (println (format "     %d. %s%s" i (or (:label a) "?")
+                         (if (:playable a) "" "   [not usable right now]"))))
+      (println "   Note: a breaker's 'Fully break <ICE>' ability only exists DURING an encounter.")
+      (flush)
+      {:status :error
+       :reason (format "No ability %d on %s (has %d)" ability-index card-name (count abilities))
+       :card-name card-name})
+
+    (and ability (not (:playable ability)))
+    (unplayable-ability-error card-name ability-index ability))))
+
+(defn- rules-explanation-after-timeout
+  "When verification timed out, look at state as it stands NOW and replace the
+   timeout wording if the current state explains the failure as a rules one.
+
+   The pre-send gate can't catch everything (#116, guest-panel MAJOR): the
+   reverse of the stale-negative race is a stale POSITIVE. If a `continue` moved
+   the server out of the encounter but that diff hadn't applied, the ability
+   still read :playable, we sent it, the engine refused — and the diff that
+   arrives moments later plainly shows why. The issue asked for exactly this:
+   'before falling through to the timeout path, check whether the ability is
+   legal in the current run phase.' Returns nil when the state offers no
+   explanation, so a genuine harness fault still reports as one."
+  [card-name ability-index get-abilities]
+  (let [abilities (get-abilities)
+        ability (when (and abilities (< ability-index (count abilities)))
+                  (nth abilities ability-index))]
+    (when (and abilities (not (:playable ability)))
+      (unplayable-ability-error card-name ability-index ability))))
+
 (defn use-ability!
   "Use an installed card's ability. Returns status map:
    - {:status :success} - ability fired
@@ -358,6 +544,14 @@
     (if card
       (let [gameid (:gameid client-state)
             card-ref (core/create-card-ref card)
+            ;; Re-looks-up the card each call, so the legality gate and the
+            ;; post-timeout explanation both read LIVE state rather than the
+            ;; snapshot this fn opened with (#116, guest-panel CRITICAL).
+            get-abilities (fn []
+                            (:abilities
+                              (if (core/side= "Corp" side)
+                                (core/find-installed-corp-card card-name)
+                                (core/find-installed-card card-name))))
             ;; Check if this ability is dynamic (e.g., auto-pump, auto-pump-and-break)
             abilities (:abilities card)
             ability (when (and abilities (< ability-index (count abilities)))
@@ -368,6 +562,9 @@
             ;; response arrives before we start polling (fixes false timeouts)
             pre-log-size (core/get-log-size)
             pre-prompt (state/get-prompt)]
+        (if-let [blocked (ability-blocked card-name ability-index get-abilities)]
+          blocked
+          (do
         ;; Send the ability command
         (if dynamic-type
           ;; Use dynamic-ability command for abilities with :dynamic field
@@ -403,9 +600,15 @@
             (println (str "⏳ Ability triggered prompt: " card-name " - "
                           (or ability-label (str "#" ability-index))))
 
+            ;; #116: prefer a rules explanation from CURRENT state over the
+            ;; timeout wording, which describes only how we noticed.
             :error
-            (println (str "❌ Ability failed: " card-name " - " (:reason result))))
-          result))
+            nil)
+          (if (= :error (:status result))
+            (or (rules-explanation-after-timeout card-name ability-index get-abilities)
+                (do (println (str "❌ Ability failed: " card-name " - " (:reason result)))
+                    result))
+            result)))))
       ;; Own-side lookup missed. From the Runner seat the card may be a Corp
       ;; card whose printed ability is Runner-usable (bioroid click-to-break,
       ;; issue #95) — route to the runner-ability command instead of
@@ -437,7 +640,9 @@
   (let [client-state @state/client-state
         card (core/find-installed-corp-card card-name)
         runner-abilities (:runner-abilities card)
-        ability (when card (nth runner-abilities ability-index nil))]
+        ability (when card (nth runner-abilities ability-index nil))
+        ;; Live re-read, same as use-ability! — see settle-ability.
+        get-abilities (fn [] (:runner-abilities (core/find-installed-corp-card card-name)))]
     (cond
       (not card)
       (ambiguous-or-missing-error card-name)
@@ -453,7 +658,14 @@
         (flush)
         {:status :error :reason (str "No runner-ability " ability-index " on " card-name)})
 
+      ;; #116: same legality gate as use-ability!. A bioroid's click-to-break is
+      ;; exactly as encounter-bound as a breaker's, and this sender had the same
+      ;; send-then-blame-the-log shape. Goes through the SHARED helper (which
+      ;; settles in-flight diffs first) rather than testing :playable inline, so
+      ;; the two senders can't drift — the N-senders tax this repo keeps paying.
       :else
+      (if-let [blocked (ability-blocked card-name ability-index get-abilities)]
+        blocked
       (let [gameid (:gameid client-state)
             card-ref (core/create-card-ref card)
             ;; Capture state BEFORE sending (same race guard as use-ability!)
@@ -474,10 +686,15 @@
             :waiting-input
             (println (str "⏳ Runner ability triggered prompt: " card-name " - " (:label ability)))
 
+            ;; #116: same post-timeout re-diagnosis as use-ability!.
             :error
-            (println (str "❌ Runner ability failed: " card-name " - " (:reason result))))
+            nil)
           (flush)
-          result)))))
+          (if (= :error (:status result))
+            (or (rules-explanation-after-timeout card-name ability-index get-abilities)
+                (do (println (str "❌ Runner ability failed: " card-name " - " (:reason result)))
+                    result))
+            result)))))))
 
 (defn trash-installed!
   "Trash an installed card (Corp: ICE/asset/upgrade, Runner: rig card)

--- a/dev/test/ai_actions_test.clj
+++ b/dev/test/ai_actions_test.clj
@@ -326,8 +326,14 @@
    :subroutines [{:label "Install ice from HQ" :broken false}
                  {:label "End the run" :broken false}
                  {:label "End the run" :broken false}]
+   ;; :playable is what the wire actually carries (game.core.diffs/ability-keys)
+   ;; and it is TRUE here: this fixture is mid-encounter, where a bioroid's
+   ;; click-break is legal. The fixture omitted it, which was fine while nothing
+   ;; read it and wrong the moment #116's gate did — the same
+   ;; fixture-omits-the-field-that-matters trap as #31's missing :log.
    :runner-abilities [{:label "Lose [click]: Break 1 subroutine"
-                       :cost-label "Lose [click]"}]})
+                       :cost-label "Lose [click]"
+                       :playable true}]})
 
 (defn- encounter-state-vs-bran []
   (mock-client-state
@@ -548,3 +554,264 @@
   ;; Run from main
   (-main)
   )
+
+;; ============================================================================
+;; #116 — a phase-legality refusal must not be reported as a log timeout
+;; ============================================================================
+;; The Luna Runner seat ran `use-ability "Mayfly" 0` at the approach window and
+;; got `Ability not confirmed in game log (timeout).` That sentence describes a
+;; HARNESS fault — lost message, slow server, desync — and the correct response
+;; to it is a retry. The actual condition was a rules one, whose correct response
+;; is `continue` first. The seat guessed right; retrying an illegal ability at
+;; the wrong phase is the duplicate-send pattern that mints phantom prompts
+;; (#75/#77).
+;;
+;; The engine already publishes the verdict: game.core.diffs/ability-playable?
+;; assoc's :playable only when the ability is legal right now, and board.cljs
+;; renders an ability without it as [:li.disabled] — no click handler, so the
+;; human UI cannot send what we were sending. Pinned against the real engine in
+;; game.ai-ability-legality-test: at approach-ice a Corroder's break ability has
+;; NO :playable while its pump ability keeps it.
+
+(def ^:private corroder-at-approach
+  {:cid 90 :title "Corroder" :type "Program" :subtypes ["Icebreaker" "Fracter"]
+   :zone [:program]
+   :abilities [{:label "Break 1 Barrier subroutine" :cost-label "1 [Credits]"}
+               {:label "Add 1 strength" :cost-label "1 [Credits]" :playable true}]})
+
+(defn- approach-state
+  "Runner mid-run at the APPROACH window (not encountering), rig holding a
+   breaker whose printed break ability the engine has not marked playable."
+  []
+  (mock-client-state
+   :side "runner"
+   :game-state {:runner {:credit 5 :click 2
+                         :rig {:program [corroder-at-approach]
+                               :hardware [] :resource []}}
+                :corp {:servers {:hq {:ices [] :content []}}}
+                :run {:position 1 :server ["hq"] :phase "approach-ice"}
+                :active-player "runner"}))
+
+(deftest use-ability-refuses-unplayable-break-instead-of-blaming-the-log
+  (testing "#116: nothing is sent, so the illegal action can't mint a prompt"
+    (let [sent (atom [])]
+      (with-mock-state (approach-state)
+        (with-redefs [ws/send-message! (mock-websocket-send! sent)]
+          (let [result (ai-card-actions/use-ability! "Corroder" 0)]
+            (is (= :error (:status result)))
+            (is (zero? (count @sent))
+                "an ability the human UI renders as disabled must not go on the wire"))))))
+
+  (testing "#116: the message names the CAUSE, not the detection mechanism"
+    (let [out (with-out-str
+                (with-mock-state (approach-state)
+                  (with-redefs [ws/send-message! (fn [& _] nil)]
+                    (ai-card-actions/use-ability! "Corroder" 0))))]
+      (is (not (str/includes? out "timeout"))
+          (str "'timeout' invites the retry that mints phantom prompts; got:\n" out))
+      (is (not (str/includes? out "game log"))
+          (str "the log is how we noticed, not why it failed; got:\n" out))
+      (is (str/includes? out "approach-ice")
+          (str "name the phase the seat is actually at; got:\n" out))
+      (is (re-find #"(?i)encounter" out)
+          (str "and the rule: subroutines break during the encounter; got:\n" out))
+      (is (str/includes? out "continue")
+          (str "and the one command that fixes it; got:\n" out))))
+
+  (testing "#116: the SAME card's pump ability still sends — the gate is per-ability"
+    ;; A phase-level 'nothing works at approach' rule would block a legal action.
+    ;; The engine marks this one :playable at approach (pinned in the engine test).
+    (let [sent (atom [])]
+      (with-mock-state (approach-state)
+        (with-redefs [ws/send-message! (mock-websocket-send! sent)
+                      ai-core/verify-ability-in-log (fn [& _] {:status :success})]
+          (let [result (ai-card-actions/use-ability! "Corroder" 1)]
+            (is (= :success (:status result)))
+            (is (= 1 (count @sent))
+                "pumping outside an encounter is legal and must still be sent")))))))
+
+(deftest use-ability-out-of-range-index-names-what-exists
+  (testing "#116: reaching for the encounter-only 'Fully break' index at approach"
+    ;; The dynamic ability is absent from the list until the encounter, so the
+    ;; index is out of range — a different refusal from 'present but unplayable',
+    ;; and previously also reported as a log timeout.
+    (let [sent (atom [])
+          out (with-out-str
+                (with-mock-state (approach-state)
+                  (with-redefs [ws/send-message! (mock-websocket-send! sent)]
+                    (ai-card-actions/use-ability! "Corroder" 2))))]
+      (is (zero? (count @sent)))
+      (is (not (str/includes? out "timeout")) (str "got:\n" out))
+      (is (str/includes? out "Break 1 Barrier subroutine")
+          (str "list what the card actually offers; got:\n" out))
+      (is (str/includes? out "not usable right now")
+          (str "and mark which of those are currently blocked; got:\n" out)))))
+
+(deftest use-runner-ability-shares-the-legality-gate
+  (testing "#116: the bioroid sender refuses the same way — one rule, both senders"
+    ;; N-senders-one-command: #75/#77 (three send-continue! copies), #113, #115.
+    (let [sent (atom [])
+          bran-unplayable (assoc-in bran [:runner-abilities 0 :playable] false)
+          out (with-out-str
+                (with-mock-state
+                  (mock-client-state
+                   :side "runner"
+                   :game-state {:runner {:credit 5 :click 2
+                                         :rig {:program [] :hardware [] :resource []}}
+                                :corp {:servers {:rd {:ices [bran-unplayable] :content []}}}
+                                :run {:position 1 :server ["rd"] :phase "approach-ice"}
+                                :active-player "runner"})
+                  (with-redefs [ws/send-message! (mock-websocket-send! sent)]
+                    (ai-card-actions/use-runner-ability! "Brân 1.0" 0))))]
+      (is (zero? (count @sent))
+          "the click-break is as encounter-bound as a breaker's")
+      (is (not (str/includes? out "timeout")) (str "got:\n" out))
+      (is (str/includes? out "continue")
+          (str "same recovery, same wording; got:\n" out))
+      (is (= 1 (count (re-seq #"NOT sent" out)))
+          (str "the diagnosis prints ONCE, not once per cond probe; got:\n" out)))))
+
+;; ---------------------------------------------------------------------------
+;; #116, guest-panel round: the four ways the first cut was wrong
+;; ---------------------------------------------------------------------------
+
+(defn- run-state-at [phase]
+  (mock-client-state
+   :side "runner"
+   :game-state {:runner {:credit 5 :click 2
+                         :rig {:program [corroder-at-approach]
+                               :hardware [] :resource []}}
+                :corp {:servers {:hq {:ices [] :content []}}}
+                :run {:position 1 :server ["hq"] :phase phase}
+                :active-player "runner"}))
+
+(deftest use-ability-only-promises-the-encounter-when-it-is-actually-ahead
+  ;; MAJOR: the first cut printed "you have not reached the ICE yet → continue to
+  ;; enter the encounter" at EVERY non-encounter phase. The engine's run ladder is
+  ;; approach-ice / encounter-ice / movement / pass-ice / success; at movement or
+  ;; success the ICE is behind the Runner, so `continue` moves them further from
+  ;; any recovery. Guidance text that asserts engine behaviour is code (#115).
+  (testing "#116: at approach-ice the encounter IS ahead — promise it"
+    (let [out (with-out-str
+                (with-mock-state (run-state-at "approach-ice")
+                  (with-redefs [ws/send-message! (fn [& _] nil)]
+                    (ai-card-actions/use-ability! "Corroder" 0))))]
+      (is (str/includes? out "have not reached the ICE yet") (str "got:\n" out))
+      (is (str/includes? out "continue") (str "got:\n" out))))
+
+  (doseq [phase ["movement" "pass-ice" "success"]]
+    (testing (str "#116: at " phase " the ICE is behind us — do NOT say continue")
+      (let [out (with-out-str
+                  (with-mock-state (run-state-at phase)
+                    (with-redefs [ws/send-message! (fn [& _] nil)]
+                      (ai-card-actions/use-ability! "Corroder" 0))))]
+        (is (not (str/includes? out "have not reached the ICE yet"))
+            (str "false at " phase "; got:\n" out))
+        (is (not (str/includes? out "Use 'continue' to enter the encounter"))
+            (str "continuing cannot make this legal at " phase "; got:\n" out))
+        (is (re-find #"(?i)encounter" out)
+            (str "the rule itself still holds and must be stated; got:\n" out))))))
+
+(deftest use-ability-generic-hint-names-real-commands
+  ;; MINOR, but the exact class this project keeps re-learning: the first cut
+  ;; pointed the seat at `show-card`, which `send_command` does not have. An
+  ;; invented command name reads as authoritative and costs a wasted round trip.
+  (testing "#116: a non-break unplayable ability points at commands that exist"
+    (let [pump-unplayable (assoc-in corroder-at-approach [:abilities 1 :playable] false)
+          out (with-out-str
+                (with-mock-state
+                  (mock-client-state
+                   :side "runner"
+                   :game-state {:runner {:credit 5 :click 2
+                                         :rig {:program [pump-unplayable]
+                                               :hardware [] :resource []}}
+                                :active-player "runner"})
+                  (with-redefs [ws/send-message! (fn [& _] nil)]
+                    (ai-card-actions/use-ability! "Corroder" 1))))]
+      (is (not (str/includes? out "show-card"))
+          (str "no such command; got:\n" out))
+      (is (str/includes? out "abilities")
+          (str "point at the indexed menu; got:\n" out))
+      (is (str/includes? out "card-text")
+          (str "and the real card-lookup command; got:\n" out)))))
+
+(deftest use-ability-lets-an-in-flight-diff-settle-before-refusing
+  ;; CRITICAL: :playable is a CACHED negative. `continue` then `use-ability` can
+  ;; read the pre-encounter snapshot and hard-refuse an action that is about to
+  ;; be legal. board.cljs disables its button off the same cached field, but a
+  ;; human re-reads a greyed button where a seat treats an error as final.
+  (testing "#116: an ability that becomes playable mid-wait is SENT, not refused"
+    (let [sent (atom [])
+          reads (atom 0)
+          ;; The diff lands on the THIRD read. Read 1 is use-ability!'s own card
+          ;; lookup and read 2 is settle's first poll, so the ability only turns
+          ;; playable after settle has had to sleep at least once — otherwise
+          ;; this test passes with a 0ms window and pins nothing. (It did: the
+          ;; first version put the flip at read 2 and survived that mutation.)
+          card-now (fn [_]
+                     (if (< (swap! reads inc) 3)
+                       corroder-at-approach
+                       (assoc-in corroder-at-approach [:abilities 0 :playable] true)))]
+      (with-mock-state (run-state-at "approach-ice")
+        (with-redefs [ws/send-message! (mock-websocket-send! sent)
+                      ai-core/find-installed-card card-now
+                      ai-core/verify-ability-in-log (fn [& _] {:status :success})]
+          (let [result (ai-card-actions/use-ability! "Corroder" 0)]
+            (is (= :success (:status result))
+                "the settle window must not turn a race into a hard refusal")
+            (is (= 1 (count @sent))))))))
+
+  (testing "#116: a genuinely illegal ability still refuses after the wait"
+    (let [sent (atom [])]
+      (with-mock-state (run-state-at "approach-ice")
+        (with-redefs [ws/send-message! (mock-websocket-send! sent)]
+          (let [result (ai-card-actions/use-ability! "Corroder" 0)]
+            (is (= :error (:status result)))
+            (is (zero? (count @sent))
+                "the flag never appears, so we pay the wait and then refuse")))))))
+
+(deftest use-ability-timeout-is-re-explained-from-current-state
+  ;; MAJOR / the issue's literal ask: "before falling through to the timeout
+  ;; path, check whether the ability is legal in the current run phase." The
+  ;; pre-send gate cannot catch the reverse race — a STALE POSITIVE, where the
+  ;; ability still reads :playable, we send, the engine refuses, and the diff
+  ;; explaining why lands while we are polling the log.
+  (testing "#116: a timeout whose cause is visible in current state is re-worded"
+    (let [reads (atom 0)
+          ;; Playable for reads 1-2 (use-ability!'s card lookup, then settle's
+          ;; single poll — settle returns at once when the flag is there) so the
+          ;; pre-send gate PASSES and we actually send. The diff that explains
+          ;; the refusal lands by read 3, which is the post-timeout re-read.
+          ;; Flipping at read 2 instead makes the pre-send gate fire and the
+          ;; assertions below pass without ever reaching the code under test.
+          card-now (fn [_]
+                     (if (< (swap! reads inc) 3)
+                       (assoc-in corroder-at-approach [:abilities 0 :playable] true)
+                       corroder-at-approach))
+          out (with-out-str
+                (with-mock-state (run-state-at "approach-ice")
+                  (with-redefs [ws/send-message! (fn [& _] nil)
+                                ai-core/find-installed-card card-now
+                                ai-core/verify-ability-in-log
+                                (fn [& _] {:status :error
+                                           :reason "Ability not confirmed in game log (timeout)."})]
+                    (ai-card-actions/use-ability! "Corroder" 0))))]
+      (is (not (str/includes? out "timeout"))
+          (str "current state explains it as a rules failure; got:\n" out))
+      (is (re-find #"(?i)encounter" out)
+          (str "and says which rule; got:\n" out))))
+
+  (testing "#116: a timeout with no rules explanation still reports as a timeout"
+    ;; A real harness fault must keep its own wording — this is the branch that
+    ;; stops the re-diagnosis from swallowing genuine desyncs.
+    (let [playable-card (assoc-in corroder-at-approach [:abilities 0 :playable] true)
+          out (with-out-str
+                (with-mock-state (run-state-at "encounter-ice")
+                  (with-redefs [ws/send-message! (fn [& _] nil)
+                                ai-core/find-installed-card (fn [_] playable-card)
+                                ai-core/verify-ability-in-log
+                                (fn [& _] {:status :error
+                                           :reason "Ability not confirmed in game log (timeout)."})]
+                    (ai-card-actions/use-ability! "Corroder" 0))))]
+      (is (str/includes? out "timeout")
+          (str "nothing in state contradicts the send; got:\n" out)))))

--- a/test/clj/game/ai_ability_legality_test.clj
+++ b/test/clj/game/ai_ability_legality_test.clj
@@ -1,0 +1,86 @@
+(ns game.ai-ability-legality-test
+  "Issue #116: `use-ability` at the approach window reported
+   `Ability not confirmed in game log (timeout)` for what is a rules/timing
+   condition. That sentence describes a HARNESS fault and invites a retry;
+   retrying an illegal ability is the duplicate-send pattern that mints phantom
+   prompts (#75/#77).
+
+   The client fix refuses to send when the engine has already marked the ability
+   unplayable. This namespace pins the ENGINE facts that gate depends on, so the
+   unit fixtures in ai-actions-test can't drift away from the wire:
+
+   1. The per-ability `:playable` flag really is absent at `approach-ice` for a
+      break ability and present at `encounter-ice`.
+   2. It is PER-ABILITY, not per-phase: the same breaker's pump ability keeps
+      `:playable` at approach. A blanket 'nothing works before the encounter'
+      gate would wrongly block it.
+   3. The synthesised `:auto-pump-and-break` ability does not exist in the list
+      at all until the encounter — so its index is out of range at approach,
+      which is a different refusal than 'present but unplayable'."
+  (:require [game.core :as core]
+            [game.core.diffs :as diffs]
+            [game.test-framework :refer :all]
+            [cheshire.core :as json]
+            [clojure.test :refer :all]))
+
+(defn- breaker-abilities
+  "Corroder's abilities as the seat receives them: privatized, then round-tripped
+   through the transport's JSON encoding. public-states alone stops short of the
+   boundary that matters (the #114 lesson — a keyword server-side can arrive as a
+   string), and `:playable` is exactly the kind of flag a summary change could
+   silently drop."
+  [state]
+  (->> (get-in (diffs/public-states state) [:runner-state :runner :rig :program])
+       (filter #(= "Corroder" (:title %)))
+       first
+       :abilities
+       (#(json/parse-string (json/generate-string %) true))))
+
+(defn- by-label [abilities re]
+  (first (filter #(re-find re (str (:label %))) abilities)))
+
+(deftest breaker-ability-playability-is-per-ability-and-per-phase
+  (do-game
+    (new-game {:corp {:hand ["Ice Wall"]}
+               :runner {:hand ["Corroder"] :credits 10}})
+    (play-from-hand state :corp "Ice Wall" "HQ")
+    (take-credits state :corp)
+    (play-from-hand state :runner "Corroder")
+    (run-on state "HQ")
+    (rez state :corp (get-ice state :hq 0))
+
+    (testing "#116 at approach-ice: the break ability is NOT playable"
+      (is (= :approach-ice (:phase (:run @state)))
+          "precondition: we are at the approach window, not encountering")
+      (is (empty? (:encounters @state))
+          "precondition: no encounter has begun")
+      (let [abs (breaker-abilities state)
+            break-ab (by-label abs #"(?i)break.*subroutine")]
+        (is (some? break-ab) "the printed break ability is still listed")
+        (is (not (:playable break-ab))
+            (str "the engine refuses it here — this is what the client must read "
+                 "instead of blaming a log timeout; got: " (pr-str break-ab)))))
+
+    (testing "#116: the SAME breaker's pump ability IS playable at approach"
+      ;; The gate must be per-ability. A phase-level 'nothing works at approach'
+      ;; rule would block a legal action.
+      (let [pump-ab (by-label (breaker-abilities state) #"(?i)strength")]
+        (is (some? pump-ab) "the pump ability is listed")
+        (is (true? (:playable pump-ab))
+            (str "pumping outside an encounter is legal; got: " (pr-str pump-ab)))))
+
+    (testing "#116: the dynamic full-break ability does not exist yet at approach"
+      ;; So a seat reaching for it by index gets an out-of-range refusal, not an
+      ;; 'unplayable' one — the client distinguishes the two.
+      (is (nil? (by-label (breaker-abilities state) #"(?i)fully break"))
+          "the engine synthesises it only during an encounter"))
+
+    (run-continue state)
+
+    (testing "#116 at encounter-ice: the break ability becomes playable"
+      (is (= :encounter-ice (:phase (:run @state))))
+      (let [abs (breaker-abilities state)]
+        (is (true? (:playable (by-label abs #"(?i)break.*subroutine")))
+            "the recovery the client now names ('continue', then retry) works")
+        (is (some? (by-label abs #"(?i)fully break"))
+            "and the dynamic full-break ability now exists")))))


### PR DESCRIPTION
> **⚠️ Draft, and deliberately not mergeable as-is.** Another session is working #116
> right now in the `netrunner-116` worktree (branch `ai-player/polish-116`, uncommitted
> as of writing). I found it only after finishing — I checked open issues and PRs but not
> local worktrees. Both implementations are good and they **disagree on one real design
> question**. Do not merge this over theirs; the recommendation below is a synthesis.
>
> Stacked on `ai-player/polish-117` (PR #121), which must land first.

## The bug

`use-ability` sent unconditionally and inferred failure from the absence of a log entry:
`Ability not confirmed in game log (timeout)`. That names a **harness** fault and invites
a retry. The Luna seat hit it breaking at approach-ice, where the cause is a **rules** one
and the response is `continue` first. Retrying an illegal ability is the duplicate-send
pattern that mints phantom prompts (#75/#77).

Both sessions independently found the same key fact: the engine already publishes the
verdict per ability. `game.core.diffs/ability-playable?` runs `can-pay?` + `can-trigger?`
and assoc's `:playable` only when legal *right now*; `board.cljs` renders an ability
lacking it as `[:li.disabled label]` with no click handler, so the human UI physically
cannot send what we were sending.

Pinned against the real engine (new `game.ai-ability-legality-test`, Corroder vs Ice Wall,
round-tripped through the transport's JSON encoding):

```
=== approach-ice   encounters: 0
   0 {:label "Break 1 Barrier subroutine"}                        <- no :playable
   1 {:label "Add 1 strength",     :playable true}
=== encounter-ice  encounters: 1
   0 {:label "Break 1 Barrier subroutine", :playable true}
   1 {:label "Add 1 strength",             :playable true}
   2 {:label "Fully break Ice Wall", :dynamic :auto-pump-and-break, :playable true}
```

The gate is therefore **per-ability**. The issue's suggested phase check, taken literally,
would have blocked the pump — which is legal at approach.

## The disagreement worth adjudicating

**Do we refuse the send, or send and explain better?**

- **Theirs:** refuse *only* on the engine invariant (`break-sub`'s `:break-req` needs a
  live encounter, so a break outside one is impossible in every world). For
  `:playable`-absent generally, do **not** refuse — a snapshot can be stale-false, and
  mis-refusing costs a seat a legal action.
- **Mine:** refuse on `:playable`, with a bounded 600ms settle window that re-reads live
  state first so an unapplied diff can't cause a false refusal.

Their written rationale anticipates, verbatim, the CRITICAL my guest panel raised against
mine. I think **their instinct is the better default** and my settle window is the better
mitigation. Synthesis: hard-refuse on the invariant (theirs), settle-then-refuse on the
snapshot (mine), which keeps the #75/#77 protection without betting on a cached negative.

## What each side has that the other doesn't

| | theirs | mine |
|---|---|---|
| `break-ability?` conservatism | `starts-with "break "` + explicit false-pos/neg cost analysis — **better** | `includes` regex, looser |
| Non-encounter phase wording | says "→ continue to enter the encounter" at **every** non-encounter phase | only at `approach-ice`; at movement/pass-ice/success the ICE is behind the Runner and `continue` moves them away from any recovery |
| Refusal policy | invariant-only (see above) | `:playable` + settle window |
| Out-of-range index | — | refused by name, lists what the card offers (the dynamic full-break index is out of range at approach — the literal Mayfly repro) |
| Engine-backed test | "verified live" | `game.ai-ability-legality-test`, registered in the Makefile ns list |
| Real command names in hints | n/a | `abilities` / `card-text` (my first cut invented `show-card`, which doesn't exist) |

**Recommendation:** take their `break-ability?` and their invariant-refusal split; take my
phase specificity, out-of-range branch, engine test, and settle window. I have not touched
their worktree.

## Guest panel (GPT-5.6, read-only)

Four findings, all confirmed, all fixed here: the CRITICAL cached-negative race; the
MAJOR that the issue's literal ask (re-check before the timeout path) was unimplemented —
the reverse race, a stale *positive*, now re-diagnoses from current state while a genuine
harness fault keeps its timeout wording; the MAJOR phase-wording bug; and the MINOR
invented command name.

## Tests

**689 / 1944 / 0 failures** (685 before this commit, 678 at branch start).

The mutation pass earned its keep: **two of the three new guest-fix tests were vacuous.**
`use-ability!`'s own card lookup consumed the read the fixture had meant for the settle
poll, and in the other the pre-send gate fired before the post-timeout path could run — so
both passed with their fix removed. Fixtures corrected; all three now go red on revert.

One existing fixture (`bran`) omitted `:playable`. It models a mid-encounter state where
the click-break *is* legal, so it was unfaithful to the wire; corrected rather than
worked around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)