### PR TITLE
fix(#120): wake the seat that owes the end-turn

### DIFF
--- a/dev/src/clj/ai_core.clj
+++ b/dev/src/clj/ai_core.clj
@@ -700,11 +700,14 @@
 
    Note: This does a simple counter check (counters >= requirement).
    It does NOT detect effects like 'cannot score this turn' or similar restrictions.
-   Therefore, use conservatively - if this returns agendas, assume they MIGHT be scorable."
-  []
-  (let [side (:side @state/client-state)]
+   Therefore, use conservatively - if this returns agendas, assume they MIGHT be scorable.
+
+   The 1-arg form answers about a client-state you already hold (see corp-servers)."
+  ([] (find-scorable-agendas @state/client-state))
+  ([client-state]
+   (let [side (:side client-state)]
     (if (side= "Corp" side)
-      (let [servers (state/corp-servers)
+      (let [servers (state/corp-servers client-state)
             ;; Get all content (assets/upgrades/agendas) from all servers
             all-content (mapcat :content (vals servers))
             ;; Filter for agendas only
@@ -723,7 +726,7 @@
                 :requirement (:advancementcost agenda)})
             scorable))
       ;; Not Corp, return empty
-      [])))
+      []))))
 
 (defn find-eot-rezzable-cards
   "Installed Corp assets/upgrades that are still unrezzed and affordable RIGHT NOW.
@@ -753,12 +756,15 @@
 
    Known residual, same direction: rez-cost REDUCERS are not modelled, so a card
    made cheaper by an effect can still be missed. Costs a beat, never a wrong
-   action — worth revisiting if a seat reports it."
-  []
-  (let [side (:side @state/client-state)]
+   action — worth revisiting if a seat reports it.
+
+   The 1-arg form answers about a client-state you already hold (see corp-servers)."
+  ([] (find-eot-rezzable-cards @state/client-state))
+  ([client-state]
+   (let [side (:side client-state)]
     (if (side= "Corp" side)
-      (let [pool (or (get-in @state/client-state [:game-state :corp :credit]) 0)
-            servers (vals (state/corp-servers))
+      (let [pool (or (get-in client-state [:game-state :corp :credit]) 0)
+            servers (vals (state/corp-servers client-state))
             ;; Both content and ice can carry recurring credits.
             all-cards (mapcat #(concat (:content %) (:ices %)) servers)
             recurring (->> all-cards
@@ -775,7 +781,7 @@
                     {:card card
                      :title (:title card)
                      :cost (:cost card)}))))
-      [])))
+      []))))
 
 ;; ============================================================================
 ;; Install Validation (Baby-proofing)
@@ -1761,6 +1767,10 @@
      :my-turn-start      — it's our turn at a boundary; we must call start-turn
                            before acting (we hold 0 clicks until we do)
      :my-turn            — it's our turn and we have clicks; act now
+     :my-turn-end        — our turn is out of clicks but has NOT ended (#120):
+                           nobody owes a start-turn, my-turn-to-act? is false for
+                           BOTH sides, and `end-turn` is the only move. Fires for
+                           the turn's OWNER only
      :my-run-window      — we own the un-passed pass at an active run window
                            (approach-ice / movement / approach-server). #91: a
                            seat that had passed a PREVIOUS window otherwise sleeps
@@ -1856,8 +1866,89 @@
        (my-turn-to-act? state side)
        (if (turn-awaiting-start? state side) :my-turn-start :my-turn)
 
+       ;; My turn is out of clicks but has NOT ended (#120). my-turn-to-act? is
+       ;; false for BOTH sides here — its active-player arm needs clicks, and its
+       ;; other two arms need :end-turn or turn 0 — so this cond used to fall
+       ;; through to nil on every seat and both `wait` calls slept the full 300s.
+       ;; A mutual deadlock, and the side that could break it (the one owed the
+       ;; end-turn) was the one being told it had no move.
+       ;;
+       ;; This is an END-TURN OBLIGATION, not a click count. Waking on
+       ;; 'both players at 0 clicks' is the bug my-turn-to-act?'s docstring
+       ;; explicitly refuses to reintroduce — that shape fires on every run
+       ;; started with the last click. my-turn-orphaned? is the narrower fact
+       ;; (#117): active player, 0 clicks, :end-turn false, no run, no prompt of
+       ;; ours, and none of the engine's other zero-click pauses (phase 1.2,
+       ;; post-discard priority — both resolved by a PHASE command, not end-turn).
+       ;;
+       ;; Ranked LAST on purpose, and NOT because the earlier branches are
+       ;; mutually exclusive with it — my first version of this comment claimed
+       ;; that and the guest panel falsified it. The STATE branches (run, prompt,
+       ;; game-over) are excluded by the predicate, but :run-ended and
+       ;; :game-over/:game-gone are TRANSITIONS: a run that ends on the last click
+       ;; leaves us orphaned AND reports :run-ended, which outranks this. That is
+       ;; the right precedence — the transition is the news — so the obligation is
+       ;; carried in :run-ended's guidance instead of by reordering the ladder
+       ;; (see end-turn-obligation-lines). Reordering would suppress the run-end
+       ;; report, which is a worse trade.
+       ;;
+       ;; Called with the side we were HANDED, and side-relative in the
+       ;; predicate: an end-turn from the seat whose turn it isn't ends the
+       ;; OPPONENT's turn and is unrecoverable. The opponent stays asleep here
+       ;; and wakes on :my-turn-start once the flag latches.
+       (state/my-turn-orphaned? state side)
+       :my-turn-end
+
        ;; Nothing relevant
        :else nil))))
+
+(defn- end-turn-obligation-lines
+  "The seat owns a turn that is out of clicks but has NOT ended (#120). Emitted
+   from TWO wake reasons — :my-turn-end, and :run-ended when the run that just
+   ended was the last thing standing — so it is a function, not two literals.
+
+   'Out of clicks' is NOT 'out of moves', and this is where a wake reason can lose
+   a game in one line. `check-auto-end-turn!` refuses to auto-end at 0 clicks for
+   TWO reasons, and both are still live in exactly this state:
+     - a scorable agenda — scoring costs no click (guest panel, second pass; the
+       first version of this function checked only the rez window)
+     - the end-of-turn paid window (#103 — marquee ac71ce63 lost a Nico Campaign
+       rez to an auto-end)
+   Either one is named BEFORE the end-turn steer, and end-turn is described as
+   what to do after. A wake that answers this state with a flat 'send end-turn'
+   contradicts the auto-end surface, and the seat that believes the newer surface
+   pays for it. Two surfaces, one answer: call the SAME detectors rather than
+   deciding again here.
+
+   Both detectors are handed `state` rather than re-reading the atom. The wait
+   loop classifies a snapshot and formats guidance from it later; a diff landing
+   in that gap would otherwise staple a card list from a newer board onto a
+   description of the older one (guest panel). Both are Corp-only by construction,
+   so a Runner never sees either list."
+  [state]
+  (let [scorables (find-scorable-agendas state)
+        rezzables (find-eot-rezzable-cards state)
+        closing ["      The opponent cannot move until you do, and another `wait`"
+                 "      returns here unchanged — an empty game log is expected:"
+                 "      they are already waiting on you."]]
+    (if (or (seq scorables) (seq rezzables))
+      (-> ["   👉 Your turn is out of clicks but has NOT ended — and 0 clicks does NOT"
+           "      mean 0 moves. Still available to you right now:"]
+          (into (map (fn [{:keys [title counters requirement]}]
+                       (format "        🎯 %s (%d/%d advancement) — can still be SCORED"
+                               title counters requirement))
+                     scorables))
+          (into (map (fn [{:keys [title cost]}]
+                       (format "        💰 %s can still be rezzed for %d¢" title cost))
+                     rezzables))
+          ;; Mirrors check-auto-end-turn!'s own hedge. The rez detector errs
+          ;; generous on purpose (it counts restricted recurring credits), so an
+          ;; entry here is an opportunity to CHECK, never an instruction to obey.
+          (conj "      Do those first if you want them, then `end-turn` — nothing to do? just `end-turn`.")
+          (into closing))
+      (into ["   👉 Your turn is out of clicks but has NOT ended — send `end-turn`."
+             "      Nobody owes a start-turn."]
+            closing))))
 
 (defn wake-reason-guidance-lines
   "Lines that decode a wake `reason` into the action it demands, printed under the
@@ -1895,6 +1986,24 @@
      "      Another `wait` cannot advance it, and an empty game log here means the"
      "      opponent is already waiting on you."]
 
+    ;; #120. The seat is the ACTIVE player with 0 clicks and no :end-turn — the
+    ;; state where every OTHER surface used to say "waiting". Nothing is going to
+    ;; arrive: the opponent is blocked behind this turn ending, so a seat that
+    ;; re-blocks here re-creates the deadlock the wake exists to break.
+    :my-turn-end
+    (end-turn-obligation-lines state)
+
+    ;; A run ENDING is normally self-describing, so this stayed silent. But
+    ;; :run-ended is a TRANSITION and outranks :my-turn-end in the cond, so a run
+    ;; that ends on the last click wakes here while the seat now owes the
+    ;; end-turn — and got a bare token for it (guest panel, #120; the same
+    ;; undecoded-reason trap as #115, where two seats read a token they couldn't
+    ;; decode as nothing-happened and re-blocked). The obligation is a fact about
+    ;; the CURRENT state, so ask about the current state rather than assuming the
+    ;; transition is the whole story.
+    :run-ended
+    (if (state/my-turn-orphaned? state) (end-turn-obligation-lines state) [])
+
     :encounter-decision
     ;; NOT jack-out: it is movement-window only, so at an encounter it is both
     ;; illegal and a subroutine-skip. `jack-out` refuses here with the same steer.
@@ -1920,6 +2029,8 @@
      - a run that was in progress ends (:run-ended)
      - it becomes our turn at a boundary, start-turn needed (:my-turn-start)
      - it becomes our turn to act with clicks in hand (:my-turn)
+     - our own turn is out of clicks but has not ended, so we owe the
+       end-turn (:my-turn-end, #120)
      - we acquire priority at a run pass-window we own (:my-run-window)
      - the opponent sends a 'ping' chat message (:ping wake — escape hatch
        for when an external observer wants to nudge us)

--- a/dev/src/clj/ai_state.clj
+++ b/dev/src/clj/ai_state.clj
@@ -420,13 +420,23 @@
    Requires no open prompt of ours. With an actionable prompt the honest answer
    is 'resolve your prompt', and with a waiting prompt it is 'you are blocked on
    the opponent'; both are reported by their own branches, and both are states
-   the player can still act out of."
-  [client-state]
-  (let [gs (:game-state client-state)
+   the player can still act out of.
+
+   Two arities, same rule. The 1-arg form asks about the seat's own
+   `(:side client-state)` — what every display surface wants. The 2-arg form
+   takes the side explicitly, for callers that are already handed one:
+   `relevance-reason` (#120) threads a `side` argument through the whole wake
+   ladder, and having this predicate quietly answer about a DIFFERENT side than
+   its caller asked about is precisely the divergence that makes a side-relative
+   safety property worthless."
+  ([client-state]
+   (my-turn-orphaned? client-state (:side client-state)))
+  ([client-state side]
+   (let [gs (:game-state client-state)
         active (:active-player gs)
-        ;; :side arrives as \"corp\"/\"Corp\" depending on the path that set it;
+        ;; side arrives as \"corp\"/\"Corp\" depending on the path that set it;
         ;; game-state keys are always lowercase (see my-side-kw).
-        my-side (some-> (:side client-state) clojure.string/lower-case)]
+        my-side (some-> side name clojure.string/lower-case)]
     (boolean (and gs
                   active
                   my-side
@@ -470,7 +480,7 @@
                   (not (:runner-post-discard gs))
                   (not (game-over? gs))
                   (zero? (get-in gs [(keyword active) :click] 0))
-                  (nil? (get-in gs [(keyword my-side) :prompt-state]))))))
+                  (nil? (get-in gs [(keyword my-side) :prompt-state])))))))
 
 (defn get-prompt
   "Get current prompt for our side, if any"
@@ -702,13 +712,19 @@
 
 (defn corp-servers
   "Returns corp's servers map. Returns {} if unavailable.
-   Structure: {:hq {...} :rd {...} :archives {...} :remote1 {...} ...}"
-  []
-  (let [servers (get-in @client-state [:game-state :corp :servers])]
-    (cond
-      (nil? servers) {}
-      (map? servers) servers
-      :else (do (warn-unexpected "corp-servers" "map" servers) {}))))
+   Structure: {:hq {...} :rd {...} :archives {...} :remote1 {...} ...}
+
+   The 1-arg form reads a client-state map you already hold. Callers that
+   classified a SNAPSHOT and then describe it must use that form: re-dereferencing
+   the atom mid-render lets a websocket diff swap the board out from under a
+   description of the old one (#120 guest panel)."
+  ([] (corp-servers @client-state))
+  ([client-state]
+   (let [servers (get-in client-state [:game-state :corp :servers])]
+     (cond
+       (nil? servers) {}
+       (map? servers) servers
+       :else (do (warn-unexpected "corp-servers" "map" servers) {})))))
 
 (defn server-cards
   "Returns cards installed in a server (content). Returns [] if unavailable.

--- a/dev/test/ai_wait_test.clj
+++ b/dev/test/ai_wait_test.clj
@@ -559,3 +559,210 @@
         "a run starting needs no decoding")
     (is (empty? (core/wake-reason-guidance-lines :has-prompt {}))
         "a prompt is self-describing — the prompt itself is the guidance")))
+
+;; ---------------------------------------------------------------------------
+;; #120: the orphaned turn is a MUTUAL deadlock in the wake ladder.
+;;
+;; State (verified live, game d840fc14): the active player is out of clicks but
+;; has NOT latched :end-turn — their last click handed the opponent a decision,
+;; auto-end-turn declined, and by the time the opponent resolved it nothing was
+;; blocking any more.
+;;
+;;   active-player=corp, end-turn=false, turn=10, corp clicks=0, runner clicks=0
+;;
+;; my-turn-to-act? needs clicks>0 on its active-player arm, and its other two
+;; arms need :end-turn or turn 0 — so it is false for BOTH seats and
+;; relevance-reason returned nil for both. Neither `wait` could ever wake: the
+;; Corp, whose only legal move is `end-turn`, was told it had no move.
+;;
+;; #117 fixed the DISPLAY half (status/prompt name the right side). This is the
+;; wake half. The classification is not re-derived here — my-turn-orphaned? in
+;; ai-state is the authority, and it is side-relative on purpose: an end-turn
+;; sent by the player whose turn it isn't ends the OPPONENT's turn and is
+;; unrecoverable.
+;; ---------------------------------------------------------------------------
+
+(def ^:private orphaned-turn-game-state
+  "Corp's turn, 0 clicks, :end-turn NOT set, no run, no prompt on either seat."
+  {:active-player "corp" :turn 10 :end-turn false
+   :corp {:click 0} :runner {:click 0}})
+
+(deftest test-wait-orphaned-turn-wakes-the-active-seat
+  (testing "#120: the seat that OWES the end-turn wakes with :my-turn-end
+            instead of sleeping the full timeout on its own move"
+    (with-redefs [state/get-cursor (fn [] 10)]
+      (with-mock-state (mock-game "corp" orphaned-turn-game-state)
+        (let [result (core/wait-for-relevant-diff {:timeout 0 :verbose false})]
+          (is (= :relevant-change (:status result))
+              (str "an orphaned turn must wake its owner, not time out, got: " result))
+          (is (= :my-turn-end (:reason result))
+              (str "expected :my-turn-end, got: " result)))))))
+
+(deftest test-wait-orphaned-turn-does-not-wake-the-opponent
+  (testing "#120 safety: the seat whose turn it ISN'T must stay asleep — an
+            end-turn from the Runner here ends the CORP's turn, unrecoverably"
+    (with-redefs [state/get-cursor (fn [] 10)]
+      (with-mock-state (mock-game "runner" orphaned-turn-game-state)
+        (let [result (core/wait-for-relevant-diff {:timeout 0 :verbose false})]
+          (is (= :timeout (:status result))
+              (str "the non-active seat owes nothing here, got: " result))
+          (is (not= :my-turn-end (:reason result))
+              (str "never hand the opponent an end-turn hint, got: " result)))))))
+
+(deftest test-wait-orphaned-turn-deadlock-actually-breaks
+  (testing "#120 end-to-end: once the owner ends the turn, :end-turn latches and
+            the OPPONENT wakes — the two halves compose into a live boundary"
+    (with-redefs [state/get-cursor (fn [] 10)]
+      (with-mock-state (mock-game "runner" (assoc orphaned-turn-game-state :end-turn true))
+        (let [result (core/wait-for-relevant-diff {:timeout 0 :verbose false})]
+          (is (= :my-turn-start (:reason result))
+              (str "after the end-turn the Runner is owed a start-turn, got: " result)))))
+    (with-redefs [state/get-cursor (fn [] 10)]
+      (with-mock-state (mock-game "corp" (assoc orphaned-turn-game-state :end-turn true))
+        (let [result (core/wait-for-relevant-diff {:timeout 0 :verbose false})]
+          (is (not= :my-turn-end (:reason result))
+              (str "a turn that HAS ended is not orphaned — no second end-turn, got: " result)))))))
+
+(deftest test-wait-last-click-run-does-not-report-my-turn-end
+  (testing "#120 regression, the one my-turn-to-act?'s docstring guards: a run
+            started with the last click is ALSO both-sides-at-0-clicks with
+            :end-turn false. `continue` is the move there, never `end-turn`"
+    (with-redefs [state/get-cursor (fn [] 10)]
+      (with-mock-state (mock-game "runner"
+                          (-> approach-server-game-state
+                              (assoc :end-turn false)
+                              (assoc-in [:run :no-action] "runner")))
+        (let [result (core/wait-for-relevant-diff {:timeout 0 :verbose false})]
+          (is (= :timeout (:status result))
+              (str "a passed Runner mid-run must still sleep, got: " result))
+          (is (not= :my-turn-end (:reason result))
+              (str "ending a turn with a run live is not the move, got: " result)))))))
+
+(deftest test-wait-zero-click-phase-windows-do-not-report-my-turn-end
+  (testing "#120: the engine's OTHER zero-click pauses (phase 1.2 and the
+            post-discard priority window) share this exact shape, and in both the
+            resolving action is a PHASE command, not end-turn"
+    (doseq [k [:corp-phase-12 :runner-phase-12 :corp-post-discard :runner-post-discard]]
+      (with-redefs [state/get-cursor (fn [] 10)]
+        (with-mock-state (mock-game "corp" (assoc orphaned-turn-game-state k true))
+          (let [result (core/wait-for-relevant-diff {:timeout 0 :verbose false})]
+            (is (not= :my-turn-end (:reason result))
+                (str "steering a seat to end-turn at " k
+                     " skips a window the opponent is entitled to, got: " result))))))))
+
+(deftest test-my-turn-end-wake-names-the-command-that-clears-it
+  (testing "#120: `wait` returning a bare :my-turn-end token is the #115 trap —
+            two Luna seats read an undecoded reason as nothing-happened and
+            re-blocked. The wake must name end-turn"
+    (let [lines (core/wake-reason-guidance-lines :my-turn-end {})]
+      (is (seq lines) "an orphaned turn is exactly the reason that needs decoding")
+      (is (re-find #"end-turn" (str/join " " lines))
+          (str "the guidance must name the command that clears it, got: " lines)))))
+
+;; --- #120 review panel (off-vendor guest, GPT-5.6): three confirmed findings ---
+;;
+;; The wake itself was right; what the guest killed was my claim that
+;; my-turn-orphaned? is mutually exclusive with every earlier branch, and my
+;; assumption that "0 clicks, turn not ended" always means "just end it".
+
+(deftest test-my-turn-end-does-not-fire-under-our-own-blocking-prompt
+  (testing "#120, the issue's own exclusion list: '...must exclude at minimum: an
+            active run, and a genuinely blocking prompt of our own.' With a prompt
+            up the honest answer is 'resolve your prompt', and it wakes as
+            :has-prompt — never as an end-turn obligation"
+    (with-redefs [state/get-cursor (fn [] 10)]
+      (with-mock-state (mock-game "corp"
+                          (assoc-in orphaned-turn-game-state [:corp :prompt-state]
+                                    {:prompt-type "select" :msg "Choose a card to trash"
+                                     :choices [{:value "a"}]}))
+        (let [result (core/wait-for-relevant-diff {:timeout 0 :verbose false})]
+          (is (= :has-prompt (:reason result))
+              (str "an open prompt outranks the end-turn obligation, got: " result))
+          (is (not= :my-turn-end (:reason result))
+              (str "never steer past our own live prompt, got: " result)))))))
+
+(deftest test-my-turn-end-guidance-does-not-slam-the-eot-paid-window
+  (testing "#120 vs #103: the end-of-turn paid window has the SAME signature —
+            0 clicks, no prompt, :end-turn false, no run, no phase flag. Telling
+            the Corp to `end-turn` there throws away the rez that check-auto-end-turn!
+            deliberately holds the turn open for (marquee ac71ce63 lost a Nico
+            Campaign to exactly this). Two seat-facing surfaces must not contradict"
+    (with-mock-state (mock-game "corp"
+                        (-> orphaned-turn-game-state
+                            (assoc-in [:corp :credit] 5)
+                            (assoc-in [:corp :servers :remote1 :content]
+                                      [{:title "Nico Campaign" :type "Asset"
+                                        :rezzed false :cost 2}])))
+      (let [lines (core/wake-reason-guidance-lines :my-turn-end @state/client-state)
+            text (str/join " " lines)]
+        (is (str/includes? text "Nico Campaign")
+            (str "the open paid window must be named before we say 'end-turn', got: " lines))
+        (is (re-find #"(?i)rez" text)
+            (str "and the seat must be told it can still rez, got: " lines))))))
+
+(deftest test-my-turn-end-guidance-stays-terse-with-no-paid-window
+  (testing "#120: the paid-window line is CONDITIONAL — a Corp with nothing
+            rezzable gets the plain end-turn steer, not a phantom window"
+    (with-mock-state (mock-game "corp" orphaned-turn-game-state)
+      (let [text (str/join " " (core/wake-reason-guidance-lines :my-turn-end @state/client-state))]
+        (is (re-find #"end-turn" text) "the steer itself is unconditional")
+        (is (not (re-find #"(?i)rez" text))
+            (str "no rezzables => no rez line, got: " text))))))
+
+(deftest test-run-ended-into-an-orphaned-turn-says-so
+  (testing "#120: :run-ended OUTRANKS :my-turn-end and is not mutually exclusive
+            with it — a run that ends on the last click leaves us owing the
+            end-turn, but the seat woke on the transition and :run-ended carried
+            no guidance at all. That is the #115 undecoded-token trap: the seat
+            reads 'run ended' as the opponent's cue and re-blocks"
+    (with-mock-state (mock-game "runner"
+                        (-> orphaned-turn-game-state
+                            (assoc :active-player "runner")))
+      (let [text (str/join " " (core/wake-reason-guidance-lines :run-ended @state/client-state))]
+        (is (re-find #"end-turn" text)
+            (str "a run ending into our own orphaned turn must name end-turn, got: " text)))))
+  (testing "#120: and stays silent when the run ended with clicks still in hand"
+    (with-mock-state (mock-game "runner"
+                        (-> orphaned-turn-game-state
+                            (assoc :active-player "runner")
+                            (assoc-in [:runner :click] 2)))
+      (is (empty? (core/wake-reason-guidance-lines :run-ended @state/client-state))
+          "a normal run end is self-describing — no end-turn steer"))))
+
+;; --- #120 review panel, SECOND pass on the fixes themselves ---
+;;
+;; The guest found the paid-window fix was half a fix: check-auto-end-turn! holds
+;; the turn open for TWO reasons at 0 clicks, and I had only mirrored one.
+
+(deftest test-my-turn-end-guidance-does-not-slam-a-live-score
+  (testing "#120 vs the scorable-agenda hold: scoring costs no click, so a fully
+            advanced agenda is still live at 0 clicks — check-auto-end-turn!
+            refuses to auto-end for exactly this. Telling the seat `end-turn` here
+            throws away the score, which is how you lose a game in one line"
+    (with-mock-state (mock-game "corp"
+                        (assoc-in orphaned-turn-game-state [:corp :servers :remote1 :content]
+                                  [{:title "Offworld Office" :type "Agenda"
+                                    :advance-counter 4 :advancementcost 4}]))
+      (let [text (str/join " " (core/wake-reason-guidance-lines :my-turn-end @state/client-state))]
+        (is (str/includes? text "Offworld Office")
+            (str "the scorable agenda must be named before the end-turn steer, got: " text))
+        (is (re-find #"(?i)score" text)
+            (str "and the seat must be told it can still score, got: " text))))))
+
+(deftest test-end-turn-guidance-reads-the-snapshot-it-was-handed
+  (testing "#120: the wait loop classifies a SNAPSHOT and formats guidance from it
+            later. Reading the live atom instead means a diff landing in that gap
+            can staple a card list from a different turn onto the wake reason —
+            so the detectors take the state they are given"
+    ;; The atom holds a board with nothing pending; the snapshot passed in has the
+    ;; rezzable. The lines must describe the ARGUMENT, not the atom.
+    (with-mock-state (mock-game "corp" orphaned-turn-game-state)
+      (let [snapshot (mock-game "corp"
+                       (-> orphaned-turn-game-state
+                           (assoc-in [:corp :credit] 5)
+                           (assoc-in [:corp :servers :remote1 :content]
+                                     [{:title "Nico Campaign" :type "Asset"
+                                       :rezzed false :cost 2}])))
+            text (str/join " " (core/wake-reason-guidance-lines :my-turn-end snapshot))]
+        (is (str/includes? text "Nico Campaign")
+            (str "guidance must describe the state it was handed, got: " text))))))


### PR DESCRIPTION
Closes #120.

## The deadlock

Orphaned turn — active player out of clicks, engine's `:end-turn` still false
(their last click handed the opponent a decision, auto-end declined, and by the
time the opponent resolved it nothing was blocking any more):

```
active-player=corp, end-turn=false, turn=10, corp clicks=0, runner clicks=0
corp   | my-turn-to-act? = false | relevance-reason = nil
runner | my-turn-to-act? = false | relevance-reason = nil
```

Both seats slept the full 300s. The one side that could break it — the Corp,
whose only legal move is `end-turn` — was the side being told it had no move.
#117 fixed the display half (`status`/`prompt` name the right side); a seat that
does the natural thing at a boundary and calls `wait` still hung.

## The fix

New `:my-turn-end` wake reason, ranked last, keyed on the **end-turn obligation**
rather than a click count — waking on "both players at 0 clicks" is precisely the
bug `my-turn-to-act?`'s docstring refuses to reintroduce (that shape fires on
every run started with the last click).

No fourth copy of the predicate: `my-turn-orphaned?` (#117) is the authority and
gains an explicit-side arity, so the wake ladder asks about the side it was
handed instead of the seat's stored `:side`. Only the turn's **owner** wakes —
an `end-turn` from the other seat ends the opponent's turn and is unrecoverable.
The opponent stays asleep and wakes on `:my-turn-start` once the flag latches.

## Review panel (Claude judge + GPT-5.6 guest, two passes)

Five findings, all confirmed, four acted on. Both passes attacked stated
assumptions rather than the diff alone.

| # | Severity | Finding | Disposition |
|---|---|---|---|
| 1 | MAJOR | A scorable agenda is still live at 0 clicks — scoring costs no click, and `check-auto-end-turn!` refuses to auto-end for exactly that. "Send end-turn" throws away the score. | Fixed: guidance calls `find-scorable-agendas` |
| 2 | MAJOR | Same shape for the #103 end-of-turn paid window (marquee ac71ce63 lost a Nico Campaign rez to an auto-end). | Fixed: guidance calls `find-eot-rezzable-cards` |
| 3 | MAJOR | `:run-ended` is a TRANSITION, outranks `:my-turn-end`, and is **not** mutually exclusive with it — my comment claimed it was. A run ending on the last click woke with a bare undecoded token (#115 trap) while the seat owed the end-turn. | Fixed: `:run-ended` carries the obligation lines; comment corrected, not deleted |
| 4 | MAJOR | Guidance re-read the client-state atom while the wait loop had classified a **snapshot** — a diff in that gap staples a newer board's card list onto a description of the older one. | Fixed: `corp-servers` / both detectors take the state they are given |
| 5 | MINOR | The issue's own exclusion list names "a genuinely blocking prompt of our own"; no test drove that through the new wake path. | Fixed: added |

**Rejected (1):** the rez detector counts restricted recurring credits
(Dedicated Server pays only for ICE), so it can list an unaffordable rez. Real,
but a deliberate documented tradeoff owned by #103 — it errs generous because a
false negative silently closes the window, and the same list is already printed
by `check-auto-end-turn!`. The guidance hedges it the way that surface does
("nothing to do? just `end-turn`") rather than re-deciding it here.

The through-line in 1/2/3: **0 clicks is not 0 moves**, and "the complement of
one known state is a single other state" is the mistake this file keeps making.

## Tests

Suite 694 → **706**, green. Red-first; the first cut reproduced the issue
exactly (`:timeout`, reason `nil`).

- wakes `:my-turn-end` for the owner; opponent stays asleep
- end-to-end: once `:end-turn` latches, the opponent wakes `:my-turn-start` and
  the owner does **not** re-wake — the deadlock actually breaks
- does not fire for a last-click run, for our own blocking prompt, or for any of
  the four zero-click phase windows (phase 1.2 / post-discard, both sides)
- guidance names `end-turn`, names a live score / open paid window when there is
  one, stays terse when there isn't, and describes the snapshot it was handed

## Not verified live

The persistent dev REPLs are rooted in the main checkout, so a worktree branch
can't be `:reload`ed into a running seat. `make test` is the authority here;
worth a seat-level sanity check when this lands on `ai-player/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)